### PR TITLE
Add rustfmt params

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+merge_imports = true
+use_field_init_shorthand = true
+reorder_imports = true
+reorder_modules = true


### PR DESCRIPTION
This adds in rustfmt params that are fairly standard on most projects and cleans things up nicely.

DO run rustfmt with nightly Rust target and ensure that you have nightly target:

```bash
cargo +nightly fmt
```