### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .cargo/config
 /target
 Cargo.lock
+**/*.rs.bk


### PR DESCRIPTION
This includes some IDE folder settings which may likely not be wanted. Do note that a `Cargo.lock` file should only be present if it is a binary. Of course, this is a library so that will remain but making a note of it here.