### PR TITLE
Rustfmt merge imports deprecated

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-merge_imports = true
+imports_granularity = "Crate"
 use_field_init_shorthand = true
 reorder_imports = true
 reorder_modules = true


### PR DESCRIPTION
On latest nightly merge imports has been deprecated. It had suggested to use `imports_granularity = "Crate"` instead which is what is done here.