### PR TITLE
chore: temp allow dead code

### DIFF
--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -1,3 +1,6 @@
+// TEMP allow as everything gets plugged into each other.
+// TODO: Remove before we do a release to ensure there is no hanging code.
+#![allow(dead_code)]
 #![allow(clippy::type_complexity)]
 
 pub(crate) mod communication;


### PR DESCRIPTION
Temporarily allow dead code for now so that we can focus on the more priority messages and temporarily drop the noise until we start tying everything together.

This MUST be removed before a release later on!