### PR TITLE
fix: topic hashes

### DIFF
--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -25,7 +25,10 @@ pub type AuthorityPair = app::Pair;
 pub(crate) mod temp {
     use codec::{Decode, Encode};
     use sp_runtime::traits::Block;
-    use std::fmt::{Display, Formatter, Result as FmtResult};
+    use std::{
+        fmt::{Display, Formatter, Result as FmtResult},
+        slice::Iter,
+    };
 
     #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode)]
     pub struct NodeIndex(pub(crate) u32);
@@ -85,6 +88,22 @@ pub(crate) mod temp {
     pub struct UnitCoord {
         pub creator: CreatorId,
         pub round: Round,
+    }
+
+    #[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode)]
+    pub struct UnitCoords(Vec<UnitCoord>);
+
+    impl UnitCoords {
+        pub fn iter(&self) -> Iter<'_, UnitCoord> {
+            self.0.iter()
+        }
+    }
+
+    impl From<Vec<UnitCoord>> for UnitCoords {
+        fn from(mut coords: Vec<UnitCoord>) -> Self {
+            coords.sort();
+            UnitCoords(coords)
+        }
     }
 
     #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Encode, Decode)]


### PR DESCRIPTION
Topics were wrong upon review. This fixes that.

Topic hashes have an important use in regards to matching for example a request to a response. The consensus code would watch if we got a response to a topic and if something exists, then it can process that.

At the time the topics were more so placeholders as I was not sure at the time what they should have been. This updates them to be based on how we request information from our peers or receive information. For example, a `coord_topic` is based on a unit coordinate and a `coords_topic` is based on a vector of unit coordinates. 

What should be considered is possible a different topics for Multicast messages based on epoch? Something that is predictable that the consensus can figure out what the next topic to watch is going to be. So for that reason, this pull request should be considered kind of half open.

An extra benefit of this pull request is that I am introducing the `UnitCoords` object which wraps a vector of coordinates. This was made in response to the fact that I was worried if someone forgot to `.sort()` the vector, they would end up with a different topic hash.