### PR TITLE
chore: ssh rush lib

### DIFF
--- a/finality-aleph/Cargo.toml
+++ b/finality-aleph/Cargo.toml
@@ -20,6 +20,7 @@ sp-application-crypto = "2.0"
 sp-core = "2.0"
 sp-runtime = "2.0"
 sp-utils = "2.0"
+rush = { git = "ssh://git@github.com/Cardinal-Cryptography/rush.git", branch = "main" }
 
 [dev-dependencies]
 parity-util-mem = "0.7"


### PR DESCRIPTION
Uses SSH to get the private `rush` lib as it isn't public yet.

Ensure that you setup `.ssh/config` as such:
```
Host *
    UseKeychain yes
    AddKeysToAgent yes
    IdentityFile ~/.ssh/id_ed25519
```
With of course the `id_ed25519` being your private key that is set to work with Github.