### PR TITLE
minor: fix `Network` to use a separate hash apart from `Block`

### DIFF
--- a/finality-aleph/src/communication/network.rs
+++ b/finality-aleph/src/communication/network.rs
@@ -31,7 +31,7 @@ pub(crate) const ALEPH_PROTOCOL_NAME: &str = "/cardinals/aleph/1";
 
 pub trait Network<B: Block>: GossipNetwork<B> + Clone + Send + Sync + 'static {}
 
-impl<B: Block> Network<B> for Arc<NetworkService<B, B::Hash>> {}
+impl<B: Block, H: Hash> Network<B> for Arc<NetworkService<B, H>> {}
 
 pub struct NotificationOutSender<B: Block, H: Hash> {
     network: Arc<Mutex<GossipEngine<B>>>,


### PR DESCRIPTION
While running code inspections, this was flagged. I checked what it is supposed to be and the `Hash` is meant to be an extra trait, not part of `Block`. This fixes that and now it now longer is flagged.