### PR TITLE
Make constants `Period` and `MillisecsPerBlock` specified by environment variables

### DIFF
--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -39,9 +39,12 @@ where
 }
 
 fn read_keys(n_members: usize) -> (Vec<AuraId>, Vec<AlephId>) {
-    let auth_keys = std::fs::read_to_string(KEY_PATH).expect("keys were not generated");
     let auth_keys: HashMap<u32, Vec<[u8; 32]>> =
-        serde_json::from_str(&auth_keys).expect("should contain list of keys");
+        if let Ok(auth_keys) = std::fs::read_to_string(KEY_PATH) {
+            serde_json::from_str(&auth_keys).expect("should contain list of keys")
+        } else {
+            return Default::default()
+        };
 
     let aura_keys: Vec<_> = auth_keys
         .get(&key_types::AURA.into())

--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -60,38 +60,61 @@ pub struct ChainParams {
 impl ChainParams {
     pub fn from_cli(session_period: Option<u32>, millisecs_per_block: Option<u64>) -> Self {
         ChainParams {
-            session_period: Self::param("session period", session_period, "SESSION_PERIOD", DEFAULT_SESSION_PERIOD),
-            millisecs_per_block: Self::param("millisecs per block", millisecs_per_block, "MILLISECS_PER_BLOCK", DEFAULT_MILLISECS_PER_BLOCK),
+            session_period: Self::param(
+                "session period",
+                session_period,
+                "SESSION_PERIOD",
+                DEFAULT_SESSION_PERIOD,
+            ),
+            millisecs_per_block: Self::param(
+                "millisecs per block",
+                millisecs_per_block,
+                "MILLISECS_PER_BLOCK",
+                DEFAULT_MILLISECS_PER_BLOCK,
+            ),
         }
     }
 
-    fn param<T: FromStr + Display>(debug_name: &str, cli_value: Option<T>, var: &str, default: T) -> T where
-        <T as FromStr>::Err: ToString
+    fn param<T: FromStr + Display>(
+        debug_name: &str,
+        cli_value: Option<T>,
+        var: &str,
+        default: T,
+    ) -> T
+    where
+        <T as FromStr>::Err: ToString,
     {
-        cli_value.or_else(|| {Self::parse_env_var(var)}).unwrap_or_else(|| {
-            log::debug!("{} parameter not specified, using default value: {}", debug_name, default);
-            default
-        })
+        cli_value
+            .or_else(|| Self::parse_env_var(var))
+            .unwrap_or_else(|| {
+                log::debug!(
+                    "{} parameter not specified, using default value: {}",
+                    debug_name,
+                    default
+                );
+                default
+            })
     }
 
-    fn parse_env_var<T: FromStr>(var: &str) -> Option<T> where
-        <T as FromStr>::Err: ToString
+    fn parse_env_var<T: FromStr>(var: &str) -> Option<T>
+    where
+        <T as FromStr>::Err: ToString,
     {
         match std::env::var(var) {
-            Ok(value) => {
-                match value.parse() {
-                    Ok(value) => Some(value),
-                    Err(err) => {
-                        panic!("error parsing environment variable {}: {}", var, err.to_string());
-                    }
+            Ok(value) => match value.parse() {
+                Ok(value) => Some(value),
+                Err(err) => {
+                    panic!(
+                        "error parsing environment variable {}: {}",
+                        var,
+                        err.to_string()
+                    );
                 }
             },
-            Err(VarError::NotPresent) => {
-                None
-            }
+            Err(VarError::NotPresent) => None,
             Err(err @ VarError::NotUnicode(_)) => {
                 panic!("environment variable {} is not unicode: {}", var, err);
-            },
+            }
         }
     }
 }
@@ -133,7 +156,6 @@ fn read_keys(n_members: usize) -> Vec<AuthorityKeys> {
         })
         .collect()
 }
-
 
 pub fn development_config(chain_params: ChainParams) -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -19,7 +19,7 @@ pub struct Cli {
     pub extra: ExtraParams,
 }
 
-#[derive(Clone, Copy, Debug, Default,   StructOpt)]
+#[derive(Clone, Copy, Debug, Default, StructOpt)]
 pub struct ExtraParams {
     #[structopt(long)]
     pub(crate) session_period: Option<u32>,

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -14,6 +14,18 @@ pub struct Cli {
 
     #[structopt(flatten)]
     pub run: RunCmd,
+
+    #[structopt(flatten)]
+    pub extra: ExtraParams,
+}
+
+#[derive(Clone, Copy, Debug, Default,   StructOpt)]
+pub struct ExtraParams {
+    #[structopt(long)]
+    pub(crate) session_period: Option<u32>,
+
+    #[structopt(long)]
+    pub(crate) millisecs_per_block: Option<u64>,
 }
 
 #[derive(Debug, StructOpt)]

--- a/bin/node/src/command.rs
+++ b/bin/node/src/command.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     chain_spec,
-    cli::{Cli, Subcommand},
+    cli::{Cli, ExtraParams, Subcommand},
     service,
 };
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
@@ -46,9 +46,14 @@ impl SubstrateCli for Cli {
     }
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
+        let ExtraParams {
+            session_period,
+            millisecs_per_block,
+        } = self.extra;
+        let chain_params = chain_spec::ChainParams::from_cli(session_period, millisecs_per_block);
         Ok(match id {
-            "testnet1" => Box::new(chain_spec::testnet1_config()?),
-            "dev" => Box::new(chain_spec::development_config()?),
+            "testnet1" => Box::new(chain_spec::testnet1_config(chain_params)?),
+            "dev" => Box::new(chain_spec::development_config(chain_params)?),
             path => Box::new(chain_spec::ChainSpec::from_json_file(
                 std::path::PathBuf::from(path),
             )?),

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -203,8 +203,16 @@ impl pallet_aura::Config for Runtime {
     type AuthorityId = AuraId;
 }
 
-parameter_types! {
-    pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
+pub struct MinimumPeriod;
+impl MinimumPeriod {
+    pub fn get() -> u64 {
+        Aleph::millisecs_per_block() / 2
+    }
+}
+impl<I: From<u64>> ::frame_support::traits::Get<I> for MinimumPeriod {
+    fn get() -> I {
+        I::from(Self::get())
+    }
 }
 
 impl pallet_timestamp::Config for Runtime {
@@ -261,8 +269,35 @@ impl_opaque_keys! {
     }
 }
 
+pub struct SessionPeriod;
+
+impl SessionPeriod {
+    pub fn get() -> u32 {
+        Aleph::session_period()
+    }
+}
+
+impl<I: From<u32>> ::frame_support::traits::Get<I> for SessionPeriod {
+    fn get() -> I {
+        I::from(Self::get())
+    }
+}
+
+pub struct MillisecsPerBlock;
+
+impl MillisecsPerBlock {
+    pub fn get() -> u64 {
+        Aleph::millisecs_per_block()
+    }
+}
+
+impl<I: From<u64>> ::frame_support::traits::Get<I> for MillisecsPerBlock {
+    fn get() -> I {
+        I::from(Self::get())
+    }
+}
+
 parameter_types! {
-    pub const Period: u32 = 500;
     pub const Offset: u32 = 0;
 }
 
@@ -274,8 +309,8 @@ impl pallet_session::Config for Runtime {
     type Event = Event;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
     type ValidatorIdOf = ConvertInto;
-    type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
-    type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+    type ShouldEndSession = pallet_session::PeriodicSessions<SessionPeriod, Offset>;
+    type NextSessionRotation = pallet_session::PeriodicSessions<SessionPeriod, Offset>;
     // The () SessionManager makes always a new session with the same set of validators as before.
     type SessionManager = ();
     type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
@@ -458,7 +493,11 @@ impl_runtime_apis! {
         }
 
         fn session_period() -> u32 {
-            Period::get()
+            SessionPeriod::get()
+        }
+
+        fn millisecs_per_block() -> u64 {
+            MillisecsPerBlock::get()
         }
     }
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -24,6 +24,9 @@ sp_application_crypto::with_pair! {
 pub type AuthoritySignature = app::Signature;
 pub type AuthorityId = app::Public;
 
+pub const DEFAULT_SESSION_PERIOD: u32 = 5;
+pub const DEFAULT_MILLISECS_PER_BLOCK: u64 = 4000;
+
 #[derive(codec::Encode, codec::Decode, PartialEq, Eq, sp_std::fmt::Debug)]
 pub enum ApiError {
     DecodeKey,
@@ -39,6 +42,7 @@ sp_api::decl_runtime_apis! {
         fn next_session() -> Result<Session<Id, BlockNumber>, ApiError>;
         fn authorities() -> Vec<AuthorityId>;
         fn session_period() -> u32;
+        fn millisecs_per_block() -> u64;
     }
 }
 

--- a/run_nodes.sh
+++ b/run_nodes.sh
@@ -20,7 +20,7 @@ n_members="$1"
 echo "$n_members" > /tmp/n_members
 shift
 
-# cargo build --release -p aleph-node
+cargo build --release -p aleph-node
 
 authorities=(Damian Tomasz Zbyszko Hansu Adam Matt Antoni Michal)
 authorities=("${authorities[@]::$n_members}")

--- a/run_nodes.sh
+++ b/run_nodes.sh
@@ -20,7 +20,7 @@ n_members="$1"
 echo "$n_members" > /tmp/n_members
 shift
 
-cargo build --release -p aleph-node
+# cargo build --release -p aleph-node
 
 authorities=(Damian Tomasz Zbyszko Hansu Adam Matt Antoni Michal)
 authorities=("${authorities[@]::$n_members}")


### PR DESCRIPTION
The parameters `SessionPeriod` (formerly `Period`) and `MillisecsPerBlock` no longer have to be known at compile time. Instead, you specify them if environment variables `SESSION_PERIOD` and `MILLISECS_PER_BLOCK`, respectively. If a variable is not set, a default value is used (5 for `SessionPeriod` and 4000 for `MilliSecsPerBlock`).

This PR also fixes the bug with incorrect generation of local keys. The bug was cause by the fact that when keys were supposed to be generated (and saved in the `/tmp/authorities_keys` file), an instance of `ChainSpec` is created. However, constructing a `ChainSpec` involves reading keys from `/tmp/authorities_keys`, and panics if that file does not exist. The bug is fixed by returning an empty list of keys instead of panicking in the described case. This simple fix is not the cleanest solution, but is simple and avoids repetition of code