### PR TITLE
fixes chain id for which keys are generated

### DIFF
--- a/bin/node/src/command.rs
+++ b/bin/node/src/command.rs
@@ -132,7 +132,7 @@ pub fn run() -> sc_cli::Result<()> {
                 Ok((cmd.run(client, backend), task_manager))
             })
         }
-        Some(Subcommand::DevKeys(cmd)) => cmd.run(),
+        Some(Subcommand::DevKeys(cmd)) => cmd.run(&cli),
         None => {
             let runner = cli.create_runner(&cli.run)?;
             runner.run_node_until_exit(|config| async move {


### PR DESCRIPTION
For testnet keys were generated in chains/testnet1 directory instead of chains/a0tnet1. This is fixed now.