### PR TITLE
fix permissions of the executable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,8 +122,8 @@ jobs:
           mkdir -p target/release/
           # copy artifact
           cp aleph-node target/release/aleph-node
-          # Build and tag a docker container
-          docker build --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f ./docker/Dockerfile .
+          # Build and tag a docker container, we use two tags: `latest` and the sha of the commit that triggered the build
+          docker build --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA -f ./docker/Dockerfile .
           # Login to Amazon ECR
           aws ecr-public get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_REGISTRY
           # push it to ECR

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,5 +3,6 @@ FROM ubuntu:latest
 WORKDIR node
 
 COPY target/release/aleph-node /node/aleph-node
+RUN chmod +x aleph-node
 
 ENTRYPOINT ["./node/aleph-node"]


### PR DESCRIPTION
This fixes a bug which causes images to crash due to lack of execution permissions inside the docker container