### PR TITLE
Feature/chainspec and keygen

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -118,8 +118,7 @@ jobs:
 
       - name: Generate chainspec
         run: |
-          # NOTE : remove this step after keys are moved to a separate JSON file
-          # populate vlaidators keystore and generate chainspec
+          # populate validators keystore and generate chainspec
           chmod +x target/release/aleph-node
           ./target/release/aleph-node bootstrap-chain --base-path docker/data --chain a0tnet1 > docker/data/chainspec.json
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           # populate validators keystore and generate chainspec
           chmod +x target/release/aleph-node
-          ./target/release/aleph-node bootstrap-chain --base-path docker/data --chain a0tnet1 > docker/data/chainspec.json
+          ./target/release/aleph-node bootstrap-chain --base-path docker/data --chain-id a0tnet1 > docker/data/chainspec.json
 
       - name: Run consensus party
         run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -119,11 +119,9 @@ jobs:
       - name: Generate chainspec
         run: |
           # NOTE : remove this step after keys are moved to a separate JSON file
-          cp docker/data/n_members /tmp/n_members
-          # generate keys and chainspec
+          # populate vlaidators keystore and generate chainspec
           chmod +x target/release/aleph-node
-          ./target/release/aleph-node dev-keys --base-path docker/data --chain a0tnet1 --key-types aura alp0
-          ./target/release/aleph-node build-spec --disable-default-bootnode  --chain a0tnet1 > docker/data/chainspec.json
+          ./target/release/aleph-node bootstrap-chain --base-path docker/data --chain a0tnet1 > docker/data/chainspec.json
 
       - name: Run consensus party
         run: |

--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use aleph_primitives::{
     AuthorityId as AlephId, DEFAULT_MILLISECS_PER_BLOCK, DEFAULT_SESSION_PERIOD,
 };
@@ -9,23 +7,18 @@ use aleph_runtime::{
 };
 use hex_literal::hex;
 use sc_service::ChainType;
-use sp_application_crypto::key_types;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{ed25519, sr25519, Pair, Public};
+use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
-use std::{env::VarError, fmt::Display, str::FromStr};
 
 const FAUCET_HASH: [u8; 32] =
     hex!("eaefd9d9b42915bda608154f17bb03e407cbf244318a0499912c2fb1cd879b74");
 
-pub(crate) const LOCAL_AUTHORITIES: [&str; 8] = [
+pub const LOCAL_AUTHORITIES: [&str; 8] = [
     "Damian", "Tomasz", "Zbyszko", "Hansu", "Adam", "Matt", "Antoni", "Michal",
 ];
 
-pub(crate) const KEY_PATH: &str = "/tmp/authorities_keys";
-
-pub(crate) const TESTNET_ID: &str = "a0tnet1";
-pub(crate) const DEVNET_ID: &str = "dev";
+pub const DEVNET_ID: &str = "dev";
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;
@@ -49,12 +42,12 @@ where
 
 #[derive(Clone)]
 pub struct AuthorityKeys {
-    account_id: AccountId,
-    aura_key: AuraId,
-    aleph_key: AlephId,
+    pub account_id: AccountId,
+    pub aura_key: AuraId,
+    pub aleph_key: AlephId,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ChainParams {
     session_period: u32,
     millisecs_per_block: u64,
@@ -63,113 +56,17 @@ pub struct ChainParams {
 impl ChainParams {
     pub fn from_cli(session_period: Option<u32>, millisecs_per_block: Option<u64>) -> Self {
         ChainParams {
-            session_period: Self::param(
-                "session period",
-                session_period,
-                "SESSION_PERIOD",
-                DEFAULT_SESSION_PERIOD,
-            ),
-            millisecs_per_block: Self::param(
-                "millisecs per block",
-                millisecs_per_block,
-                "MILLISECS_PER_BLOCK",
-                DEFAULT_MILLISECS_PER_BLOCK,
-            ),
-        }
-    }
-
-    fn param<T: FromStr + Display>(
-        debug_name: &str,
-        cli_value: Option<T>,
-        var: &str,
-        default: T,
-    ) -> T
-    where
-        <T as FromStr>::Err: ToString,
-    {
-        cli_value
-            .or_else(|| Self::parse_env_var(var))
-            .unwrap_or_else(|| {
-                log::debug!(
-                    "{} parameter not specified, using default value: {}",
-                    debug_name,
-                    default
-                );
-                default
-            })
-    }
-
-    fn parse_env_var<T: FromStr>(var: &str) -> Option<T>
-    where
-        <T as FromStr>::Err: ToString,
-    {
-        match std::env::var(var) {
-            Ok(value) => match value.parse() {
-                Ok(value) => Some(value),
-                Err(err) => {
-                    panic!(
-                        "error parsing environment variable {}: {}",
-                        var,
-                        err.to_string()
-                    );
-                }
-            },
-            Err(VarError::NotPresent) => None,
-            Err(err @ VarError::NotUnicode(_)) => {
-                panic!("environment variable {} is not unicode: {}", var, err);
-            }
+            session_period: session_period.unwrap_or(DEFAULT_SESSION_PERIOD),
+            millisecs_per_block: millisecs_per_block.unwrap_or(DEFAULT_MILLISECS_PER_BLOCK),
         }
     }
 }
 
-fn read_keys(n_members: usize) -> Vec<AuthorityKeys> {
-    let auth_keys: HashMap<u32, Vec<[u8; 32]>> =
-        if let Ok(auth_keys) = std::fs::read_to_string(KEY_PATH) {
-            serde_json::from_str(&auth_keys).expect("should contain list of keys")
-        } else {
-            return Default::default();
-        };
-
-    let aura_keys = auth_keys
-        .get(&key_types::AURA.into())
-        .unwrap()
-        .iter()
-        .copied()
-        .map(|bytes| AuraId::from(sr25519::Public::from_raw(bytes)));
-
-    let aleph_keys = auth_keys
-        .get(&aleph_primitives::KEY_TYPE.into())
-        .unwrap()
-        .iter()
-        .copied()
-        .map(|bytes| AlephId::from(ed25519::Public::from_raw(bytes)));
-
-    let account_ids = LOCAL_AUTHORITIES
-        .iter()
-        .map(get_account_id_from_seed::<sr25519::Public>);
-
-    aura_keys
-        .zip(aleph_keys)
-        .zip(account_ids)
-        .take(n_members)
-        .map(|((aura_key, aleph_key), account_id)| AuthorityKeys {
-            account_id,
-            aura_key,
-            aleph_key,
-        })
-        .collect()
-}
-
-pub fn development_config(chain_params: ChainParams) -> Result<ChainSpec, String> {
+pub fn development_config(
+    chain_params: ChainParams,
+    authorities: Vec<AuthorityKeys>,
+) -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
-
-    let n_members = std::fs::read_to_string("/tmp/n_members")
-        .expect("Committee size is not specified")
-        .trim()
-        .parse::<usize>()
-        .expect("Wrong committee size");
-
-    let authorities = read_keys(n_members);
 
     let rich_accounts: Vec<_> = [
         "Alice",
@@ -195,7 +92,7 @@ pub fn development_config(chain_params: ChainParams) -> Result<ChainSpec, String
         DEVNET_ID,
         ChainType::Development,
         move || {
-            testnet_genesis(
+            genesis(
                 wasm_binary,
                 // Initial PoA authorities
                 authorities.clone(),
@@ -226,16 +123,12 @@ pub fn development_config(chain_params: ChainParams) -> Result<ChainSpec, String
     ))
 }
 
-pub fn testnet1_config(chain_params: ChainParams) -> Result<ChainSpec, String> {
+pub fn config(
+    chain_params: ChainParams,
+    authorities: Vec<AuthorityKeys>,
+    chain_id: &str,
+) -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
-
-    let n_members = std::fs::read_to_string("/tmp/n_members")
-        .expect("Committee size is not specified")
-        .trim()
-        .parse::<usize>()
-        .expect("Wrong committee size");
-
-    let authorities = read_keys(n_members);
 
     let sudo_account: AccountId = hex![
         // 5F4SvwaUEQubiqkPF8YnRfcN77cLsT2DfG4vFeQmSXNjR7hD
@@ -243,21 +136,23 @@ pub fn testnet1_config(chain_params: ChainParams) -> Result<ChainSpec, String> {
     ]
     .into();
 
-    // Give money to the faucet account.
+    // Give money to the faucet account
     let faucet: AccountId = FAUCET_HASH.into();
     let rich_accounts = vec![faucet, sudo_account.clone()];
+
     Ok(ChainSpec::from_genesis(
         // Name
-        "Aleph Zero",
+        "AlephZero",
         // ID
-        TESTNET_ID,
+        chain_id,
         ChainType::Live,
         move || {
-            testnet_genesis(
+            genesis(
                 wasm_binary,
+                // Initial PoA authorities
                 authorities.clone(),
-                sudo_account.clone(),
                 // Pre-funded accounts
+                sudo_account.clone(),
                 rich_accounts.clone(),
                 chain_params,
             )
@@ -272,7 +167,7 @@ pub fn testnet1_config(chain_params: ChainParams) -> Result<ChainSpec, String> {
         Some(
             [(
                 "tokenSymbol".to_string(),
-                serde_json::Value::String("TZERO".into()),
+                serde_json::Value::String("DZERO".into()),
             )]
             .iter()
             .cloned()
@@ -283,21 +178,21 @@ pub fn testnet1_config(chain_params: ChainParams) -> Result<ChainSpec, String> {
     ))
 }
 
-/// Configure initial storage state for FRAME modules.
-fn testnet_genesis(
+/// Configure initial storage state for FRAME modules
+fn genesis(
     wasm_binary: &[u8],
     authorities: Vec<AuthorityKeys>,
     root_key: AccountId,
     rich_accounts: Vec<AccountId>,
     chain_params: ChainParams,
 ) -> GenesisConfig {
-    let session_period = chain_params.session_period;
-    let millisecs_per_block = chain_params.millisecs_per_block;
-    log::debug!(
-        "session-period: {}, millisecs-per-block: {}",
+    let ChainParams {
         session_period,
-        millisecs_per_block
-    );
+        millisecs_per_block,
+    } = chain_params;
+
+    log::debug!("chain parameters {:?}", &chain_params);
+
     GenesisConfig {
         system: SystemConfig {
             // Add Wasm runtime to storage.
@@ -322,10 +217,7 @@ fn testnet_genesis(
             key: root_key,
         },
         aleph: AlephConfig {
-            authorities: authorities
-                .iter()
-                .map(|auth| auth.aleph_key.clone())
-                .collect(),
+            authorities: vec![],
             session_period,
             millisecs_per_block,
         },

--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -142,7 +142,7 @@ pub fn config(
 
     Ok(ChainSpec::from_genesis(
         // Name
-        "AlephZero",
+        "Aleph Zero",
         // ID
         chain_id,
         ChainType::Live,
@@ -167,7 +167,7 @@ pub fn config(
         Some(
             [(
                 "tokenSymbol".to_string(),
-                serde_json::Value::String("DZERO".into()),
+                serde_json::Value::String("AZERO".into()),
             )]
             .iter()
             .cloned()

--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -78,7 +78,7 @@ pub struct ChainParams {
 impl ChainParams {
     pub fn chain_id(&self) -> &str {
         match &self.chain_name {
-            Some(id) => &id,
+            Some(id) => id,
             None => "a0tnet1",
         }
     }
@@ -98,14 +98,14 @@ impl ChainParams {
 
     pub fn token_symbol(&self) -> &str {
         match &self.token_symbol {
-            Some(symbol) => &symbol,
+            Some(symbol) => symbol,
             None => "DZERO",
         }
     }
 
     pub fn chain_name(&self) -> &str {
         match &self.chain_name {
-            Some(name) => &name,
+            Some(name) => name,
             None => "Aleph Zero Development",
         }
     }

--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -79,7 +79,7 @@ impl ChainParams {
     pub fn chain_id(&self) -> &str {
         match &self.chain_name {
             Some(id) => id,
-            None => "a0tnet1",
+            None => "a0dnet1",
         }
     }
 

--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -13,7 +13,6 @@ use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use std::path::PathBuf;
 use structopt::StructOpt;
-// use crate::com
 
 const FAUCET_HASH: [u8; 32] =
     hex!("eaefd9d9b42915bda608154f17bb03e407cbf244318a0499912c2fb1cd879b74");
@@ -53,10 +52,9 @@ pub struct AuthorityKeys {
 
 #[derive(Debug, StructOpt, Clone)]
 pub struct ChainParams {
-    /// Specify the chain specification.
+    /// Pass the chain id.
     ///
-    /// It can be one of the predefined ones (dev, local, or staging) or it can be a path to a file with
-    /// the chainspec (such as one exported by the `build-spec` subcommand).
+    /// It can be a predefined one (dev) or an arbitrary chain id passed to the genesis block
     #[structopt(long, value_name = "CHAIN_SPEC")]
     pub chain_id: Option<String>,
 
@@ -78,15 +76,15 @@ pub struct ChainParams {
 }
 
 impl ChainParams {
-    pub fn chain_id(&self) -> String {
-        match &self.chain_id {
-            Some(id) => String::from(id),
-            None => String::from("a0tnet1"),
+    pub fn chain_id(&self) -> &str {
+        match &self.chain_name {
+            Some(id) => &id,
+            None => "a0tnet1",
         }
     }
 
-    pub fn base_path(&self) -> Option<BasePath> {
-        self.base_path.clone().map(Into::into)
+    pub fn base_path(&self) -> BasePath {
+        self.base_path.clone().unwrap().into()
     }
 
     pub fn millisecs_per_block(&self) -> u64 {
@@ -98,17 +96,17 @@ impl ChainParams {
         self.session_period.unwrap_or(DEFAULT_SESSION_PERIOD)
     }
 
-    pub fn token_symbol(&self) -> String {
+    pub fn token_symbol(&self) -> &str {
         match &self.token_symbol {
-            Some(symbol) => String::from(symbol),
-            None => String::from("DZERO"),
+            Some(symbol) => &symbol,
+            None => "DZERO",
         }
     }
 
-    pub fn chain_name(&self) -> String {
+    pub fn chain_name(&self) -> &str {
         match &self.chain_name {
-            Some(name) => String::from(name),
-            None => String::from("Aleph Zero Development"),
+            Some(name) => &name,
+            None => "Aleph Zero Development",
         }
     }
 }
@@ -135,8 +133,8 @@ pub fn development_config(
     .collect();
 
     let sudo_account = rich_accounts[0].clone();
-    let token_symbol = chain_params.token_symbol();
-    let chain_name = chain_params.chain_name();
+    let token_symbol = String::from(chain_params.token_symbol());
+    let chain_name = String::from(chain_params.chain_name());
 
     Ok(ChainSpec::from_genesis(
         // Name
@@ -189,8 +187,8 @@ pub fn config(
     ]
     .into();
 
-    let token_symbol = chain_params.token_symbol();
-    let chain_name = chain_params.chain_name();
+    let token_symbol = String::from(chain_params.token_symbol());
+    let chain_name = String::from(chain_params.chain_name());
 
     // Give money to the faucet account
     let faucet: AccountId = FAUCET_HASH.into();
@@ -207,8 +205,8 @@ pub fn config(
                 wasm_binary,
                 // Initial PoA authorities
                 authorities.clone(),
-                // Pre-funded accounts
                 sudo_account.clone(),
+                // Pre-funded accounts
                 rich_accounts.clone(),
                 chain_params.clone(),
             )

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -70,9 +70,6 @@ pub enum Subcommand {
     /// Populate authorities keystore and generate JSON chainspec (printed to stdout)    
     BootstrapChain(BootstrapChainCmd),
 
-    /// Same as BootstrapChain
-    BuildSpec(BootstrapChainCmd),
-
     /// Validate blocks.
     CheckBlock(sc_cli::CheckBlockCmd),
 

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -2,15 +2,6 @@ use crate::{chain_spec, commands::BootstrapChainCmd};
 use sc_cli::{ChainSpec, RunCmd, RuntimeVersion, SubstrateCli};
 use structopt::StructOpt;
 
-#[derive(Clone, Debug, Default, StructOpt)]
-pub struct ExtraParams {
-    #[structopt(long)]
-    pub(crate) session_period: Option<u32>,
-
-    #[structopt(long)]
-    pub(crate) millisecs_per_block: Option<u64>,
-}
-
 #[derive(Debug, StructOpt)]
 pub struct Cli {
     #[structopt(subcommand)]
@@ -18,9 +9,6 @@ pub struct Cli {
 
     #[structopt(flatten)]
     pub run: RunCmd,
-
-    #[structopt(flatten)]
-    pub extra: ExtraParams,
 }
 
 impl SubstrateCli for Cli {

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -1,11 +1,15 @@
-use sc_cli::{Error, KeystoreParams, RunCmd, SharedParams};
-use sc_service::config::{BasePath, KeystoreConfig};
-use std::{collections::HashMap, convert::TryFrom, sync::Arc};
-
-use sc_keystore::LocalKeystore;
-use sp_core::crypto::KeyTypeId;
-use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
+use crate::{chain_spec, commands::BootstrapChainCmd};
+use sc_cli::{ChainSpec, RunCmd, RuntimeVersion, SubstrateCli};
 use structopt::StructOpt;
+
+#[derive(Clone, Debug, Default, StructOpt)]
+pub struct ExtraParams {
+    #[structopt(long)]
+    pub(crate) session_period: Option<u32>,
+
+    #[structopt(long)]
+    pub(crate) millisecs_per_block: Option<u64>,
+}
 
 #[derive(Debug, StructOpt)]
 pub struct Cli {
@@ -19,107 +23,39 @@ pub struct Cli {
     pub extra: ExtraParams,
 }
 
-#[derive(Clone, Copy, Debug, Default, StructOpt)]
-pub struct ExtraParams {
-    #[structopt(long)]
-    pub(crate) session_period: Option<u32>,
-
-    #[structopt(long)]
-    pub(crate) millisecs_per_block: Option<u64>,
-}
-
-#[derive(Debug, StructOpt)]
-pub struct GenerateKeysCmd {
-    /// List of genesis authorities
-    #[structopt(long)]
-    pub authorities: Vec<String>,
-
-    /// Key types, examples: "aura", or "alp0"
-    #[structopt(long)]
-    pub key_types: Vec<String>,
-
-    #[structopt(flatten)]
-    pub keystore_params: KeystoreParams,
-
-    #[structopt(flatten)]
-    pub shared_params: SharedParams,
-}
-
-impl GenerateKeysCmd {
-    pub fn run(&self) -> Result<(), Error> {
-        let key_types: Vec<_> = self
-            .key_types
-            .iter()
-            .map(|kt| KeyTypeId::try_from(kt.as_str()).expect("wrong key type"))
-            .collect();
-        // A hashmap from a key type to a 32-byte representation of a sr25519 or ed25519 key.
-        let mut auth_keys: HashMap<_, _> = key_types
-            .iter()
-            .zip(vec![vec![]].into_iter().cycle())
-            .collect();
-        for authority in &crate::chain_spec::LOCAL_AUTHORITIES {
-            let keystore = self.open_keystore(authority)?;
-            for &key_type in &key_types {
-                use sp_core::crypto::key_types;
-                match key_type {
-                    key_types::AURA => {
-                        let keys = SyncCryptoStore::sr25519_public_keys(&*keystore, key_type);
-                        let key = keys.into_iter().next().map_or_else(
-                            || {
-                                SyncCryptoStore::sr25519_generate_new(&*keystore, key_type, None)
-                                    .map_err(|_| Error::KeyStoreOperation)
-                            },
-                            Ok,
-                        )?;
-                        auth_keys
-                            .get_mut(&key_type)
-                            .unwrap()
-                            .push(*key.as_array_ref());
-                    }
-                    aleph_primitives::KEY_TYPE => {
-                        let keys = SyncCryptoStore::ed25519_public_keys(&*keystore, key_type);
-                        let key = keys.into_iter().next().map_or_else(
-                            || {
-                                SyncCryptoStore::ed25519_generate_new(&*keystore, key_type, None)
-                                    .map_err(|_| Error::KeyStoreOperation)
-                            },
-                            Ok,
-                        )?;
-                        auth_keys
-                            .get_mut(&key_type)
-                            .unwrap()
-                            .push(*key.as_array_ref());
-                    }
-                    _ => return Err(Error::Input("Unsupported key type".into())),
-                }
-            }
-        }
-
-        let keys_path = crate::chain_spec::KEY_PATH;
-        let auth_keys: HashMap<_, _> = auth_keys.iter().map(|(k, v)| (u32::from(**k), v)).collect();
-        let auth_keys = serde_json::to_string(&auth_keys).map_err(|e| Error::Io(e.into()))?;
-        std::fs::write(keys_path, &auth_keys).map_err(Error::Io)?;
-
-        Ok(())
+impl SubstrateCli for Cli {
+    fn impl_name() -> String {
+        "Substrate Node".into()
     }
 
-    fn open_keystore(&self, authority: &str) -> Result<SyncCryptoStorePtr, Error> {
-        let base_path: BasePath = self
-            .shared_params
-            .base_path()
-            .unwrap()
-            .path()
-            .join(authority)
-            .into();
-        let chain_id = self.shared_params.chain_id(self.shared_params.is_dev());
-        let config_dir = base_path.config_dir(&chain_id);
+    fn impl_version() -> String {
+        env!("SUBSTRATE_CLI_IMPL_VERSION").into()
+    }
 
-        match self.keystore_params.keystore_config(&config_dir)? {
-            (_, KeystoreConfig::Path { path, password }) => {
-                Ok(Arc::new(LocalKeystore::open(path, password)?))
-            }
-            _ => unreachable!("keystore_config always returns path and password; qed"),
-        }
+    fn description() -> String {
+        env!("CARGO_PKG_DESCRIPTION").into()
+    }
+
+    fn author() -> String {
+        env!("CARGO_PKG_AUTHORS").into()
+    }
+
+    fn support_url() -> String {
+        "support.anonymous.an".into()
+    }
+
+    fn copyright_start_year() -> i32 {
+        2021
+    }
+
+    fn load_spec(&self, path: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
+        Ok(Box::new(chain_spec::ChainSpec::from_json_file(
+            std::path::PathBuf::from(path),
+        )?))
+    }
+
+    fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
+        &aleph_runtime::VERSION
     }
 }
 
@@ -127,8 +63,15 @@ impl GenerateKeysCmd {
 pub enum Subcommand {
     /// Key management cli utilities
     Key(sc_cli::KeySubcommand),
-    /// Build a chain specification.
-    BuildSpec(sc_cli::BuildSpecCmd),
+
+    // NOTE: similarly we could have a BootstrapNode command that takes a node-name parameter
+    // and writes aura, aleph and (optionally) libp2p private keys to the base-path of a single node
+    // and prints accountId and peerId to the stdout
+    /// Populate authorities keystore and generate JSON chainspec (printed to stdout)    
+    BootstrapChain(BootstrapChainCmd),
+
+    /// Same as BootstrapChain
+    BuildSpec(BootstrapChainCmd),
 
     /// Validate blocks.
     CheckBlock(sc_cli::CheckBlockCmd),
@@ -147,7 +90,4 @@ pub enum Subcommand {
 
     /// Revert the chain to a previous state.
     Revert(sc_cli::RevertCmd),
-
-    /// Generate keys for local tests
-    DevKeys(GenerateKeysCmd),
 }

--- a/bin/node/src/command.rs
+++ b/bin/node/src/command.rs
@@ -13,68 +13,19 @@
 // limitations under the License.
 
 use crate::{
-    chain_spec,
-    cli::{Cli, ExtraParams, Subcommand},
+    cli::{Cli, Subcommand},
     service,
 };
-use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
+use sc_cli::SubstrateCli;
 use sc_service::PartialComponents;
-
-impl SubstrateCli for Cli {
-    fn impl_name() -> String {
-        "Substrate Node".into()
-    }
-
-    fn impl_version() -> String {
-        env!("SUBSTRATE_CLI_IMPL_VERSION").into()
-    }
-
-    fn description() -> String {
-        env!("CARGO_PKG_DESCRIPTION").into()
-    }
-
-    fn author() -> String {
-        env!("CARGO_PKG_AUTHORS").into()
-    }
-
-    fn support_url() -> String {
-        "support.anonymous.an".into()
-    }
-
-    fn copyright_start_year() -> i32 {
-        2021
-    }
-
-    fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
-        let ExtraParams {
-            session_period,
-            millisecs_per_block,
-        } = self.extra;
-        let chain_params = chain_spec::ChainParams::from_cli(session_period, millisecs_per_block);
-        Ok(match id {
-            chain_spec::TESTNET_ID => Box::new(chain_spec::testnet1_config(chain_params)?),
-            chain_spec::DEVNET_ID => Box::new(chain_spec::development_config(chain_params)?),
-            path => Box::new(chain_spec::ChainSpec::from_json_file(
-                std::path::PathBuf::from(path),
-            )?),
-        })
-    }
-
-    fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
-        &aleph_runtime::VERSION
-    }
-}
 
 /// Parse and run command line arguments
 pub fn run() -> sc_cli::Result<()> {
     let cli = Cli::from_args();
-
     match &cli.subcommand {
+        Some(Subcommand::BootstrapChain(cmd)) => cmd.run(&cli),
+        Some(Subcommand::BuildSpec(cmd)) => cmd.run(&cli),
         Some(Subcommand::Key(cmd)) => cmd.run(&cli),
-        Some(Subcommand::BuildSpec(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
-        }
         Some(Subcommand::CheckBlock(cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.async_run(|config| {
@@ -137,7 +88,6 @@ pub fn run() -> sc_cli::Result<()> {
                 Ok((cmd.run(client, backend), task_manager))
             })
         }
-        Some(Subcommand::DevKeys(cmd)) => cmd.run(),
         None => {
             let runner = cli.create_runner(&cli.run)?;
             runner.run_node_until_exit(|config| async move {

--- a/bin/node/src/command.rs
+++ b/bin/node/src/command.rs
@@ -24,7 +24,6 @@ pub fn run() -> sc_cli::Result<()> {
     let cli = Cli::from_args();
     match &cli.subcommand {
         Some(Subcommand::BootstrapChain(cmd)) => cmd.run(&cli),
-        Some(Subcommand::BuildSpec(cmd)) => cmd.run(&cli),
         Some(Subcommand::Key(cmd)) => cmd.run(&cli),
         Some(Subcommand::CheckBlock(cmd)) => {
             let runner = cli.create_runner(cmd)?;

--- a/bin/node/src/command.rs
+++ b/bin/node/src/command.rs
@@ -23,7 +23,7 @@ use sc_service::PartialComponents;
 pub fn run() -> sc_cli::Result<()> {
     let cli = Cli::from_args();
     match &cli.subcommand {
-        Some(Subcommand::BootstrapChain(cmd)) => cmd.run(&cli),
+        Some(Subcommand::BootstrapChain(cmd)) => cmd.run(),
         Some(Subcommand::Key(cmd)) => cmd.run(&cli),
         Some(Subcommand::CheckBlock(cmd)) => {
             let runner = cli.create_runner(cmd)?;

--- a/bin/node/src/commands.rs
+++ b/bin/node/src/commands.rs
@@ -2,7 +2,7 @@ use crate::chain_spec::{self, get_account_id_from_seed, AuthorityKeys, LOCAL_AUT
 use crate::cli::{Cli, ExtraParams};
 use aleph_primitives::AuthorityId as AlephId;
 use log::info;
-use sc_cli::{CliConfiguration, Error, KeystoreParams, NodeKeyParams, SharedParams};
+use sc_cli::{CliConfiguration, Error, KeystoreParams, SharedParams};
 use sc_keystore::LocalKeystore;
 use sc_service::config::{BasePath, KeystoreConfig};
 use sp_application_crypto::key_types;
@@ -23,26 +23,16 @@ pub struct BootstrapChainCmd {
     #[structopt(long = "raw")]
     pub raw: bool,
 
-    #[allow(missing_docs)]
     #[structopt(flatten)]
     pub keystore_params: KeystoreParams,
 
-    #[allow(missing_docs)]
     #[structopt(flatten)]
     pub shared_params: SharedParams,
-
-    #[allow(missing_docs)]
-    #[structopt(flatten)]
-    pub node_key_params: NodeKeyParams,
 }
 
 impl CliConfiguration for BootstrapChainCmd {
     fn shared_params(&self) -> &SharedParams {
         &self.shared_params
-    }
-
-    fn node_key_params(&self) -> Option<&NodeKeyParams> {
-        Some(&self.node_key_params)
     }
 }
 

--- a/bin/node/src/commands.rs
+++ b/bin/node/src/commands.rs
@@ -61,7 +61,7 @@ impl BootstrapChainCmd {
             .iter()
             .map(|authority| {
                 let authority_keystore = self
-                    .open_keystore(authority, &chain_id)
+                    .open_keystore(authority, chain_id)
                     .unwrap_or_else(|_| panic!("Cannot open keystore for {}", authority));
 
                 let aura_key = aura_key(Deref::deref(&authority_keystore));
@@ -83,7 +83,7 @@ impl BootstrapChainCmd {
             chain_spec::DEVNET_ID => {
                 chain_spec::development_config(self.chain_params.clone(), genesis_authorities)
             }
-            _ => chain_spec::config(self.chain_params.clone(), genesis_authorities, &chain_id),
+            _ => chain_spec::config(self.chain_params.clone(), genesis_authorities, chain_id),
         };
 
         let spec = chain_spec?;

--- a/bin/node/src/commands.rs
+++ b/bin/node/src/commands.rs
@@ -1,20 +1,42 @@
-use crate::chain_spec::{self, get_account_id_from_seed, AuthorityKeys, LOCAL_AUTHORITIES};
-use crate::cli::{Cli, ExtraParams};
+use crate::chain_spec::{
+    self, get_account_id_from_seed, AuthorityKeys, ChainParams, LOCAL_AUTHORITIES,
+};
 use aleph_primitives::AuthorityId as AlephId;
 use log::info;
-use sc_cli::{CliConfiguration, Error, KeystoreParams, SharedParams};
+use sc_cli::{Error, KeystoreParams};
 use sc_keystore::LocalKeystore;
 use sc_service::config::{BasePath, KeystoreConfig};
 use sp_application_crypto::key_types;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::crypto::KeyTypeId;
-use sp_core::{ed25519, sr25519};
+use sp_core::sr25519;
 use sp_keystore::SyncCryptoStore;
 use std::io::Write;
 use std::sync::Arc;
 use structopt::StructOpt;
 
-/// The `bootstrap-chain` command is used generate keys for the genesis authorities
+fn get_or_set_aura_key(keystore: &LocalKeystore) -> AuraId {
+    SyncCryptoStore::sr25519_public_keys(&*keystore, key_types::AURA)
+        .pop()
+        .map_or_else(
+            || SyncCryptoStore::sr25519_generate_new(&*keystore, key_types::AURA, None),
+            Ok,
+        )
+        .expect("Could not retrieve nor create Aura key")
+        .into()
+}
+
+fn get_or_set_aleph_key(keystore: &LocalKeystore) -> AlephId {
+    SyncCryptoStore::ed25519_public_keys(&*keystore, aleph_primitives::KEY_TYPE)
+        .pop()
+        .map_or_else(
+            || SyncCryptoStore::ed25519_generate_new(&*keystore, aleph_primitives::KEY_TYPE, None),
+            Ok,
+        )
+        .expect("Could not retrieve nor create Aleph key")
+        .into()
+}
+
+/// The `bootstrap-chain` command is used to generate private keys for the genesis authorities
 /// keys are written to the keystore of the authorities
 /// and the chain specification is printed to stdout in the JSON format
 #[derive(Debug, StructOpt)]
@@ -27,117 +49,45 @@ pub struct BootstrapChainCmd {
     pub keystore_params: KeystoreParams,
 
     #[structopt(flatten)]
-    pub shared_params: SharedParams,
-}
-
-impl CliConfiguration for BootstrapChainCmd {
-    fn shared_params(&self) -> &SharedParams {
-        &self.shared_params
-    }
+    pub chain_params: ChainParams,
 }
 
 impl BootstrapChainCmd {
-    fn upsert_aura_key(
-        &self,
-        keystore: &LocalKeystore,
-        key_type: KeyTypeId,
-    ) -> Result<AuraId, Error> {
-        let key = SyncCryptoStore::sr25519_public_keys(&*keystore, key_type)
-            .into_iter()
-            .next()
-            .map_or_else(
-                || {
-                    SyncCryptoStore::sr25519_generate_new(&*keystore, key_type, None)
-                        .map_err(|_| Error::KeyStoreOperation)
-                },
-                Ok,
-            );
+    pub fn run(&self) -> Result<(), Error> {
+        let chain_id = self.chain_params.chain_id();
 
-        match key {
-            Ok(k) => {
-                let bytes = k.as_array_ref();
-                Ok(AuraId::from(sr25519::Public::from_raw(*bytes)))
-            }
-            Err(why) => panic!("{}", why),
-        }
-    }
+        let genesis_authorities = LOCAL_AUTHORITIES
+            .iter()
+            .map(|authority| {
+                let authority_keystore = self
+                    .open_keystore(authority, &chain_id)
+                    .unwrap_or_else(|_| panic!("Cannot open keystore for {}", authority));
 
-    fn upsert_aleph_key(
-        &self,
-        keystore: &LocalKeystore,
-        key_type: KeyTypeId,
-    ) -> Result<AlephId, Error> {
-        let key = SyncCryptoStore::ed25519_public_keys(&*keystore, key_type)
-            .into_iter()
-            .next()
-            .map_or_else(
-                || {
-                    SyncCryptoStore::ed25519_generate_new(&*keystore, key_type, None)
-                        .map_err(|_| Error::KeyStoreOperation)
-                },
-                Ok,
-            );
+                let aura_key = get_or_set_aura_key(&authority_keystore);
+                let aleph_key = get_or_set_aleph_key(&authority_keystore);
+                let account_id = get_account_id_from_seed::<sr25519::Public>(authority);
 
-        match key {
-            Ok(k) => {
-                let bytes = k.as_array_ref();
-                Ok(AlephId::from(ed25519::Public::from_raw(*bytes)))
-            }
-            Err(why) => panic!("{}", why),
-        }
-    }
-
-    pub fn run(&self, cli: &Cli) -> Result<(), Error> {
-        let chain_id = self.shared_params.chain_id(self.shared_params.is_dev());
-
-        let mut genesis_authorities: Vec<AuthorityKeys> = Vec::new();
-
-        LOCAL_AUTHORITIES.iter().for_each(|authority| {
-            let authority_keystore = self
-                .open_keystore(authority, &chain_id)
-                .unwrap_or_else(|_| panic!("Cannot open keystore for {}", authority));
-
-            let aura_key = self
-                .upsert_aura_key(&authority_keystore, key_types::AURA)
-                .unwrap();
-            let aleph_key = self
-                .upsert_aleph_key(&authority_keystore, aleph_primitives::KEY_TYPE)
-                .unwrap();
-            let account_id = get_account_id_from_seed::<sr25519::Public>(authority);
-
-            // NOTE: we could generate libp2p secrets here and add PeerIds to bootstrap nodes list,
-            // see Substrate's GenerateNodeKeyCmd
-
-            genesis_authorities.push(AuthorityKeys {
-                account_id,
-                aura_key,
-                aleph_key,
-            });
-        });
+                AuthorityKeys {
+                    account_id,
+                    aura_key,
+                    aleph_key,
+                }
+            })
+            .collect();
 
         info!("Building chain spec");
 
-        let ExtraParams {
-            session_period,
-            millisecs_per_block,
-        } = cli.extra;
-
-        let chain_params = chain_spec::ChainParams::from_cli(session_period, millisecs_per_block);
-        let chain_spec = match chain_id.as_str() {
+        let chain_spec = match self.chain_params.chain_id().as_str() {
             chain_spec::DEVNET_ID => {
-                chain_spec::development_config(chain_params, genesis_authorities)
+                chain_spec::development_config(self.chain_params.clone(), genesis_authorities)
             }
-            _ => chain_spec::config(chain_params, genesis_authorities, &chain_id),
+            _ => chain_spec::config(self.chain_params.clone(), genesis_authorities, &chain_id),
         };
 
-        match chain_spec {
-            Ok(spec) => {
-                let json = sc_service::chain_ops::build_spec(&spec, self.raw)?;
-                if std::io::stdout().write_all(json.as_bytes()).is_err() {
-                    let _ = std::io::stderr().write_all(b"Error writing to stdout\n");
-                }
-            }
-            Err(why) => panic!("{}", why),
+        let spec = chain_spec?;
+        let json = sc_service::chain_ops::build_spec(&spec, self.raw)?;
+        if std::io::stdout().write_all(json.as_bytes()).is_err() {
+            let _ = std::io::stderr().write_all(b"Error writing to stdout\n");
         }
 
         Ok(())
@@ -145,7 +95,7 @@ impl BootstrapChainCmd {
 
     fn open_keystore(&self, authority: &str, chain_id: &str) -> Result<Arc<LocalKeystore>, Error> {
         let base_path: BasePath = self
-            .shared_params
+            .chain_params
             .base_path()
             .unwrap()
             .path()

--- a/bin/node/src/commands.rs
+++ b/bin/node/src/commands.rs
@@ -1,0 +1,178 @@
+use crate::chain_spec::{self, get_account_id_from_seed, AuthorityKeys, LOCAL_AUTHORITIES};
+use crate::cli::{Cli, ExtraParams};
+use aleph_primitives::AuthorityId as AlephId;
+use log::info;
+use sc_cli::{CliConfiguration, Error, KeystoreParams, NodeKeyParams, SharedParams};
+use sc_keystore::LocalKeystore;
+use sc_service::config::{BasePath, KeystoreConfig};
+use sp_application_crypto::key_types;
+use sp_consensus_aura::sr25519::AuthorityId as AuraId;
+use sp_core::crypto::KeyTypeId;
+use sp_core::{ed25519, sr25519};
+use sp_keystore::SyncCryptoStore;
+use std::io::Write;
+use std::sync::Arc;
+use structopt::StructOpt;
+
+/// The `bootstrap-chain` command is used generate keys for the genesis authorities
+/// keys are written to the keystore of the authorities
+/// and the chain specification is printed to stdout in the JSON format
+#[derive(Debug, StructOpt)]
+pub struct BootstrapChainCmd {
+    /// Force raw genesis storage output.
+    #[structopt(long = "raw")]
+    pub raw: bool,
+
+    #[allow(missing_docs)]
+    #[structopt(flatten)]
+    pub keystore_params: KeystoreParams,
+
+    #[allow(missing_docs)]
+    #[structopt(flatten)]
+    pub shared_params: SharedParams,
+
+    #[allow(missing_docs)]
+    #[structopt(flatten)]
+    pub node_key_params: NodeKeyParams,
+}
+
+impl CliConfiguration for BootstrapChainCmd {
+    fn shared_params(&self) -> &SharedParams {
+        &self.shared_params
+    }
+
+    fn node_key_params(&self) -> Option<&NodeKeyParams> {
+        Some(&self.node_key_params)
+    }
+}
+
+impl BootstrapChainCmd {
+    fn upsert_aura_key(
+        &self,
+        keystore: &LocalKeystore,
+        key_type: KeyTypeId,
+    ) -> Result<AuraId, Error> {
+        let key = SyncCryptoStore::sr25519_public_keys(&*keystore, key_type)
+            .into_iter()
+            .next()
+            .map_or_else(
+                || {
+                    SyncCryptoStore::sr25519_generate_new(&*keystore, key_type, None)
+                        .map_err(|_| Error::KeyStoreOperation)
+                },
+                Ok,
+            );
+
+        match key {
+            Ok(k) => {
+                let bytes = k.as_array_ref();
+                Ok(AuraId::from(sr25519::Public::from_raw(*bytes)))
+            }
+            Err(why) => panic!("{}", why),
+        }
+    }
+
+    fn upsert_aleph_key(
+        &self,
+        keystore: &LocalKeystore,
+        key_type: KeyTypeId,
+    ) -> Result<AlephId, Error> {
+        let key = SyncCryptoStore::ed25519_public_keys(&*keystore, key_type)
+            .into_iter()
+            .next()
+            .map_or_else(
+                || {
+                    SyncCryptoStore::ed25519_generate_new(&*keystore, key_type, None)
+                        .map_err(|_| Error::KeyStoreOperation)
+                },
+                Ok,
+            );
+
+        match key {
+            Ok(k) => {
+                let bytes = k.as_array_ref();
+                Ok(AlephId::from(ed25519::Public::from_raw(*bytes)))
+            }
+            Err(why) => panic!("{}", why),
+        }
+    }
+
+    pub fn run(&self, cli: &Cli) -> Result<(), Error> {
+        let chain_id = self.shared_params.chain_id(self.shared_params.is_dev());
+
+        let mut genesis_authorities: Vec<AuthorityKeys> = Vec::new();
+
+        LOCAL_AUTHORITIES.iter().for_each(|authority| {
+            let authority_keystore = self
+                .open_keystore(authority, &chain_id)
+                .unwrap_or_else(|_| panic!("Cannot open keystore for {}", authority));
+
+            let aura_key = self
+                .upsert_aura_key(&authority_keystore, key_types::AURA)
+                .unwrap();
+            let aleph_key = self
+                .upsert_aleph_key(&authority_keystore, aleph_primitives::KEY_TYPE)
+                .unwrap();
+            let account_id = get_account_id_from_seed::<sr25519::Public>(authority);
+
+            // NOTE: we could generate libp2p secrets here and add PeerIds to bootstrap nodes list,
+            // see Substrate's GenerateNodeKeyCmd
+
+            genesis_authorities.push(AuthorityKeys {
+                account_id,
+                aura_key,
+                aleph_key,
+            });
+        });
+
+        info!("Building chain spec");
+
+        let ExtraParams {
+            session_period,
+            millisecs_per_block,
+        } = cli.extra;
+
+        let chain_params = chain_spec::ChainParams::from_cli(session_period, millisecs_per_block);
+        let chain_spec = match chain_id.as_str() {
+            chain_spec::DEVNET_ID => {
+                chain_spec::development_config(chain_params, genesis_authorities)
+            }
+            _ => chain_spec::config(chain_params, genesis_authorities, &chain_id),
+        };
+
+        match chain_spec {
+            Ok(spec) => {
+                let json = sc_service::chain_ops::build_spec(&spec, self.raw)?;
+                if std::io::stdout().write_all(json.as_bytes()).is_err() {
+                    let _ = std::io::stderr().write_all(b"Error writing to stdout\n");
+                }
+            }
+            Err(why) => panic!("{}", why),
+        }
+
+        Ok(())
+    }
+
+    fn open_keystore(&self, authority: &str, chain_id: &str) -> Result<Arc<LocalKeystore>, Error> {
+        let base_path: BasePath = self
+            .shared_params
+            .base_path()
+            .unwrap()
+            .path()
+            .join(authority)
+            .into();
+
+        info!(
+            "Writing to keystore for authority {} and chain id {} under path {:?}",
+            authority, chain_id, base_path
+        );
+
+        let config_dir = base_path.config_dir(chain_id);
+        match self.keystore_params.keystore_config(&config_dir)? {
+            (_, KeystoreConfig::Path { path, password }) => {
+                Ok(Arc::new(LocalKeystore::open(path, password)?))
+            }
+            _ => unreachable!("keystore_config always returns path and password; qed"),
+        }
+    }
+}

--- a/bin/node/src/commands.rs
+++ b/bin/node/src/commands.rs
@@ -11,28 +11,29 @@ use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::sr25519;
 use sp_keystore::SyncCryptoStore;
 use std::io::Write;
+use std::ops::Deref;
 use std::sync::Arc;
 use structopt::StructOpt;
 
-fn get_or_set_aura_key(keystore: &LocalKeystore) -> AuraId {
+/// returns Aura key, if absent a new key is generated
+fn aura_key(keystore: &impl SyncCryptoStore) -> AuraId {
     SyncCryptoStore::sr25519_public_keys(&*keystore, key_types::AURA)
         .pop()
-        .map_or_else(
-            || SyncCryptoStore::sr25519_generate_new(&*keystore, key_types::AURA, None),
-            Ok,
-        )
-        .expect("Could not retrieve nor create Aura key")
+        .unwrap_or_else(|| {
+            SyncCryptoStore::sr25519_generate_new(&*keystore, key_types::AURA, None)
+                .expect("Could not create Aura key")
+        })
         .into()
 }
 
-fn get_or_set_aleph_key(keystore: &LocalKeystore) -> AlephId {
+/// returns Aleph key, if absent a new key is generated
+fn aleph_key(keystore: &impl SyncCryptoStore) -> AlephId {
     SyncCryptoStore::ed25519_public_keys(&*keystore, aleph_primitives::KEY_TYPE)
         .pop()
-        .map_or_else(
-            || SyncCryptoStore::ed25519_generate_new(&*keystore, aleph_primitives::KEY_TYPE, None),
-            Ok,
-        )
-        .expect("Could not retrieve nor create Aleph key")
+        .unwrap_or_else(|| {
+            SyncCryptoStore::ed25519_generate_new(&*keystore, aleph_primitives::KEY_TYPE, None)
+                .expect("Could not create Aleph key")
+        })
         .into()
 }
 
@@ -63,8 +64,9 @@ impl BootstrapChainCmd {
                     .open_keystore(authority, &chain_id)
                     .unwrap_or_else(|_| panic!("Cannot open keystore for {}", authority));
 
-                let aura_key = get_or_set_aura_key(&authority_keystore);
-                let aleph_key = get_or_set_aleph_key(&authority_keystore);
+                let aura_key = aura_key(Deref::deref(&authority_keystore));
+                let aleph_key = aleph_key(Deref::deref(&authority_keystore));
+                // NOTE : the account_id's should definitely not be generated from seed in case of testnet and mainnet
                 let account_id = get_account_id_from_seed::<sr25519::Public>(authority);
 
                 AuthorityKeys {
@@ -77,7 +79,7 @@ impl BootstrapChainCmd {
 
         info!("Building chain spec");
 
-        let chain_spec = match self.chain_params.chain_id().as_str() {
+        let chain_spec = match self.chain_params.chain_id() {
             chain_spec::DEVNET_ID => {
                 chain_spec::development_config(self.chain_params.clone(), genesis_authorities)
             }
@@ -94,13 +96,7 @@ impl BootstrapChainCmd {
     }
 
     fn open_keystore(&self, authority: &str, chain_id: &str) -> Result<Arc<LocalKeystore>, Error> {
-        let base_path: BasePath = self
-            .chain_params
-            .base_path()
-            .unwrap()
-            .path()
-            .join(authority)
-            .into();
+        let base_path: BasePath = self.chain_params.base_path().path().join(authority).into();
 
         info!(
             "Writing to keystore for authority {} and chain id {} under path {:?}",

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -3,6 +3,7 @@ mod chain_spec;
 mod service;
 mod cli;
 mod command;
+mod commands;
 mod rpc;
 
 fn main() -> sc_cli::Result<()> {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -97,4 +97,3 @@ services:
       - RUST_LOG=info
     volumes:
       - ./data/:/tmp/
-      

--- a/run_nodes.sh
+++ b/run_nodes.sh
@@ -25,14 +25,14 @@ shift
 authorities=(Damian Tomasz Zbyszko Hansu Adam Matt Antoni Michal)
 authorities=("${authorities[@]::$n_members}")
 
-./target/release/aleph-node dev-keys  --base-path /tmp --chain dev --key-types aura alp0
+./target/release/aleph-node bootstrap-chain --base-path docker/data --chain-id dev > docker/data/chainspec.json
 
 for i in ${!authorities[@]}; do
   auth=${authorities[$i]}
-  ./target/release/aleph-node purge-chain --base-path /tmp/"$auth" --chain dev -y
+  ./target/release/aleph-node purge-chain --base-path /tmp/"$auth" --chain docker/data/chainspec.json -y
   ./target/release/aleph-node \
     --validator \
-    --chain dev \
+    --chain docker/data/chainspec.json \
     --base-path /tmp/$auth \
     --name $auth \
     --rpc-port $(expr 9933 + $i) \


### PR DESCRIPTION
This PR introduces new command(s)

* bootstrap-chain (alias: build-spec) command [4/4]
- [x] takes chain identifier and base-path parameters
- [x] writes aura + aleph keys to the keystore of all validators
- [x] creates and prints to stdout a corresponding chainspec (with validators account ids and public keys written to pallet_session keys at genesis)
- [x] `dev` is a "special" chain identifier as it creates a development chain and a corresponding chainspec

Example:

``` bash
./aleph-node bootstrap-chain --base-path chain/data --chain a0tnet1 > chain/data/chainspec.json
```

* run chain (default) command [1/1]
- [x] takes a path to JSON chainspec

**Follow-up work**

This is an MVP required to geneate a chainspec for mainnet version of aleph-node, therefore the following items are moved for a follow-up PRs

* for the bootstrap chain command
- [ ] OPTIONAL: create libp2p network secret keys and print peerIds to the stdout

* OPTIONAL bootstrap-node command [0/2]
- [ ] takes base-path chain and node-name arguments, writes aura + aleph keys to the keystore for one validator
- [ ] OPTIONAL: creates libp2p network secret key and prints peerId to the stdout
