### PR TITLE
A0-406: Fix script to work with bootstrapping and add non-validator nodes

### DIFF
--- a/run_nodes.sh
+++ b/run_nodes.sh
@@ -3,9 +3,7 @@
 if [ -z "$1" ] || (("$1" < 2 || "$1" > 8))
 then
     echo "The committee size is missing, usage:
-
     ./run_nodes.sh SIZE [Additional Arguments to ./target/debug/aleph-node]
-
 where 2 <= SIZE <= 8"
     exit
 fi
@@ -17,23 +15,41 @@ set -e
 clear
 
 n_members="$1"
-echo "$n_members" > /tmp/n_members
+# echo "$n_members" > /tmp/n_members
 shift
 
 # cargo build --release -p aleph-node
 
+account_ids=(
+    "5D34dL5prEUaGNQtPPZ3yN5Y6BnkfXunKXXz6fo7ZJbLwRRH"
+    "5GBNeWRhZc2jXu7D55rBimKYDk8PGk8itRYFTPfC8RJLKG5o" \
+    "5Dfis6XL8J2P6JHUnUtArnFWndn62SydeP8ee8sG2ky9nfm9" \
+    "5F4H97f7nQovyrbiq4ZetaaviNwThSVcFobcA5aGab6167dK" \
+    "5DiDShBWa1fQx6gLzpf3SFBhMinCoyvHM1BWjPNsmXS8hkrW" \
+    "5EFb84yH9tpcFuiKUcsmdoF7xeeY3ajG1ZLQimxQoFt9HMKR" \
+    "5DZLHESsfGrJ5YzT3HuRPXsSNb589xQ4Unubh1mYLodzKdVY" \
+    "5GHJzqvG6tXnngCpG7B12qjUvbo5e4e9z8Xjidk3CQZHxTPZ" \
+    "5CUnSsgAyLND3bxxnfNhgWXSe9Wn676JzLpGLgyJv858qhoX" \
+    "5CVKn7HAZW1Ky4r7Vkgsr7VEW88C2sHgUNDiwHY9Ct2hjU8q")
+account_ids=("${account_ids[@]::$n_members}")
+# space separated ids
+account_ids_string="${account_ids[*]}"
+# comma separated ids
+account_ids_string="${account_ids_string//${IFS:0:1}/,}"
+
 authorities=(Damian Tomasz Zbyszko Hansu Adam Matt Antoni Michal)
 authorities=("${authorities[@]::$n_members}")
 
-./target/release/aleph-node bootstrap-chain --base-path docker/data --chain-id dev > docker/data/chainspec.json
+./target/release/aleph-node bootstrap-chain --base-path docker/data --chain-id dev --account-ids "$account_ids_string" > docker/data/chainspec.json
 
-for i in ${!authorities[@]}; do
+for i in ${!account_ids[@]}; do
   auth=${authorities[$i]}
-  ./target/release/aleph-node purge-chain --base-path /tmp/"$auth" --chain docker/data/chainspec.json -y
+  account_id=${account_ids[$i]}
+  ./target/release/aleph-node purge-chain --base-path "docker/data/$account_id" --chain docker/data/chainspec.json -y
   ./target/release/aleph-node \
     --validator \
     --chain docker/data/chainspec.json \
-    --base-path /tmp/$auth \
+    --base-path "docker/data/$account_id" \
     --name $auth \
     --rpc-port $(expr 9933 + $i) \
     --ws-port $(expr 9944 + $i) \

--- a/run_nodes.sh
+++ b/run_nodes.sh
@@ -2,20 +2,22 @@
 
 function usage(){
   echo "Usage:
-      ./run_nodes.sh [-v N_VALIDATORS] [-n N_NON_VALIDATORS] [ALEPH_NODE_ARG]...
+      ./run_nodes.sh [-v N_VALIDATORS] [-n N_NON_VALIDATORS] [-s] [ALEPH_NODE_ARG]...
   where 2 <= N_VALIDATORS <= N_VALIDATORS + N_NON_VALIDATORS <= 10
   (by default, N_VALIDATORS=4 and N_NON_VALIDATORS=0)"
 }
 
 N_VALIDATORS=4
 N_NON_VALIDATORS=0
+BUILD_ALEPH_NODE='true'
 
-while getopts "v:n:" flag
+while getopts "v:n:s" flag
 do
   case "${flag}" in
     v) N_VALIDATORS=${OPTARG};;
     n) N_NON_VALIDATORS=${OPTARG};;
-    \?)
+    s) BUILD_ALEPH_NODE='false';;
+    *)
       usage
       exit
       ;;
@@ -30,7 +32,9 @@ set -e
 
 clear
 
-cargo build --release -p aleph-node
+if $BUILD_ALEPH_NODE ; then
+  cargo build --release -p aleph-node
+fi
 
 account_ids=(
     "5D34dL5prEUaGNQtPPZ3yN5Y6BnkfXunKXXz6fo7ZJbLwRRH"

--- a/run_nodes.sh
+++ b/run_nodes.sh
@@ -39,6 +39,7 @@ validator_ids_string="${validator_ids[*]}"
 validator_ids_string="${validator_ids_string//${IFS:0:1}/,}"
 
 
+echo "Bootstrapping chain for nodes 0..$((n_validators - 1))"
 ./target/release/aleph-node bootstrap-chain --base-path docker/data --chain-id dev --account-ids "$validator_ids_string" > docker/data/chainspec.json
 
 

--- a/run_nodes.sh
+++ b/run_nodes.sh
@@ -12,7 +12,7 @@ N_NON_VALIDATORS=0
 BUILD_ALEPH_NODE='true'
 BASE_PATH='/tmp'
 
-while getopts "v:n:b:p" flag
+while getopts "v:n:b:p:" flag
 do
   case "${flag}" in
     v) N_VALIDATORS=${OPTARG};;


### PR DESCRIPTION
Fix the script to work with chain/node bootstrapping
Added an extra argument, which specifies the number of non validator nodes to run. These nodes will not be included in the list of validators in the chainspec, but will be helpful in testing committee changes.