### PR TITLE
Enable setting unit creation delay with a flag

### DIFF
--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -1,6 +1,6 @@
 use aleph_primitives::{
-    AuthorityId as AlephId, ADDRESSES_ENCODING, DEFAULT_MILLISECS_PER_BLOCK,
-    DEFAULT_SESSION_PERIOD, TOKEN_DECIMALS,
+    AuthorityId as AlephId, ADDRESSES_ENCODING, DEFAULT_BASE_UNIT_CREATION_DELAY,
+    DEFAULT_MILLISECS_PER_BLOCK, DEFAULT_SESSION_PERIOD, TOKEN_DECIMALS,
 };
 use aleph_runtime::{
     AccountId, AlephConfig, AuraConfig, BalancesConfig, GenesisConfig, SessionConfig, SessionKeys,
@@ -110,6 +110,9 @@ pub struct ChainParams {
     pub millisecs_per_block: Option<u64>,
 
     #[structopt(long)]
+    pub base_unit_creation_delay: Option<u64>,
+
+    #[structopt(long)]
     pub chain_name: Option<String>,
 
     #[structopt(long)]
@@ -139,6 +142,11 @@ impl ChainParams {
     pub fn millisecs_per_block(&self) -> u64 {
         self.millisecs_per_block
             .unwrap_or(DEFAULT_MILLISECS_PER_BLOCK)
+    }
+
+    pub fn base_unit_creation_delay(&self) -> u64 {
+        self.base_unit_creation_delay
+            .unwrap_or(DEFAULT_BASE_UNIT_CREATION_DELAY)
     }
 
     pub fn session_period(&self) -> u32 {
@@ -317,6 +325,7 @@ fn genesis(
 ) -> GenesisConfig {
     let session_period = chain_params.session_period();
     let millisecs_per_block = chain_params.millisecs_per_block();
+    let base_unit_creation_delay = chain_params.base_unit_creation_delay();
 
     log::debug!("chain parameters {:?}", &chain_params);
 
@@ -351,6 +360,7 @@ fn genesis(
                 .iter()
                 .map(|auth| auth.account_id.clone())
                 .collect(),
+            base_unit_creation_delay,
         },
         session: SessionConfig {
             keys: authorities

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -3,8 +3,8 @@
 use aleph_primitives::AlephSessionApi;
 use aleph_runtime::{self, opaque::Block, RuntimeApi};
 use finality_aleph::{
-    run_aleph_consensus, AlephBlockImport, AlephConfig, JustificationNotification, Metrics,
-    MillisecsPerBlock, SessionPeriod,
+    run_aleph_consensus, AlephBlockImport, AlephConfig, BaseUnitCreationDelay,
+    JustificationNotification, Metrics, MillisecsPerBlock, SessionPeriod,
 };
 use futures::channel::mpsc;
 use log::warn;
@@ -182,6 +182,13 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
             .unwrap(),
     );
 
+    let base_unit_creation_delay = BaseUnitCreationDelay(
+        client
+            .runtime_api()
+            .base_unit_creation_delay(&BlockId::Number(Zero::zero()))
+            .unwrap(),
+    );
+
     let role = config.role.clone();
     let force_authoring = config.force_authoring;
     let backoff_authoring_blocks: Option<()> = None;
@@ -276,6 +283,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
             keystore: keystore_container.sync_keystore(),
             justification_rx,
             metrics,
+            base_unit_creation_delay,
         };
         task_manager
             .spawn_essential_handle()

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -315,6 +315,20 @@ impl<I: From<u64>> ::frame_support::traits::Get<I> for MillisecsPerBlock {
     }
 }
 
+pub struct BaseUnitCreationDelay;
+
+impl BaseUnitCreationDelay {
+    pub fn get() -> u64 {
+        Aleph::base_unit_creation_delay()
+    }
+}
+
+impl<I: From<u64>> ::frame_support::traits::Get<I> for BaseUnitCreationDelay {
+    fn get() -> I {
+        I::from(Self::get())
+    }
+}
+
 parameter_types! {
     pub const Offset: u32 = 0;
 }
@@ -550,6 +564,10 @@ impl_runtime_apis! {
 
         fn millisecs_per_block() -> u64 {
             MillisecsPerBlock::get()
+        }
+
+        fn base_unit_creation_delay() -> u64 {
+            BaseUnitCreationDelay::get()
         }
     }
 }

--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -59,6 +59,9 @@ pub struct SessionPeriod(pub u32);
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd, Encode, Decode)]
 pub struct MillisecsPerBlock(pub u64);
 
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd, Encode, Decode)]
+pub struct BaseUnitCreationDelay(pub u64);
+
 use sp_core::crypto::KeyTypeId;
 pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"alp0");
 pub use crate::metrics::Metrics;
@@ -241,6 +244,7 @@ pub struct AlephConfig<B: Block, N, C, SC> {
     pub metrics: Option<Metrics<B::Header>>,
     pub session_period: SessionPeriod,
     pub millisecs_per_block: MillisecsPerBlock,
+    pub base_unit_creation_delay: BaseUnitCreationDelay,
 }
 
 pub fn run_aleph_consensus<B: Block, BE, C, N, SC>(

--- a/finality-aleph/src/party.rs
+++ b/finality-aleph/src/party.rs
@@ -14,8 +14,8 @@ use crate::{
     network::{
         split_network, AlephNetworkData, ConsensusNetwork, DataNetwork, NetworkData, SessionManager,
     },
-    session_id_from_block_num, AuthorityId, Future, KeyBox, Metrics, MultiKeychain, NodeIndex,
-    SessionId, SessionMap, SessionPeriod, KEY_TYPE,
+    session_id_from_block_num, AuthorityId, BaseUnitCreationDelay, Future, KeyBox, Metrics,
+    MultiKeychain, NodeIndex, SessionId, SessionMap, SessionPeriod, KEY_TYPE,
 };
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 
@@ -68,6 +68,7 @@ where
                 metrics,
                 session_period,
                 millisecs_per_block,
+                base_unit_creation_delay,
                 ..
             },
     } = aleph_params;
@@ -118,6 +119,7 @@ where
         session_period,
         spawn_handle: spawn_handle.into(),
         phantom: PhantomData,
+        base_unit_creation_delay,
     };
 
     debug!(target: "afa", "Consensus party has started.");
@@ -179,6 +181,7 @@ where
     phantom: PhantomData<BE>,
     metrics: Option<Metrics<B::Header>>,
     authority_justification_tx: mpsc::UnboundedSender<JustificationNotification<B>>,
+    base_unit_creation_delay: BaseUnitCreationDelay,
 }
 
 async fn run_aggregator<B, C, BE>(
@@ -285,7 +288,12 @@ where
         let (aleph_network, rmc_network, forwarder) =
             split_network(data_network, aleph_network_tx, aleph_network_rx);
 
-        let consensus_config = create_aleph_config(authorities.len(), node_id, session_id);
+        let consensus_config = create_aleph_config(
+            authorities.len(),
+            node_id,
+            session_id,
+            self.base_unit_creation_delay.0,
+        );
 
         let best_header = self
             .select_chain
@@ -543,14 +551,15 @@ pub(crate) fn create_aleph_config(
     n_members: usize,
     node_id: NodeIndex,
     session_id: SessionId,
+    base_unit_creation_delay: u64,
 ) -> aleph_bft::Config {
     let mut consensus_config = default_aleph_config(n_members.into(), node_id, session_id.0 as u64);
     consensus_config.max_round = 7000;
-    let unit_creation_delay = Arc::new(|t| {
+    let unit_creation_delay = Arc::new(move |t| {
         if t == 0 {
             Duration::from_millis(2000)
         } else {
-            exponential_slowdown(t, 300.0, 5000, 1.005)
+            exponential_slowdown(t, base_unit_creation_delay as f64, 5000, 1.005)
         }
     });
     let unit_broadcast_delay = Arc::new(|t| exponential_slowdown(t, 4000., 0, 2.));

--- a/pallet/src/lib.rs
+++ b/pallet/src/lib.rs
@@ -22,7 +22,8 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use pallet_session::{Pallet as Session, SessionManager};
     use primitives::{
-        ApiError as AlephApiError, DEFAULT_MILLISECS_PER_BLOCK, DEFAULT_SESSION_PERIOD,
+        ApiError as AlephApiError, DEFAULT_BASE_UNIT_CREATION_DELAY, DEFAULT_MILLISECS_PER_BLOCK,
+        DEFAULT_SESSION_PERIOD,
     };
 
     #[pallet::type_value]
@@ -113,11 +114,22 @@ pub mod pallet {
     pub(super) type MillisecsPerBlock<T: Config> =
         StorageValue<_, u64, ValueQuery, DefaultForMillisecsPerBlock>;
 
+    #[pallet::type_value]
+    pub(super) fn DefaultForBaseUnitCreationDelay() -> u64 {
+        DEFAULT_BASE_UNIT_CREATION_DELAY
+    }
+
+    #[pallet::storage]
+    #[pallet::getter(fn base_unit_creation_delay)]
+    pub(super) type BaseUnitCreationDelay<T: Config> =
+        StorageValue<_, u64, ValueQuery, DefaultForBaseUnitCreationDelay>;
+
     #[pallet::genesis_config]
     pub struct GenesisConfig<T: Config> {
         pub authorities: Vec<T::AuthorityId>,
         pub session_period: u32,
         pub millisecs_per_block: u64,
+        pub base_unit_creation_delay: u64,
         pub validators: Vec<T::AccountId>,
     }
 
@@ -128,6 +140,7 @@ pub mod pallet {
                 authorities: Vec::new(),
                 session_period: DEFAULT_SESSION_PERIOD,
                 millisecs_per_block: DEFAULT_MILLISECS_PER_BLOCK,
+                base_unit_creation_delay: DEFAULT_BASE_UNIT_CREATION_DELAY,
                 validators: Vec::new(),
             }
         }
@@ -138,6 +151,7 @@ pub mod pallet {
         fn build(&self) {
             <SessionPeriod<T>>::put(&self.session_period);
             <MillisecsPerBlock<T>>::put(&self.millisecs_per_block);
+            <BaseUnitCreationDelay<T>>::put(&self.base_unit_creation_delay);
             <Validators<T>>::put(Some(&self.validators));
             <SessionForValidatorsChange<T>>::put(Some(0));
         }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -27,6 +27,7 @@ pub const DEFAULT_SESSION_PERIOD: u32 = 5;
 pub const DEFAULT_MILLISECS_PER_BLOCK: u64 = 4000;
 pub const TOKEN_DECIMALS: u32 = 12;
 pub const ADDRESSES_ENCODING: u32 = 42;
+pub const DEFAULT_BASE_UNIT_CREATION_DELAY: u64 = 300;
 
 #[derive(codec::Encode, codec::Decode, PartialEq, Eq, sp_std::fmt::Debug)]
 pub enum ApiError {
@@ -40,5 +41,6 @@ sp_api::decl_runtime_apis! {
         fn authorities() -> Vec<AuthorityId>;
         fn session_period() -> u32;
         fn millisecs_per_block() -> u64;
+        fn base_unit_creation_delay() -> u64;
     }
 }


### PR DESCRIPTION
A new flag `--base-unit-creation-delay` enables manipulating delay for unit creation. The mechanics is analogous to `--millisecs-per-block`.