### PR TITLE
AZ: Include weight fee

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -109,7 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 1,
+    spec_version: 2,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
The default implementation for `()` as `FeeMultiplierUpdate` zeros the fee implied by a call weight. As far as I know, when implementing custom `FeeMultiplierUpdate` the only thing that matters is an implementation of the `Convert<Multiplier, Multiplier>` trait (used [here](https://github.com/paritytech/substrate/blob/485e592ee2ef4db499134e9a903c02574d731593/frame/transaction-payment/src/lib.rs#L342)). The methods `min`, `target` and `variability` are useful when aiming for an adaptive updates (described [here](https://research.web3.foundation/en/latest/polkadot/overview/2-token-economics.html#-2.-slow-adjusting-mechanism)).

A corresponding test should be added after merging #149. (Jira: https://cardinal-cryptography.atlassian.net/browse/AZ-151)