### PR TITLE
Reminder about runtime version bump

### DIFF
--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -24,7 +24,7 @@ jobs:
       SCCACHE_VERSION: 0.2.13
       SCCACHE_CACHE_SIZE: 2G
       SCCACHE_PATH: /home/runner/.cache/sccache
-      SCCACHE_RECACHE: 1 # to clear cache uncomment this, let the workflow run once, then comment it out again
+      # SCCACHE_RECACHE: 1 # to clear cache uncomment this, let the workflow run once, then comment it out again
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0

--- a/.github/workflows/post-dod-checklist.yml
+++ b/.github/workflows/post-dod-checklist.yml
@@ -13,3 +13,4 @@ jobs:
             - [ ] Infrastructure updated accordingly
             - [ ] Updated existing documentation
             - [ ] New documentation created
+            - [ ] Bump spec_version and transaction_version if relevant


### PR DESCRIPTION
Also reenables the e2e test cache, although I'm unsure disabling it did anything. :/