### PR TITLE
AZ-62: Add synchronization workflow with foundation repository

### DIFF
--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -1,0 +1,17 @@
+name: Sync Cardinal-Cryptography repo with Aleph-Zero-Foundation repo
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'Cardinal-Cryptography/aleph-node'}}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SYNCAZF }}
+      - name: Push to Aleph-Zero-Foundation
+        run: git push https://x-access-token:${{ secrets.SYNCAZF }}@github.com/aleph-zero-foundation/aleph-node.git


### PR DESCRIPTION
I tested it here:
* workflow - https://github.com/Cardinal-Cryptography/aleph-node/runs/4187960088?check_suite_focus=true
* commit - https://github.com/Cardinal-Cryptography/aleph-node/commit/bba0b589d47c2786167ab00366065832accd1bd4
* foundation branch - https://github.com/aleph-zero-foundation/aleph-node/tree/AZ-62-add-sync-with-foundation-repo