### PR TITLE
defaults are too long and CI times out

### DIFF
--- a/.github/scripts/run_consensus.sh
+++ b/.github/scripts/run_consensus.sh
@@ -8,7 +8,7 @@ mkdir -p docker/data/
 source docker/env
 
 # Generate chainspec and populate comittee keystores
-docker run -v $(pwd)/docker/data:/data --entrypoint "/bin/sh" -e DAMIAN -e TOMASZ -e ZBYSZKO -e HANSU -e RUST_LOG=info aleph-node:latest -c "aleph-node bootstrap-chain --base-path /data --chain-id a0dnet1 --account-ids $DAMIAN,$TOMASZ,$ZBYSZKO,$HANSU --sudo-account-id $DAMIAN > /data/chainspec.json"
+docker run -v $(pwd)/docker/data:/data --entrypoint "/bin/sh" -e DAMIAN -e TOMASZ -e ZBYSZKO -e HANSU -e RUST_LOG=info aleph-node:latest -c "aleph-node bootstrap-chain --base-path /data --chain-id a0dnet1 --millisecs-per-block 1000 --session-period 5 --account-ids $DAMIAN,$TOMASZ,$ZBYSZKO,$HANSU --sudo-account-id $DAMIAN > /data/chainspec.json"
 
 # get bootnote peer id
 export BOOTNODE_PEER_ID=$(docker run -v $(pwd)/docker/data:/data --entrypoint "/bin/sh" -e DAMIAN -e RUST_LOG=info aleph-node:latest -c "aleph-node key inspect-node-key --file /data/$DAMIAN/p2p_secret")

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -2,13 +2,9 @@ name: e2e-tests-main-devnet
 
 on:
   pull_request:
-    paths-ignore:
-        - "*.md"
     branches:
       - main
   push:
-    paths-ignore:
-        - "*.md"
     branches:
       - main
 

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -3,13 +3,13 @@ name: e2e-tests-main-devnet
 on:
   pull_request:
     paths-ignore:
-        - ".github/**"
+        # - ".github/**"
         - "*.md"
     branches:
       - main
   push:
     paths-ignore:
-        - ".github/**"
+        # - ".github/**"
         - "*.md"
     branches:
       - main

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -3,13 +3,11 @@ name: e2e-tests-main-devnet
 on:
   pull_request:
     paths-ignore:
-        # - ".github/**"
         - "*.md"
     branches:
       - main
   push:
     paths-ignore:
-        # - ".github/**"
         - "*.md"
     branches:
       - main


### PR DESCRIPTION
Check started failing after merging to main. This is because of #e1b0397 that wasn't part of the branch when merging.  

- session period is set to 5 (previous default) to fit the 2 sessions change within the 5 min limit on the tests run. 
- changed branch protection rules - branch needs to be up-to date (rebased on top of main) before it can be merged to avoid similar problems in the future
- had to remove ignored paths from e2e workflow because of a dumb GH requirement that a status check needs to be specified to activate this rule:
![2021-11-14-1636910274_screenshot_3000x1920](https://user-images.githubusercontent.com/468572/141691670-8347b409-f579-4a59-886b-e85aa42cf7cc.jpg)

This means workflows will run after every change including changes to e.g README, but that is better than not being able to merge any changes to these paths or breaking main.