### PR TITLE
AZ-107: New network first parts of implementation

### DIFF
--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -24,6 +24,7 @@ mod import;
 mod justification;
 pub mod metrics;
 mod network;
+mod new_network;
 mod party;
 #[cfg(test)]
 pub mod testing;

--- a/finality-aleph/src/new_network/mod.rs
+++ b/finality-aleph/src/new_network/mod.rs
@@ -1,0 +1,109 @@
+// Everything here is dead code, but I don't want to create one enormous PR.
+#![allow(dead_code)]
+use codec::{Decode, Encode};
+use futures::stream::Stream;
+use sc_network::{Event, Multiaddr, NotificationSender, PeerId as ScPeerId};
+use sp_api::NumberFor;
+use sp_runtime::traits::Block;
+use std::{borrow::Cow, collections::HashSet, pin::Pin};
+
+mod service;
+mod substrate;
+
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+pub struct PeerId(pub(crate) ScPeerId);
+
+impl From<PeerId> for ScPeerId {
+    fn from(wrapper: PeerId) -> Self {
+        wrapper.0
+    }
+}
+
+impl From<ScPeerId> for PeerId {
+    fn from(id: ScPeerId) -> Self {
+        PeerId(id)
+    }
+}
+
+impl Encode for PeerId {
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        self.0.to_bytes().using_encoded(f)
+    }
+}
+
+impl Decode for PeerId {
+    fn decode<I: codec::Input>(value: &mut I) -> Result<Self, codec::Error> {
+        let bytes = Vec::<u8>::decode(value)?;
+        ScPeerId::from_bytes(&bytes)
+            .map_err(|_| "PeerId not encoded with to_bytes".into())
+            .map(|pid| pid.into())
+    }
+}
+
+/// Name of the network protocol used by Aleph Zero. This is how messages
+/// are subscribed to ensure that we are gossiping and communicating with our
+/// own network.
+pub(crate) const ALEPH_PROTOCOL_NAME: &str = "/cardinals/aleph/2";
+
+/// Name of the network protocol used by Aleph Zero validators. Similar to
+/// ALEPH_PROTOCOL_NAME, but only used by validators that authenticated to each other.
+pub(crate) const ALEPH_VALIDATOR_PROTOCOL_NAME: &str = "/cardinals/aleph_validator/1";
+
+enum Protocol {
+    Generic,
+    Validator,
+}
+
+impl Protocol {
+    fn name(&self) -> Cow<'static, str> {
+        use Protocol::*;
+        match self {
+            Generic => Cow::Borrowed(ALEPH_PROTOCOL_NAME),
+            Validator => Cow::Borrowed(ALEPH_VALIDATOR_PROTOCOL_NAME),
+        }
+    }
+}
+
+type NetworkEventStream = Pin<Box<dyn Stream<Item = Event> + Send>>;
+
+/// Abstraction over a network.
+pub trait Network: Clone + Send + Sync + 'static {
+    /// Returns a stream of events representing what happens on the network.
+    fn event_stream(&self) -> NetworkEventStream;
+
+    /// A sender for sending messages to the given peer, see the substrate network docs for how to
+    /// use it. Returns None if not connected to the peer.
+    fn message_sender(
+        &self,
+        peer_id: PeerId,
+        protocol: Cow<'static, str>,
+    ) -> Option<NotificationSender>;
+
+    /// Add peers to one of the reserved sets.
+    fn add_reserved(&self, addresses: HashSet<Multiaddr>, protocol: Cow<'static, str>);
+
+    /// Remove peers from one of the reserved sets.
+    fn remove_reserved(&self, peers: HashSet<PeerId>, protocol: Cow<'static, str>);
+
+    /// The external identity of this node, consisting of addresses and the PeerId.
+    fn identity(&self) -> (Vec<Multiaddr>, PeerId);
+}
+
+/// Abstraction for requesting justifications for finalized blocks and stale blocks.
+pub trait RequestBlocks<B: Block>: Clone + Send + Sync + 'static {
+    /// Request the justification for the given block
+    fn request_justification(&self, hash: &B::Hash, number: NumberFor<B>);
+
+    /// Request the given block -- this is supposed to be used only for "old forks".
+    fn request_stale_block(&self, hash: B::Hash, number: NumberFor<B>);
+}
+
+enum DataCommand {
+    Broadcast,
+    SendTo(PeerId, Protocol),
+}
+
+enum ConnectionCommand {
+    AddReserved(HashSet<Multiaddr>),
+    DelReserved(HashSet<PeerId>),
+}

--- a/finality-aleph/src/new_network/service.rs
+++ b/finality-aleph/src/new_network/service.rs
@@ -1,0 +1,187 @@
+use crate::new_network::{
+    ConnectionCommand, DataCommand, Network, PeerId, Protocol, ALEPH_PROTOCOL_NAME,
+    ALEPH_VALIDATOR_PROTOCOL_NAME,
+};
+use codec::Codec;
+use futures::{channel::mpsc, StreamExt};
+use log::{debug, error, trace, warn};
+use sc_network::{multiaddr, Event, NotificationSender};
+use std::{
+    borrow::Cow,
+    collections::{HashSet, VecDeque},
+    iter,
+};
+
+struct Service<N: Network, D: Clone + Codec> {
+    network: N,
+    messages_from_user: mpsc::UnboundedReceiver<(D, DataCommand)>,
+    messages_for_user: mpsc::UnboundedSender<D>,
+    commands_from_manager: mpsc::UnboundedReceiver<ConnectionCommand>,
+    connected_peers: HashSet<PeerId>,
+    to_send: VecDeque<(D, PeerId, Protocol)>,
+}
+
+pub struct IO<D: Clone + Codec> {
+    messages_from_user: mpsc::UnboundedReceiver<(D, DataCommand)>,
+    messages_for_user: mpsc::UnboundedSender<D>,
+    commands_from_manager: mpsc::UnboundedReceiver<ConnectionCommand>,
+}
+
+impl<N: Network, D: Clone + Codec> Service<N, D> {
+    pub fn new(network: N, io: IO<D>) -> Service<N, D> {
+        let IO {
+            messages_from_user,
+            messages_for_user,
+            commands_from_manager,
+        } = io;
+        Service {
+            network,
+            messages_from_user,
+            messages_for_user,
+            commands_from_manager,
+            connected_peers: HashSet::new(),
+            to_send: VecDeque::new(),
+        }
+    }
+
+    fn send_to_peer(&mut self, data: D, peer: PeerId, protocol: Protocol) {
+        self.to_send.push_back((data, peer, protocol));
+    }
+
+    fn broadcast(&mut self, data: D) {
+        for peer in self.connected_peers.clone() {
+            // We only broadcast authentication information in this sense, so we use the generic
+            // Protocol.
+            self.send_to_peer(data.clone(), peer, Protocol::Generic);
+        }
+    }
+
+    fn handle_network_event(&mut self, event: Event) -> Result<(), mpsc::TrySendError<D>> {
+        match event {
+            Event::SyncConnected { remote } => {
+                trace!(target: "aleph-network", "SyncConnected event for peer {:?}", remote);
+                let addr = iter::once(multiaddr::Protocol::P2p(remote.into())).collect();
+                self.network.add_reserved(
+                    iter::once(addr).collect(),
+                    Cow::Borrowed(ALEPH_PROTOCOL_NAME),
+                );
+            }
+            Event::SyncDisconnected { remote } => {
+                trace!(target: "aleph-network", "SyncDisconnected event for peer {:?}", remote);
+                self.network.remove_reserved(
+                    iter::once(remote.into()).collect(),
+                    Cow::Borrowed(ALEPH_PROTOCOL_NAME),
+                );
+            }
+            Event::NotificationStreamOpened {
+                remote, protocol, ..
+            } => {
+                if protocol == ALEPH_PROTOCOL_NAME {
+                    self.connected_peers.insert(remote.into());
+                }
+            }
+            Event::NotificationStreamClosed { remote, protocol } => {
+                if protocol == ALEPH_PROTOCOL_NAME {
+                    self.connected_peers.remove(&remote.into());
+                }
+            }
+            Event::NotificationsReceived {
+                remote: _,
+                messages,
+            } => {
+                for (protocol, data) in messages.into_iter() {
+                    if protocol == ALEPH_PROTOCOL_NAME || protocol == ALEPH_VALIDATOR_PROTOCOL_NAME
+                    {
+                        match D::decode(&mut &data[..]) {
+                            Ok(message) => self.messages_for_user.unbounded_send(message)?,
+                            Err(e) => {
+                                debug!(target: "aleph-network", "Error decoding message: {}", e)
+                            }
+                        }
+                    }
+                }
+            }
+            // Irrelevant for us, ignore.
+            Event::Dht(_) => {}
+        }
+        Ok(())
+    }
+
+    fn on_manager_command(&self, command: ConnectionCommand) {
+        use ConnectionCommand::*;
+        match command {
+            AddReserved(addresses) => self
+                .network
+                .add_reserved(addresses, Cow::Borrowed(ALEPH_VALIDATOR_PROTOCOL_NAME)),
+            DelReserved(peers) => self
+                .network
+                .remove_reserved(peers, Cow::Borrowed(ALEPH_VALIDATOR_PROTOCOL_NAME)),
+        }
+    }
+
+    fn on_user_command(&mut self, data: D, command: DataCommand) {
+        use DataCommand::*;
+        match command {
+            Broadcast => self.broadcast(data),
+            SendTo(peer, protocol) => self.send_to_peer(data, peer, protocol),
+        }
+    }
+
+    fn next_sender(&mut self) -> Option<NotificationSender> {
+        loop {
+            let (_, target, protocol) = self.to_send.front()?;
+            if let Some(sender) = self.network.message_sender(*target, protocol.name()) {
+                return Some(sender);
+            }
+            self.to_send.pop_front();
+        }
+    }
+
+    pub async fn run(mut self) {
+        let mut events_from_network = self.network.event_stream();
+        loop {
+            let maybe_sender = self.next_sender();
+            tokio::select! {
+                maybe_event = events_from_network.next() => match maybe_event {
+                    Some(event) => if let Err(e) = self.handle_network_event(event) {
+                        error!(target: "aleph-network", "Cannot forward messages to user: {:?}. Terminating.", e);
+                        return;
+                    },
+                    None => {
+                        error!(target: "aleph-network", "Network event stream ended, terminating.");
+                        return;
+                    }
+                },
+                maybe_command = self.commands_from_manager.next() => match maybe_command {
+                    Some(command) => self.on_manager_command(command),
+                    None => {
+                        error!(target: "aleph-network", "Manager command stream ended, terminating.");
+                        return;
+                    }
+                },
+                maybe_message = self.messages_from_user.next() => match maybe_message {
+                    Some((data, command)) => self.on_user_command(data, command),
+                    None => {
+                        error!(target: "aleph-network", "User message stream ended, terminating.");
+                        return;
+                    }
+                },
+                Some(maybe_ready) = async {
+                    match &maybe_sender {
+                        Some(sender) => Some(sender.ready().await),
+                        None => None,
+                    }
+                } => {
+                    match self.to_send.pop_front() {
+                        Some((data, peer, _)) => {
+                            if maybe_ready.ok().map(|ready| ready.send(data.encode()).ok()).flatten().is_none() {
+                                debug!(target: "aleph-network", "Failed sending data to peer {:?}.", peer);
+                            }
+                        },
+                        None => warn!(target: "aleph-network", "Attempted to send data despite empty queue."),
+                    }
+                },
+            }
+        }
+    }
+}

--- a/finality-aleph/src/new_network/service.rs
+++ b/finality-aleph/src/new_network/service.rs
@@ -144,25 +144,25 @@ impl<N: Network, D: Clone + Codec> Service<N, D> {
             tokio::select! {
                 maybe_event = events_from_network.next() => match maybe_event {
                     Some(event) => if let Err(e) = self.handle_network_event(event) {
-                        error!(target: "aleph-network", "Cannot forward messages to user: {:?}. Terminating.", e);
+                        error!(target: "aleph-network", "Cannot forward messages to user: {:?}", e);
                         return;
                     },
                     None => {
-                        error!(target: "aleph-network", "Network event stream ended, terminating.");
+                        error!(target: "aleph-network", "Network event stream ended.");
                         return;
                     }
                 },
                 maybe_command = self.commands_from_manager.next() => match maybe_command {
                     Some(command) => self.on_manager_command(command),
                     None => {
-                        error!(target: "aleph-network", "Manager command stream ended, terminating.");
+                        error!(target: "aleph-network", "Manager command stream ended.");
                         return;
                     }
                 },
                 maybe_message = self.messages_from_user.next() => match maybe_message {
                     Some((data, command)) => self.on_user_command(data, command),
                     None => {
-                        error!(target: "aleph-network", "User message stream ended, terminating.");
+                        error!(target: "aleph-network", "User message stream ended.");
                         return;
                     }
                 },
@@ -175,7 +175,7 @@ impl<N: Network, D: Clone + Codec> Service<N, D> {
                     match self.to_send.pop_front() {
                         Some((data, peer, _)) => {
                             if maybe_ready.ok().map(|ready| ready.send(data.encode()).ok()).flatten().is_none() {
-                                debug!(target: "aleph-network", "Failed sending data to peer {:?}.", peer);
+                                debug!(target: "aleph-network", "Failed sending data to peer {:?}", peer);
                             }
                         },
                         None => warn!(target: "aleph-network", "Attempted to send data despite empty queue."),

--- a/finality-aleph/src/new_network/substrate.rs
+++ b/finality-aleph/src/new_network/substrate.rs
@@ -32,7 +32,7 @@ impl<B: Block, H: ExHashT> Network for Arc<NetworkService<B, H>> {
         protocol: Cow<'static, str>,
     ) -> Option<NotificationSender> {
         self.notification_sender(peer_id.into(), protocol)
-            .map_err(|_| debug!(target: "aleph-network", "attempted send to peer we are not connected to"))
+            .map_err(|_| debug!(target: "aleph-network", "Attempted send to peer we are not connected to."))
             .ok()
     }
 

--- a/finality-aleph/src/new_network/substrate.rs
+++ b/finality-aleph/src/new_network/substrate.rs
@@ -1,0 +1,60 @@
+use crate::new_network::{Network, NetworkEventStream, PeerId, RequestBlocks};
+use log::{debug, error};
+use sc_network::{
+    multiaddr, ExHashT, Multiaddr, NetworkService, NetworkStateInfo, NotificationSender,
+};
+use sp_api::NumberFor;
+use sp_runtime::traits::Block;
+use std::{borrow::Cow, collections::HashSet, sync::Arc};
+
+impl<B: Block, H: ExHashT> RequestBlocks<B> for Arc<NetworkService<B, H>> {
+    fn request_justification(&self, hash: &B::Hash, number: NumberFor<B>) {
+        NetworkService::request_justification(self, hash, number)
+    }
+
+    fn request_stale_block(&self, hash: B::Hash, number: NumberFor<B>) {
+        // The below comment is adapted from substrate:
+        // Notifies the sync service to try and sync the given block from the given peers. If the given vector
+        // of peers is empty (as in our case) then the underlying implementation should make a best effort to fetch
+        // the block from any peers it is connected to.
+        NetworkService::set_sync_fork_request(self, Vec::new(), hash, number)
+    }
+}
+
+impl<B: Block, H: ExHashT> Network for Arc<NetworkService<B, H>> {
+    fn event_stream(&self) -> NetworkEventStream {
+        Box::pin(self.as_ref().event_stream("aleph-network"))
+    }
+
+    fn message_sender(
+        &self,
+        peer_id: PeerId,
+        protocol: Cow<'static, str>,
+    ) -> Option<NotificationSender> {
+        self.notification_sender(peer_id.into(), protocol)
+            .map_err(|_| debug!(target: "aleph-network", "attempted send to peer we are not connected to"))
+            .ok()
+    }
+
+    fn add_reserved(&self, addresses: HashSet<Multiaddr>, protocol: Cow<'static, str>) {
+        let result = self.add_peers_to_reserved_set(protocol, addresses);
+        if let Err(e) = result {
+            error!(target: "aleph-network", "add_reserved failed: {}", e);
+        }
+    }
+
+    fn remove_reserved(&self, peers: HashSet<PeerId>, protocol: Cow<'static, str>) {
+        let addresses = peers
+            .into_iter()
+            .map(|peer_id| Multiaddr::empty().with(multiaddr::Protocol::P2p(peer_id.0.into())))
+            .collect();
+        let result = self.remove_peers_from_reserved_set(protocol, addresses);
+        if let Err(e) = result {
+            error!(target: "aleph-network", "remove_reserved failed: {}", e);
+        }
+    }
+
+    fn identity(&self) -> (Vec<Multiaddr>, PeerId) {
+        (self.external_addresses(), (*self.local_peer_id()).into())
+    }
+}


### PR DESCRIPTION
This only rewrites some interfaces and implements them for the Substrate
network objects. The plan is to add more changes PR by PR, and the last
one will move new_network to network, and network to old_network. Both
will be initially supported in parallel, we will remove old_network
before the testnet update following the one when this goes live.

This is currently dead code, sorry. :/

It's also untested, since testing it would require mocking `Network`, and that would require creating much more abstraction (especially the `message_sender` method, that by itself is 3 layers). The next PR in this series will have lotsa tests tho, I promise!