### PR TITLE
updated grafana for benchmarks

### DIFF
--- a/benchmark/Dockerfile_prometheus
+++ b/benchmark/Dockerfile_prometheus
@@ -1,0 +1,12 @@
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM prom/prometheus:v2.30.3
+
+USER root
+RUN mkdir /prometheus.data && chown -R nobody:nobody /prometheus.data
+USER nobody
+WORKDIR /prometheus.data
+CMD [ "--config.file=/etc/prometheus/prometheus.yml", \
+      "--storage.tsdb.path=/prometheus.data", \
+      "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+      "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/benchmark/Dockerfile_prometheus
+++ b/benchmark/Dockerfile_prometheus
@@ -1,3 +1,6 @@
+# The sole purpose of this Dockerfile is to override the default behaviour of the `prometheus` image, i.e. storing collected data in a docker's volume.
+# It simplifies the procedure of saving of collected data for later analysis.
+# Feel free to remove it (remember to modify the `docker-compose.yml` accordingly) if you find a better solution.
 ARG ARCH="amd64"
 ARG OS="linux"
 FROM prom/prometheus:v2.30.3
@@ -6,6 +9,7 @@ USER root
 RUN mkdir /prometheus.data && chown -R nobody:nobody /prometheus.data
 USER nobody
 WORKDIR /prometheus.data
+# This line override `CMD` defined by the `prometheus` docker image, so it stores its data internally relative to its container.
 CMD [ "--config.file=/etc/prometheus/prometheus.yml", \
       "--storage.tsdb.path=/prometheus.data", \
       "--web.console.libraries=/usr/share/prometheus/console_libraries", \

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,6 +23,36 @@ _Remark: Use `host.docker.internal` instead of `localhost`_.
 
 **Important: Run `aleph-node` with `--prometheus-external` flag.**
 
+You can run multiple instances of docker-compose images for prometheus and grafana in parallel. For this, you need to provide
+an alternative port for grafana and an alternative `prometheus.yml` configuration file for prometheus. 
+Example command line invocation:
+```
+PROMETHEUS_YAML=./prometheus_alternative.yml GRAFANA_PORT=3001 docker-compose -p alternative up
+```
+
+Collected data can be easily saved by the means of `docker`. You simply need to call
+`docker commit <container_id> <image_name>` (or `docker export ...`). Then you need to update the `docker-compose.yml` file,
+so it uses your saved instances. Example:
+```
+version: '3.2'
+
+services:
+  prometheus:
+    image: saved_prometheus_image_name
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    volumes:
+      - ${PROMETHEUS_YAML:-./prometheus.yml}:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: saved_grafana_image_name
+    ports:
+      - ${GRAFANA_PORT:-3000}:3000
+    volumes:
+      - ./provisioning:/etc/grafana/provisioning
+      - ./grafana.ini:/etc/grafana/grafana.ini
+```
+
 ## Troubleshooting
 
 In case there is no data displayed in Grafana, check the connection between Prometheus server and its targets at 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -31,21 +31,23 @@ PROMETHEUS_YAML=./prometheus_alternative.yml GRAFANA_PORT=3001 docker-compose -p
 ```
 
 Collected data can be easily saved by the means of `docker`. You simply need to call
-`docker commit <container_id> <image_name>` (or `docker export ...`). Then you need to update the `docker-compose.yml` file,
+`docker commit <container_id> <image_name>` (or `docker export ...`). In case where you are attempting
+to load some external data, you need first import an image containing backup of prometheus data, i.e. `docker load prometheus.tar prometheus:custom_data`.
+Then you need to update the `docker-compose.yml` file accordingly,
 so it uses your saved instances. Example:
 ```
 version: '3.2'
 
 services:
   prometheus:
-    image: saved_prometheus_image_name
+    image: prometheus:custom_data
     extra_hosts:
       - host.docker.internal:host-gateway
     volumes:
       - ${PROMETHEUS_YAML:-./prometheus.yml}:/etc/prometheus/prometheus.yml
 
   grafana:
-    image: saved_grafana_image_name
+    image: grafana/grafana:8.2.1
     ports:
       - ${GRAFANA_PORT:-3000}:3000
     volumes:

--- a/benchmark/docker-compose.yml
+++ b/benchmark/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   grafana:
     image: grafana/grafana:8.2.1
     ports:
-      - 3000
+      - ${GRAFANA_PORT:-3000}:3000
     volumes:
       - ./provisioning:/etc/grafana/provisioning
       - ./grafana.ini:/etc/grafana/grafana.ini

--- a/benchmark/docker-compose.yml
+++ b/benchmark/docker-compose.yml
@@ -1,19 +1,19 @@
-version: '3'
+version: '3.2'
 
 services:
   prometheus:
-    image: prom/prometheus:v2.30.3
+    build:
+      context: .
+      dockerfile: Dockerfile_prometheus
     extra_hosts:
       - host.docker.internal:host-gateway
-    ports:
-      - "9090:9090"
     volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - ${PROMETHEUS_YAML:-./prometheus.yml}:/etc/prometheus/prometheus.yml
 
   grafana:
     image: grafana/grafana:8.2.1
     ports:
-      - "3000:3000"
+      - 3000
     volumes:
       - ./provisioning:/etc/grafana/provisioning
       - ./grafana.ini:/etc/grafana/grafana.ini

--- a/benchmark/prometheus.yml
+++ b/benchmark/prometheus.yml
@@ -5,3 +5,8 @@ scrape_configs:
 
     static_configs:
       - targets: ["host.docker.internal:9615"]
+
+
+  - job_name: "node"
+    static_configs:
+      - targets: ["host.docker.internal:9100"]

--- a/benchmark/provisioning/dashboards/AlephZero_Metrics.json
+++ b/benchmark/provisioning/dashboards/AlephZero_Metrics.json
@@ -1238,7 +1238,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.0",
+      "pluginVersion": "8.2.1",
       "targets": [
         {
           "expr": "substrate_block_height{status=\"best\"}",
@@ -1292,7 +1292,7 @@
         "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "8.2.0",
+      "pluginVersion": "8.2.1",
       "targets": [
         {
           "expr": "substrate_block_height{status=\"finalized\"}",
@@ -1350,7 +1350,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.0",
+      "pluginVersion": "8.2.1",
       "targets": [
         {
           "exemplar": true,
@@ -1414,7 +1414,7 @@
         "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "8.2.0",
+      "pluginVersion": "8.2.1",
       "targets": [
         {
           "expr": "substrate_state_cache_bytes",
@@ -1428,6 +1428,135 @@
       "timeShift": null,
       "title": "State Cashe (bytes)",
       "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "hiddenSeries": false,
+      "id": 50,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "libraryPanel": {
+        "meta": {
+          "connectedDashboards": 0,
+          "created": "2021-11-18T12:12:57Z",
+          "createdBy": {
+            "avatarUrl": "",
+            "id": 0,
+            "name": ""
+          },
+          "folderName": "General",
+          "folderUid": "",
+          "updated": "2021-11-18T13:47:21Z",
+          "updatedBy": {
+            "avatarUrl": "",
+            "id": 0,
+            "name": ""
+          }
+        },
+        "name": "construction time x txs",
+        "uid": "B5qYSr57k",
+        "version": 4
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.2.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:983",
+          "alias": "number of transactions",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg(substrate_proposer_number_of_transactions)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "number of transactions",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.90, sum(rate(substrate_proposer_block_constructed_bucket[5m])) by (le))",
+          "interval": "",
+          "legendFormat": "construction time",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "construction time x txs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:955",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:956",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1469,7 +1598,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.2.0",
+      "pluginVersion": "8.2.1",
       "pointradius": 2,
       "points": true,
       "renderer": "flot",
@@ -1563,7 +1692,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.2.0",
+      "pluginVersion": "8.2.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",

--- a/benchmark/provisioning/dashboards/AlephZero_Metrics.json
+++ b/benchmark/provisioning/dashboards/AlephZero_Metrics.json
@@ -1455,28 +1455,6 @@
         "total": false,
         "values": false
       },
-      "libraryPanel": {
-        "meta": {
-          "connectedDashboards": 0,
-          "created": "2021-11-18T12:12:57Z",
-          "createdBy": {
-            "avatarUrl": "",
-            "id": 0,
-            "name": ""
-          },
-          "folderName": "General",
-          "folderUid": "",
-          "updated": "2021-11-18T13:47:21Z",
-          "updatedBy": {
-            "avatarUrl": "",
-            "id": 0,
-            "name": ""
-          }
-        },
-        "name": "construction time x txs",
-        "uid": "B5qYSr57k",
-        "version": 4
-      },
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",

--- a/benchmark/provisioning/datasources/datasource.yml
+++ b/benchmark/provisioning/datasources/datasource.yml
@@ -3,7 +3,6 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
-    access: direct
-    url: http://localhost:9090
+    url: http://prometheus:9090
     jsonData:
       httpMethod: POST


### PR DESCRIPTION
- new grafana metrics: block creation time vs #txs
- support for node_exporter for collecting node's performance metrics
- support for multiple instances of docker-compose with grafana