### PR TITLE
Pipeline for mainnet deployment on release added

### DIFF
--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -1,0 +1,96 @@
+name: Deploy to Mainnet
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  deploy-mainnet:
+    name: Deploy new aleph-node image to Mainnet EKS
+    runs-on: ubuntu-latest
+    environment: 'mainnet'
+    env:
+      AWS_REGION: us-east-1 # this region is used by all public ECR repos
+    steps:
+      - name: GIT | Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: GIT | Checkout                                  
+        uses: actions/checkout@v2
+        
+      - name: GIT | Get branch info & current commit sha.
+        id: vars
+        shell: bash
+        run: |
+          echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          
+      - name: Configure AWS credentials                          
+        uses: aws-actions/configure-aws-credentials@v1           
+        with:                                                    
+          aws-access-key-id: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Public Amazon ECR
+        id: login-public-ecr                        
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: us-east-1
+          
+      - name: GIT | Checkout aleph-apps repo
+        uses: actions/checkout@master
+        with:
+          repository: Cardinal-Cryptography/aleph-apps
+          token: ${{ secrets.CI_GH_TOKEN }}
+          path: "aleph-apps"
+
+      - name: Init kustomize
+        uses: imranismail/setup-kustomize@v1
+        with:
+          kustomize-version: "3.8.6"
+          
+      - name: Update aleph-node docker image and trigger ArgoCD deploy for Mainnet                                                                      
+        env:                                                                                                          
+          MAINNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
+          REGIONS_AWS: 'eu-central-1,eu-west-1,eu-west-2,us-east-1,us-east-2'
+        run: |
+          IFS="," read -a region_array <<< ${{ env.REGIONS_AWS }}
+          export aleph_path=$(pwd)
+          for i in "${region_array[@]}"; do
+            # Deploy new image version for archivist 
+            cd ${aleph_path}/aleph-apps/aleph-node-archivists/overlays/mainnet/${i}
+            kustomize edit set image "aleph-node-archivist-image-placeholder=${{ env.MAINNET_IMAGE }}"
+
+            # Deploy new image version for validator
+            cd ${aleph_path}/aleph-apps/aleph-node-validators/overlays/mainnet/${i}
+            kustomize edit set image "aleph-node-validator-image-placeholder=${{ env.MAINNET_IMAGE }}"
+          done
+
+      - name: GIT | Commit changes to aleph-apps repository.
+        uses: EndBug/add-and-commit@v5.1.0
+        with:
+          author_name: AlephZero Automation
+          author_email: alephzero@10clouds.com
+          message: "Updating Mainnet docker image tag for release: ${{ steps.vars.outputs.branch }}"
+          add: "*.yaml"
+          cwd: "aleph-apps"
+          branch: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}
+
+      - name: Send Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        continue-on-error: true
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: GithubActions
+          SLACK_TITLE: deploy-testnet job has finished
+          MSG_MINIMAL: actions url

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -43,6 +43,16 @@ jobs:
           password: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
         env:
           AWS_REGION: us-east-1
+
+      - name: Verify aleph-node image existance
+        env:
+          IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
+        run: |
+          export image_not_exist=$(docker manifest inspect ${{ env.IMAGE }} &> /dev/null ; echo $?)
+          if [ $image_not_exist -eq 1 ]; then
+            echo "::error title=Wrong docker image tag::Docker image ${{ env.IMAGE }} doesn't exist"
+            exit 1
+          fi
           
       - name: GIT | Checkout aleph-apps repo
         uses: actions/checkout@master
@@ -92,5 +102,5 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: GithubActions
-          SLACK_TITLE: deploy-testnet job has finished
+          SLACK_TITLE: deploy-mainnet job has finished
           MSG_MINIMAL: actions url

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -57,6 +57,7 @@ jobs:
       - name: GIT | Checkout aleph-apps repo
         uses: actions/checkout@master
         with:
+          ref: mainnet
           repository: Cardinal-Cryptography/aleph-apps
           token: ${{ secrets.CI_GH_TOKEN }}
           path: "aleph-apps"
@@ -91,7 +92,7 @@ jobs:
           message: "Updating Mainnet docker image tag for release: ${{ steps.vars.outputs.branch }}"
           add: "*.yaml"
           cwd: "aleph-apps"
-          branch: main
+          branch: mainnet
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}
 


### PR DESCRIPTION
The deployment job is placed within github mainnet environment, that requires pipeline to be accept before launch. It's an additional fuse in order to make sure that the deployment is indeed what the user wants to do.