### PR TITLE
Simplify BlockFinalizer trait

### DIFF
--- a/finality-aleph/src/finalization.rs
+++ b/finality-aleph/src/finalization.rs
@@ -29,7 +29,7 @@ where
     C: HeaderBackend<B> + LockImportRun<B, BE> + Finalizer<B, BE>,
 {
     client: Arc<C>,
-    _phantom: (PhantomData<B>, PhantomData<BE>),
+    phantom: PhantomData<(B, BE)>,
 }
 
 impl<B, BE, C> AlephFinalizer<B, BE, C>
@@ -41,7 +41,7 @@ where
     pub(crate) fn new(client: Arc<C>) -> Self {
         AlephFinalizer {
             client,
-            _phantom: (PhantomData, PhantomData),
+            phantom: PhantomData,
         }
     }
 }

--- a/finality-aleph/src/finalization.rs
+++ b/finality-aleph/src/finalization.rs
@@ -1,4 +1,5 @@
 use core::result::Result;
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use log::{debug, error, warn};
@@ -12,24 +13,40 @@ use sp_runtime::{
 
 use crate::data_io::AlephDataFor;
 
-pub(crate) trait BlockFinalizer<BE, B, C>
-where
-    B: Block,
-    BE: Backend<B>,
-    C: HeaderBackend<B> + LockImportRun<B, BE> + Finalizer<B, BE>,
-{
+pub(crate) trait BlockFinalizer<B: Block> {
     fn finalize_block(
         &self,
-        client: Arc<C>,
         hash: B::Hash,
         block_number: NumberFor<B>,
         justification: Option<Justification>,
     ) -> Result<(), Error>;
 }
 
-pub(crate) struct AlephFinalizer;
+pub(crate) struct AlephFinalizer<B, BE, C>
+where
+    B: Block,
+    BE: Backend<B>,
+    C: HeaderBackend<B> + LockImportRun<B, BE> + Finalizer<B, BE>,
+{
+    client: Arc<C>,
+    _phantom: (PhantomData<B>, PhantomData<BE>),
+}
 
-impl<BE, B, C> BlockFinalizer<BE, B, C> for AlephFinalizer
+impl<B, BE, C> AlephFinalizer<B, BE, C>
+where
+    B: Block,
+    BE: Backend<B>,
+    C: HeaderBackend<B> + LockImportRun<B, BE> + Finalizer<B, BE>,
+{
+    pub(crate) fn new(client: Arc<C>) -> Self {
+        AlephFinalizer {
+            client,
+            _phantom: (PhantomData, PhantomData),
+        }
+    }
+}
+
+impl<B, BE, C> BlockFinalizer<B> for AlephFinalizer<B, BE, C>
 where
     B: Block,
     BE: Backend<B>,
@@ -37,12 +54,11 @@ where
 {
     fn finalize_block(
         &self,
-        client: Arc<C>,
         hash: B::Hash,
         block_number: NumberFor<B>,
         justification: Option<Justification>,
     ) -> Result<(), Error> {
-        let status = client.info();
+        let status = self.client.info();
         if status.finalized_number >= block_number {
             warn!(target: "afa", "trying to finalize a block with hash {} and number {}
                that is not greater than already finalized {}", hash, block_number, status.finalized_number);
@@ -50,11 +66,12 @@ where
 
         debug!(target: "afa", "Finalizing block with hash {:?} and number {:?}. Previous best: #{:?}.", hash, block_number, status.finalized_number);
 
-        let update_res = client.lock_import_and_run(|import_op| {
+        let update_res = self.client.lock_import_and_run(|import_op| {
             // NOTE: all other finalization logic should come here, inside the lock
-            client.apply_finality(import_op, BlockId::Hash(hash), justification, true)
+            self.client
+                .apply_finality(import_op, BlockId::Hash(hash), justification, true)
         });
-        let status = client.info();
+        let status = self.client.info();
         debug!(target: "afa", "Attempted to finalize block with hash {:?}. Current best: #{:?}.", hash, status.finalized_number);
         update_res
     }


### PR DESCRIPTION
As suggested by @kostekIV, the previous `BlockSimplifier` trait was probably too rigorous and tendentious. This PR simplifies it, simultaneously making mocking easier.