### PR TITLE
Fix/az 392

### DIFF
--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -312,10 +312,6 @@ fn genesis(
             authorities: vec![],
             session_period: session_period.0,
             millisecs_per_block: millisecs_per_block.0,
-            validators: authorities
-                .iter()
-                .map(|auth| auth.account_id.clone())
-                .collect(),
         },
         session: SessionConfig {
             keys: authorities

--- a/pallet/src/lib.rs
+++ b/pallet/src/lib.rs
@@ -127,7 +127,6 @@ pub mod pallet {
         pub authorities: Vec<T::AuthorityId>,
         pub session_period: u32,
         pub millisecs_per_block: u64,
-        pub validators: Vec<T::AccountId>,
     }
 
     #[cfg(feature = "std")]
@@ -137,7 +136,6 @@ pub mod pallet {
                 authorities: Vec::new(),
                 session_period: DEFAULT_SESSION_PERIOD,
                 millisecs_per_block: DEFAULT_MILLISECS_PER_BLOCK,
-                validators: Vec::new(),
             }
         }
     }

--- a/pallet/src/migrations/v0_to_v1.rs
+++ b/pallet/src/migrations/v0_to_v1.rs
@@ -32,7 +32,7 @@ pub fn migrate<T: Config, P: GetStorageVersion + PalletInfoAccess>() -> Weight {
             }
         };
 
-        match crate::Validators::<T>::translate(sp_std::convert::identity) {
+        match crate::Validators::<T>::translate(Option::unwrap) {
             Ok(_) => {
                 writes += 1;
                 log::info!(target: "pallet_aleph", "Succesfully migrated storage for Validators");

--- a/pallet/src/migrations/v0_to_v1.rs
+++ b/pallet/src/migrations/v0_to_v1.rs
@@ -22,7 +22,14 @@ pub fn migrate<T: Config, P: GetStorageVersion + PalletInfoAccess>() -> Weight {
         log::info!(target: "pallet_aleph", "Running migration from STORAGE_VERSION 0 to 1");
 
         let mut writes = 0;
-        match SessionForValidatorsChange::translate(sp_std::convert::identity) {
+        match SessionForValidatorsChange::translate(|old: Option<Option<u32>>| {
+            log::info!(target: "pallet_aleph", "Current storage value for SessionForValidatorsChange {:?}", old);
+            match old {
+                Some(None) => None,
+                Some(value) => Some(value),
+                None => None,
+            }
+        }) {
             Ok(_) => {
                 writes += 1;
                 log::info!(target: "pallet_aleph", "Succesfully migrated storage for SessionForValidatorsChange");

--- a/pallet/src/migrations/v0_to_v1.rs
+++ b/pallet/src/migrations/v0_to_v1.rs
@@ -22,12 +22,12 @@ pub fn migrate<T: Config, P: GetStorageVersion + PalletInfoAccess>() -> Weight {
         log::info!(target: "pallet_aleph", "Running migration from STORAGE_VERSION 0 to 1");
 
         let mut writes = 0;
-        match SessionForValidatorsChange::translate(|old: Option<Option<u32>>| {
+
+        match SessionForValidatorsChange::translate(|old: Option<_>| {
             log::info!(target: "pallet_aleph", "Current storage value for SessionForValidatorsChange {:?}", old);
             match old {
-                Some(None) | Some(Some(0u32)) => None,
-                Some(value) => Some(value),
-                None => None,
+                Some(None) | Some(Some(0u32)) | None => None,
+                _ => old,
             }
         }) {
             Ok(_) => {

--- a/pallet/src/migrations/v0_to_v1.rs
+++ b/pallet/src/migrations/v0_to_v1.rs
@@ -4,6 +4,7 @@ use frame_support::{
     traits::{Get, GetStorageVersion, PalletInfoAccess, StorageVersion},
     weights::Weight,
 };
+use sp_std::vec::Vec;
 
 pub fn migrate<T: Config, P: GetStorageVersion + PalletInfoAccess>() -> Weight {
     let on_chain_storage_version = <P as GetStorageVersion>::on_chain_storage_version();
@@ -32,7 +33,15 @@ pub fn migrate<T: Config, P: GetStorageVersion + PalletInfoAccess>() -> Weight {
             }
         };
 
-        match crate::Validators::<T>::translate(Option::unwrap) {
+        match crate::Validators::<T>::translate(
+            |old: Option<Option<Vec<T::AccountId>>>| -> Option<Vec<T::AccountId>> {
+                log::info!(target: "pallet_aleph", "Current storage value for Validators {:?}", old);
+                match old {
+                    Some(Some(x)) => Some(x),
+                    _ => None,
+                }
+            },
+        ) {
             Ok(_) => {
                 writes += 1;
                 log::info!(target: "pallet_aleph", "Succesfully migrated storage for Validators");

--- a/pallet/src/migrations/v0_to_v1.rs
+++ b/pallet/src/migrations/v0_to_v1.rs
@@ -25,8 +25,7 @@ pub fn migrate<T: Config, P: GetStorageVersion + PalletInfoAccess>() -> Weight {
         match SessionForValidatorsChange::translate(|old: Option<Option<u32>>| {
             log::info!(target: "pallet_aleph", "Current storage value for SessionForValidatorsChange {:?}", old);
             match old {
-                Some(None) => None,
-                Some(Some(0u32)) => None,
+                Some(None) | Some(Some(0u32)) => None,
                 Some(value) => Some(value),
                 None => None,
             }

--- a/pallet/src/migrations/v0_to_v1.rs
+++ b/pallet/src/migrations/v0_to_v1.rs
@@ -26,6 +26,7 @@ pub fn migrate<T: Config, P: GetStorageVersion + PalletInfoAccess>() -> Weight {
             log::info!(target: "pallet_aleph", "Current storage value for SessionForValidatorsChange {:?}", old);
             match old {
                 Some(None) => None,
+                Some(Some(0u32)) => None,
                 Some(value) => Some(value),
                 None => None,
             }

--- a/pallet/src/tests.rs
+++ b/pallet/src/tests.rs
@@ -23,7 +23,7 @@ fn migration_from_v0_to_v1_works() {
         assert_eq!(
             before,
             Some(Some(1)),
-            "Storage before is a double wrapped type"
+            "Storage before migration is a double Option wrapped type"
         );
 
         frame_support::migration::put_storage_value(
@@ -51,25 +51,17 @@ fn migration_from_v0_to_v1_works() {
             "Storage version after applying migration should be incremented"
         );
 
-        // let v = frame_support::migration::get_storage_value::<u32>(
-        //     b"Aleph",
-        //     b"SessionForValidatorsChange",
-        //     &[],
-        // );
-
-        // println!("@@@ {:?}", v);
-
         assert_eq!(
             Aleph::session_for_validators_change(),
             Some(1u32),
             "Migration should preserve ongoing session change with respect to the session number"
         );
 
-        // assert_eq!(
-        //     Aleph::validators(),
-        //     Some(vec![AccountId::default()]),
-        //     "Migration should preserve ongoing session change with respect to the validators set"
-        // );
+        assert_eq!(
+            Aleph::validators(),
+            Some(vec![AccountId::default()]),
+            "Migration should preserve ongoing session change with respect to the validators set"
+        );
 
         let noop_weight = migrations::v0_to_v1::migrate::<Test, Aleph>();
         assert_eq!(

--- a/pallet/src/tests.rs
+++ b/pallet/src/tests.rs
@@ -11,7 +11,7 @@ fn migration_from_v0_to_v1_works() {
             b"Aleph",
             b"SessionForValidatorsChange",
             &[],
-            Some(1u32),
+            Some(7u32),
         );
 
         let before = frame_support::migration::get_storage_value::<Option<u32>>(
@@ -22,8 +22,8 @@ fn migration_from_v0_to_v1_works() {
 
         assert_eq!(
             before,
-            Some(Some(1)),
-            "Storage before migration is a double Option wrapped type"
+            Some(Some(7)),
+            "Storage before migration has type Option<u32>"
         );
 
         frame_support::migration::put_storage_value(
@@ -53,7 +53,7 @@ fn migration_from_v0_to_v1_works() {
 
         assert_eq!(
             Aleph::session_for_validators_change(),
-            Some(1u32),
+            Some(7u32),
             "Migration should preserve ongoing session change with respect to the session number"
         );
 

--- a/pallet/src/tests.rs
+++ b/pallet/src/tests.rs
@@ -11,14 +11,26 @@ fn migration_from_v0_to_v1_works() {
             b"Aleph",
             b"SessionForValidatorsChange",
             &[],
-            1u32,
+            Some(1u32),
+        );
+
+        let before = frame_support::migration::get_storage_value::<Option<u32>>(
+            b"Aleph",
+            b"SessionForValidatorsChange",
+            &[],
+        );
+
+        assert_eq!(
+            before,
+            Some(Some(1)),
+            "Storage before is a double wrapped type"
         );
 
         frame_support::migration::put_storage_value(
             b"Aleph",
             b"Validators",
             &[],
-            vec![AccountId::default()],
+            Some(vec![AccountId::default()]),
         );
 
         let v0 = <pallet::Pallet<Test> as GetStorageVersion>::on_chain_storage_version();
@@ -39,17 +51,25 @@ fn migration_from_v0_to_v1_works() {
             "Storage version after applying migration should be incremented"
         );
 
+        // let v = frame_support::migration::get_storage_value::<u32>(
+        //     b"Aleph",
+        //     b"SessionForValidatorsChange",
+        //     &[],
+        // );
+
+        // println!("@@@ {:?}", v);
+
         assert_eq!(
             Aleph::session_for_validators_change(),
             Some(1u32),
             "Migration should preserve ongoing session change with respect to the session number"
         );
 
-        assert_eq!(
-            Aleph::validators(),
-            Some(vec![AccountId::default()]),
-            "Migration should preserve ongoing session change with respect to the validators set"
-        );
+        // assert_eq!(
+        //     Aleph::validators(),
+        //     Some(vec![AccountId::default()]),
+        //     "Migration should preserve ongoing session change with respect to the validators set"
+        // );
 
         let noop_weight = migrations::v0_to_v1::migrate::<Test, Aleph>();
         assert_eq!(


### PR DESCRIPTION
closes [#AZ-392](https://cardinal-cryptography.atlassian.net/jira/software/c/projects/AZ/boards/4?modal=detail&selectedIssue=AZ-392)

This bug is caused by the fact that since we previously stored double option wrapped type (`Option<Option<u32>>`), the default query response when getting the type is `Some(None)`. New runtime tries to decode it as Option<u32> and an error is logged (error is hidden behind runtime=debug logs). This bug is not serious, since the default behavior is to return a None when it fails to decode (see https://github.com/paritytech/substrate/blob/1ec08e88ccfb436da613473c96d01ca6679d5ff8/frame/support/src/storage/unhashed.rs#L27).

We can fix this since this migration is not applied yet, by explicitly matching on the problematic pattern. 
One more pattern that is addressed is the fact that we had stored 0 as session for change at genesis:
```
<SessionForValidatorsChange<T>>::put(Some(0));
```
I doubt any one of our environments runs with a default chainspec, but this is remapped to `None`, just in case. 