### PR TITLE
AZ-383 towards stable 1k txps

### DIFF
--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -23,6 +23,10 @@ pub struct Config {
     /// secret seed of the account keypair passed on stdin
     #[clap(long, conflicts_with_all = &["phrase"])]
     pub seed: Option<String>,
+
+    /// should we initialize all of the derived flooding accounts or just attempt to download their nonces
+    #[clap(long)]
+    pub initialize_accounts: bool,
 }
 
 pub fn read_phrase(phrase: String) -> String {

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -30,7 +30,7 @@ pub struct Config {
 
     /// beginning of the integer range used to derive accounts
     #[clap(long, default_value = "0")]
-    pub accounts_range_start: u64,
+    pub first_account_in_range: u64,
 }
 
 pub fn read_phrase(phrase: String) -> String {

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -24,9 +24,9 @@ pub struct Config {
     #[clap(long, conflicts_with_all = &["phrase"])]
     pub seed: Option<String>,
 
-    /// should we initialize all of the derived flooding accounts or just attempt to download their nonces
+    /// allows to skip accounts initialization process and just attempt to download their nonces
     #[clap(long)]
-    pub initialize_accounts: bool,
+    pub skip_initialization: bool,
 
     /// beginning of the integer range used to derive accounts
     #[clap(long, default_value = "0")]

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -27,6 +27,10 @@ pub struct Config {
     /// should we initialize all of the derived flooding accounts or just attempt to download their nonces
     #[clap(long)]
     pub initialize_accounts: bool,
+
+    /// beginning of the integer range used to derive accounts
+    #[clap(long, default_value = "0")]
+    pub accounts_range_start: u64,
 }
 
 pub fn read_phrase(phrase: String) -> String {

--- a/flooder/src/main.rs
+++ b/flooder/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), anyhow::Error> {
     let connection = pool.get(0).unwrap();
 
     let total_users = config.transactions;
-    let first_account_in_range = config.accounts_range_start;
+    let first_account_in_range = config.first_account_in_range;
     let transactions_per_batch = config.throughput / rayon::current_num_threads() as u64;
     let transfer_amount = 1u128;
 
@@ -192,7 +192,7 @@ fn sign_transactions(
 fn derive_user_accounts(
     connection: Api<sr25519::Pair, WsRpcClient>,
     account: sr25519::Pair,
-    first_account: u64,
+    first_account_in_range: u64,
     total_accounts: u64,
     transfer_amount: u128,
     initialize_accounts: bool,
@@ -209,7 +209,7 @@ fn derive_user_accounts(
     // start with a heuristic tx fee
     let mut total_amount = existential_deposit + (transfer_amount + 375_000_000);
 
-    for index in first_account..first_account + total_accounts {
+    for index in first_account_in_range..first_account_in_range + total_accounts {
         let path = Some(DeriveJunction::soft(index as u64));
         let (derived, _seed) = account.clone().derive(path.into_iter(), None).unwrap();
 

--- a/flooder/src/main.rs
+++ b/flooder/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), anyhow::Error> {
             None => panic!("Needs --phrase or --seed"),
         },
     };
-    let initialize_accounts = config.initialize_accounts;
+    let initialize_accounts = !config.skip_initialization;
 
     let pool = create_connection_pool(config.nodes);
     let connection = pool.get(0).unwrap();
@@ -195,7 +195,7 @@ fn derive_user_accounts(
     first_account: u64,
     total_accounts: u64,
     transfer_amount: u128,
-    initialize_account: bool,
+    initialize_accounts: bool,
 ) -> (Vec<sr25519::Pair>, Vec<u32>) {
     let total_accounts_cap = total_accounts
         .try_into()
@@ -214,7 +214,7 @@ fn derive_user_accounts(
         let (derived, _seed) = account.clone().derive(path.into_iter(), None).unwrap();
 
         let mut hash = None;
-        if initialize_account {
+        if initialize_accounts {
             let tx = sign_tx(
                 connection.clone(),
                 account.clone(),


### PR DESCRIPTION
- allows to skip accounts initialization
- allows to provide first index for the set of `integer` derived accounts, i.e. accounts derived from range x.. instead of the default 0.. range