### PR TITLE
AZ-383 fast accounts initialization for flooder

### DIFF
--- a/flooder/rust-toolchain.toml
+++ b/flooder/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2021-12-02"
+profile = "minimal"

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -23,6 +23,10 @@ pub struct Config {
     /// secret seed of the account keypair passed on stdin
     #[clap(long, conflicts_with_all = &["phrase"])]
     pub seed: Option<String>,
+
+    /// should we initialize all of the derived flooding accounts or just attempt to download their nonces
+    #[clap(long)]
+    pub initialize_accounts: bool,
 }
 
 pub fn read_phrase(phrase: String) -> String {

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -30,7 +30,7 @@ pub struct Config {
 
     /// beginning of the integer range used to derive accounts
     #[clap(long, default_value = "0")]
-    pub accounts_range_start: u64,
+    pub first_account_in_range: u64,
 }
 
 pub fn read_phrase(phrase: String) -> String {

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -31,6 +31,10 @@ pub struct Config {
     /// beginning of the integer range used to derive accounts
     #[clap(long, default_value = "0")]
     pub first_account_in_range: u64,
+
+    /// number of threads spawn during the flooding process
+    #[clap(long, default_value = "3")]
+    pub threads: u64,
 }
 
 pub fn read_phrase(phrase: String) -> String {

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -5,7 +5,7 @@ use std::{fs, path::PathBuf};
 #[clap(version = "1.0")]
 pub struct Config {
     /// URL address(es) of the nodes to send transactions to
-    #[clap(long, default_value = "127.0.0.1:9945")]
+    #[clap(long, default_value = "127.0.0.1:9944")]
     pub nodes: Vec<String>,
 
     /// how many transactions to send

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -31,6 +31,10 @@ pub struct Config {
     /// number of threads spawn during the flooding process
     #[clap(long)]
     pub threads: Option<u64>,
+
+    /// allows to download nonces instead of using zeros for each account
+    #[clap(long)]
+    pub download_nonces: bool,
 }
 
 pub fn read_phrase(phrase: String) -> String {

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -35,6 +35,10 @@ pub struct Config {
     /// allows to download nonces instead of using zeros for each account
     #[clap(long)]
     pub download_nonces: bool,
+
+    /// changes the awaited status of every transaction from Ready to SubmitOnly
+    #[clap(long)]
+    pub submit_only: bool,
 }
 
 pub fn read_phrase(phrase: String) -> String {

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -12,10 +12,6 @@ pub struct Config {
     #[clap(long, default_value = "10000")]
     pub transactions: u64,
 
-    /// what throughput to use (transactions/s)
-    #[clap(long, default_value = "1000")]
-    pub throughput: u64,
-
     /// secret phrase : a path to a file or passed on stdin
     #[clap(long)]
     pub phrase: Option<String>,

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -33,8 +33,8 @@ pub struct Config {
     pub first_account_in_range: u64,
 
     /// number of threads spawn during the flooding process
-    #[clap(long, default_value = "3")]
-    pub threads: u64,
+    #[clap(long)]
+    pub threads: Option<u64>,
 }
 
 pub fn read_phrase(phrase: String) -> String {

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -24,9 +24,9 @@ pub struct Config {
     #[clap(long, conflicts_with_all = &["phrase"])]
     pub seed: Option<String>,
 
-    /// should we initialize all of the derived flooding accounts or just attempt to download their nonces
+    /// allows to skip accounts initialization process and just attempt to download their nonces
     #[clap(long)]
-    pub initialize_accounts: bool,
+    pub skip_initialization: bool,
 
     /// beginning of the integer range used to derive accounts
     #[clap(long, default_value = "0")]

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -27,6 +27,10 @@ pub struct Config {
     /// should we initialize all of the derived flooding accounts or just attempt to download their nonces
     #[clap(long)]
     pub initialize_accounts: bool,
+
+    /// beginning of the integer range used to derive accounts
+    #[clap(long, default_value = "0")]
+    pub accounts_range_start: u64,
 }
 
 pub fn read_phrase(phrase: String) -> String {

--- a/flooder/src/main.rs
+++ b/flooder/src/main.rs
@@ -98,13 +98,13 @@ fn main() -> Result<(), anyhow::Error> {
 
     debug!("all accounts have received funds");
 
-    let reciever = accounts
+    let receiver = accounts
         .first()
         .expect("we should be using some accounts for this test, but the list is empty")
         .clone();
     let txs = sign_transactions(
         &connection,
-        reciever,
+        receiver,
         (accounts, nonces),
         config.transactions,
         transfer_amount,

--- a/flooder/src/main.rs
+++ b/flooder/src/main.rs
@@ -89,14 +89,15 @@ fn main() -> Result<(), anyhow::Error> {
             &accounts,
             total_amount,
         );
+        debug!("all accounts have received funds");
     }
-
-    let nonces = accounts
-        .iter()
-        .map(|account| get_nonce(&connection, &AccountId::from(account.public())))
-        .collect();
-
-    debug!("all accounts have received funds");
+    let nonces: Vec<_> = match config.download_nonces {
+        false => repeat(0).take(accounts.len()).collect(),
+        true => accounts
+            .par_iter()
+            .map(|account| get_nonce(&connection, &AccountId::from(account.public())))
+            .collect(),
+    };
 
     let receiver = accounts
         .first()

--- a/flooder/src/main.rs
+++ b/flooder/src/main.rs
@@ -149,6 +149,7 @@ fn flood(
             send_tx(
                 pool.get(index % pool.len()).unwrap(),
                 tx,
+                XtStatus::SubmitOnly,
                 Arc::clone(histogram),
             )
         })
@@ -316,6 +317,7 @@ fn derive_user_account(seed: u64) -> sr25519::Pair {
 fn send_tx<Call>(
     connection: &Api<sr25519::Pair, WsRpcClient>,
     tx: &UncheckedExtrinsicV4<Call>,
+    status: XtStatus,
     histogram: Arc<Mutex<HdrHistogram<u64>>>,
 ) where
     Call: Encode,
@@ -323,7 +325,7 @@ fn send_tx<Call>(
     let start_time = Instant::now();
 
     connection
-        .send_extrinsic(tx.hex_encode(), XtStatus::Ready)
+        .send_extrinsic(tx.hex_encode(), status)
         .expect("Could not send transaction");
 
     let elapsed_time = start_time.elapsed().as_millis();

--- a/flooder/src/main.rs
+++ b/flooder/src/main.rs
@@ -118,7 +118,7 @@ fn main() -> Result<(), anyhow::Error> {
     let tick = Instant::now();
 
     thread_pool.install(|| {
-        flood(pool, txs, threads, &histogram);
+        flood(&pool, txs, threads, &histogram);
     });
 
     let tock = tick.elapsed().as_millis();
@@ -137,7 +137,7 @@ fn main() -> Result<(), anyhow::Error> {
 }
 
 fn flood(
-    pool: Vec<Api<sr25519::Pair, WsRpcClient>>,
+    pool: &Vec<Api<sr25519::Pair, WsRpcClient>>,
     txs: Vec<TransferTransaction>,
     num_threads: usize,
     histogram: &Arc<Mutex<HdrHistogram<u64>>>,
@@ -147,8 +147,8 @@ fn flood(
         println!("Sending a batch of {} transactions", &batch.len());
         batch.iter().enumerate().for_each(|(index, tx)| {
             send_tx(
-                pool.get(index % pool.len()).unwrap().to_owned(),
-                tx.to_owned(),
+                pool.get(index % pool.len()).unwrap(),
+                tx,
                 Arc::clone(histogram),
             )
         })
@@ -314,8 +314,8 @@ fn derive_user_account(seed: u64) -> sr25519::Pair {
 }
 
 fn send_tx<Call>(
-    connection: Api<sr25519::Pair, WsRpcClient>,
-    tx: UncheckedExtrinsicV4<Call>,
+    connection: &Api<sr25519::Pair, WsRpcClient>,
+    tx: &UncheckedExtrinsicV4<Call>,
     histogram: Arc<Mutex<HdrHistogram<u64>>>,
 ) where
     Call: Encode,

--- a/flooder/src/main.rs
+++ b/flooder/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), anyhow::Error> {
     let connection = pool.get(0).unwrap();
 
     let total_users = config.transactions;
-    let first_account_in_range = config.accounts_range_start;
+    let first_account_in_range = config.first_account_in_range;
     let transactions_per_batch = config.throughput / rayon::current_num_threads() as u64;
     let transfer_amount = 1u128;
 
@@ -192,7 +192,7 @@ fn sign_transactions(
 fn derive_user_accounts(
     connection: Api<sr25519::Pair, WsRpcClient>,
     account: sr25519::Pair,
-    first_account: u64,
+    first_account_in_range: u64,
     total_accounts: u64,
     transfer_amount: u128,
     initialize_accounts: bool,
@@ -209,7 +209,7 @@ fn derive_user_accounts(
     // start with a heuristic tx fee
     let mut total_amount = existential_deposit + (transfer_amount + 375_000_000);
 
-    for index in first_account..first_account + total_accounts {
+    for index in first_account_in_range..first_account_in_range + total_accounts {
         let path = Some(DeriveJunction::soft(index as u64));
         let (derived, _seed) = account.clone().derive(path.into_iter(), None).unwrap();
 

--- a/flooder/src/main.rs
+++ b/flooder/src/main.rs
@@ -289,10 +289,8 @@ fn initialize_account(
     account_nonce + 1
 }
 
-fn derive_user_account(account: &sr25519::Pair, seed: u64) -> sr25519::Pair {
-    let path = Some(DeriveJunction::soft(seed as u64));
-    let (derived, _) = account.derive(path.into_iter(), None).unwrap();
-    derived
+fn derive_user_account(_account: &sr25519::Pair, seed: u64) -> sr25519::Pair {
+    sr25519::Pair::from_string(&("//".to_string() + &seed.to_string()), None).unwrap()
 }
 
 fn send_tx<Call>(

--- a/flooder/src/main.rs
+++ b/flooder/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), anyhow::Error> {
             None => panic!("Needs --phrase or --seed"),
         },
     };
-    let initialize_accounts = config.initialize_accounts;
+    let initialize_accounts = !config.skip_initialization;
 
     let pool = create_connection_pool(config.nodes);
     let connection = pool.get(0).unwrap();
@@ -195,7 +195,7 @@ fn derive_user_accounts(
     first_account: u64,
     total_accounts: u64,
     transfer_amount: u128,
-    initialize_account: bool,
+    initialize_accounts: bool,
 ) -> (Vec<sr25519::Pair>, Vec<u32>) {
     let total_accounts_cap = total_accounts
         .try_into()
@@ -214,7 +214,7 @@ fn derive_user_accounts(
         let (derived, _seed) = account.clone().derive(path.into_iter(), None).unwrap();
 
         let mut hash = None;
-        if initialize_account {
+        if initialize_accounts {
             let tx = sign_tx(
                 connection.clone(),
                 account.clone(),


### PR DESCRIPTION
- allows to skip accounts initialization
- allows to provide first index for the set of integer derived accounts, i.e. accounts derived from range x.. instead of the default 0.. range
- general refactor
