### PR TITLE
AZ-107: Restart authority tasks if they fail

### DIFF
--- a/finality-aleph/src/data_io.rs
+++ b/finality-aleph/src/data_io.rs
@@ -49,7 +49,7 @@ impl<H, N> AlephData<H, N> {
 
 pub(crate) type AlephDataFor<B> = AlephData<<B as BlockT>::Hash, NumberFor<B>>;
 
-pub(crate) trait AlephNetworkMessage<B: BlockT> {
+pub trait AlephNetworkMessage<B: BlockT> {
     fn included_blocks(&self) -> Vec<AlephDataFor<B>>;
 }
 
@@ -91,7 +91,7 @@ impl Default for DataStoreConfig {
 /// This component is used for filtering available data for Aleph Network.
 /// It receives new messages for network by `messages_rx` and sends available messages
 /// (messages with all blocks already imported by client) by `ready_messages_tx`
-pub(crate) struct DataStore<B, C, BE, RB, Message>
+pub struct DataStore<B, C, BE, RB, Message>
 where
     B: BlockT,
     C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
@@ -311,7 +311,7 @@ where
 }
 
 #[derive(Clone)]
-pub(crate) struct DataProvider<B: BlockT> {
+pub struct DataProvider<B: BlockT> {
     pub(crate) proposed_block: Arc<Mutex<AlephDataFor<B>>>,
     pub(crate) metrics: Option<Metrics<<B::Header as HeaderT>::Hash>>,
 }
@@ -405,7 +405,7 @@ impl<B: BlockT> aleph_bft::DataProvider<AlephDataFor<B>> for DataProvider<B> {
     }
 }
 
-pub(crate) struct FinalizationHandler<B: BlockT> {
+pub struct FinalizationHandler<B: BlockT> {
     pub(crate) ordered_units_tx: mpsc::UnboundedSender<AlephDataFor<B>>,
 }
 

--- a/finality-aleph/src/data_io.rs
+++ b/finality-aleph/src/data_io.rs
@@ -50,7 +50,7 @@ impl<H, N> AlephData<H, N> {
 pub(crate) type AlephDataFor<B> = AlephData<<B as BlockT>::Hash, NumberFor<B>>;
 
 /// A trait allowing to check the data contained in an AlephBFT network message, for the purpose of
-/// data vailability checks.
+/// data availability checks.
 pub trait AlephNetworkMessage<B: BlockT> {
     fn included_blocks(&self) -> Vec<AlephDataFor<B>>;
 }

--- a/finality-aleph/src/data_io.rs
+++ b/finality-aleph/src/data_io.rs
@@ -49,6 +49,8 @@ impl<H, N> AlephData<H, N> {
 
 pub(crate) type AlephDataFor<B> = AlephData<<B as BlockT>::Hash, NumberFor<B>>;
 
+/// A trait allowing to check the data contained in an AlephBFT network message, for the purpose of
+/// data vailability checks.
 pub trait AlephNetworkMessage<B: BlockT> {
     fn included_blocks(&self) -> Vec<AlephDataFor<B>>;
 }
@@ -310,6 +312,7 @@ where
     }
 }
 
+/// Provides data to AlephBFT for ordering.
 #[derive(Clone)]
 pub struct DataProvider<B: BlockT> {
     pub(crate) proposed_block: Arc<Mutex<AlephDataFor<B>>>,
@@ -405,6 +408,7 @@ impl<B: BlockT> aleph_bft::DataProvider<AlephDataFor<B>> for DataProvider<B> {
     }
 }
 
+/// Accepts and forwards units ordered by AlephBFT.
 pub struct FinalizationHandler<B: BlockT> {
     pub(crate) ordered_units_tx: mpsc::UnboundedSender<AlephDataFor<B>>,
 }

--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -115,7 +115,7 @@ where
 type Hasher = hash::Wrapper<BlakeTwo256>;
 
 #[derive(Clone)]
-struct SpawnHandle(SpawnTaskHandle);
+pub struct SpawnHandle(SpawnTaskHandle);
 
 impl From<SpawnTaskHandle> for SpawnHandle {
     fn from(sth: SpawnTaskHandle) -> Self {

--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -37,6 +37,7 @@ enum Error {
     SendData,
 }
 
+/// Returns a NonDefaultSetConfig for the specified protocol.
 pub fn peers_set_config(
     protocol: Option<new_network::Protocol>,
 ) -> sc_network::config::NonDefaultSetConfig {
@@ -114,6 +115,7 @@ where
 
 type Hasher = hash::Wrapper<BlakeTwo256>;
 
+/// A wrapper for spawning tasks in a way compatible with AlephBFT.
 #[derive(Clone)]
 pub struct SpawnHandle(SpawnTaskHandle);
 

--- a/finality-aleph/src/network.rs
+++ b/finality-aleph/src/network.rs
@@ -713,7 +713,7 @@ impl<D: Clone + Codec> DataNetwork<D> {
     }
 }
 
-pub(crate) struct AlephNetwork<B: BlockT> {
+pub struct AlephNetwork<B: BlockT> {
     inner: DataNetwork<AlephNetworkData<B>>,
 }
 
@@ -739,7 +739,7 @@ impl<B: BlockT> aleph_bft::Network<Hasher, AlephDataFor<B>, Signature, Signature
     }
 }
 
-pub(crate) struct RmcNetwork<B: BlockT> {
+pub struct RmcNetwork<B: BlockT> {
     inner: DataNetwork<RmcNetworkData<B>>,
 }
 

--- a/finality-aleph/src/network.rs
+++ b/finality-aleph/src/network.rs
@@ -717,6 +717,7 @@ pub struct AlephNetwork<B: BlockT> {
     inner: DataNetwork<AlephNetworkData<B>>,
 }
 
+/// A network for sending messages related to the AlephBFT protocol.
 impl<B: BlockT> AlephNetwork<B> {
     pub(crate) fn new(inner: DataNetwork<AlephNetworkData<B>>) -> Self {
         AlephNetwork { inner }
@@ -739,6 +740,7 @@ impl<B: BlockT> aleph_bft::Network<Hasher, AlephDataFor<B>, Signature, Signature
     }
 }
 
+/// A network for sending messages related to RMC.
 pub struct RmcNetwork<B: BlockT> {
     inner: DataNetwork<RmcNetworkData<B>>,
 }

--- a/finality-aleph/src/party/aggregator.rs
+++ b/finality-aleph/src/party/aggregator.rs
@@ -1,0 +1,133 @@
+use crate::{
+    aggregator::BlockSignatureAggregator,
+    crypto::KeyBox,
+    data_io::AlephDataFor,
+    finalization::should_finalize,
+    justification::{AlephJustification, JustificationNotification},
+    metrics::Checkpoint,
+    network::RmcNetwork,
+    party::{AuthoritySubtaskCommon, Task},
+    Metrics,
+};
+use aleph_bft::SpawnHandle;
+use futures::{
+    channel::{mpsc, oneshot},
+    StreamExt,
+};
+use log::{debug, error, trace};
+use sc_client_api::Backend;
+use sp_api::NumberFor;
+use sp_runtime::traits::{Block, Header};
+use std::sync::Arc;
+
+pub struct IO<B: Block> {
+    pub ordered_units_from_aleph: mpsc::UnboundedReceiver<AlephDataFor<B>>,
+    pub justifications_for_chain: mpsc::UnboundedSender<JustificationNotification<B>>,
+}
+
+async fn run_aggregator<B, C, BE>(
+    mut aggregator: BlockSignatureAggregator<'_, B, KeyBox>,
+    io: IO<B>,
+    client: Arc<C>,
+    last_block_in_session: NumberFor<B>,
+    metrics: Option<Metrics<<B::Header as Header>::Hash>>,
+    mut exit_rx: oneshot::Receiver<()>,
+) where
+    B: Block,
+    C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
+    C::Api: aleph_primitives::AlephSessionApi<B>,
+    BE: Backend<B> + 'static,
+{
+    let IO {
+        mut ordered_units_from_aleph,
+        justifications_for_chain,
+    } = io;
+    let mut last_finalized = client.info().finalized_hash;
+    let mut last_block_seen = false;
+    loop {
+        tokio::select! {
+            maybe_unit = ordered_units_from_aleph.next() => {
+                if let Some(new_block_data) = maybe_unit {
+                    trace!(target: "aleph-party", "Received unit {:?} in aggregator.", new_block_data);
+                    if last_block_seen {
+                        //This is only for optimization purposes.
+                        continue;
+                    }
+                    if let Some(metrics) = &metrics {
+                        metrics.report_block(new_block_data.hash, std::time::Instant::now(), Checkpoint::Ordered);
+                    }
+                    if let Some(data) = should_finalize(last_finalized, new_block_data, client.as_ref(), last_block_in_session) {
+                        aggregator.start_aggregation(data.hash).await;
+                        last_finalized = data.hash;
+                        if data.number == last_block_in_session {
+                            aggregator.notify_last_hash();
+                            last_block_seen = true;
+                        }
+                    }
+                } else {
+                    debug!(target: "aleph-party", "Units ended in aggregator. Terminating.");
+                    break;
+                }
+            }
+            multisigned_hash = aggregator.next_multisigned_hash() => {
+                if let Some((hash, multisignature)) = multisigned_hash {
+                    let number = client.number(hash).unwrap().unwrap();
+                    // The unwrap might actually fail if data availability is not implemented correctly.
+                    let notification = JustificationNotification {
+                        justification: AlephJustification{signature: multisignature},
+                        hash,
+                        number
+                    };
+                    if let Err(e) = justifications_for_chain.unbounded_send(notification)  {
+                        error!(target: "aleph-party", "Issue with sending justification from Aggregator to JustificationHandler {:?}.", e);
+                    }
+                } else {
+                    debug!(target: "aleph-party", "The stream of multisigned hashes has ended. Terminating.");
+                    break;
+                }
+            }
+            _ = &mut exit_rx => {
+                debug!(target: "aleph-party", "Aggregator received exit signal. Terminating.");
+                return;
+            }
+        }
+    }
+    debug!(target: "aleph-party", "Aggregator awaiting an exit signal.");
+    // this allows aggregator to exit after member,
+    // otherwise it can exit too early and member complains about a channel to aggregator being closed
+    let _ = exit_rx.await;
+}
+
+pub fn task<B, C, BE>(
+    subtask_common: AuthoritySubtaskCommon,
+    client: Arc<C>,
+    io: IO<B>,
+    last_block: NumberFor<B>,
+    metrics: Option<Metrics<<B::Header as Header>::Hash>>,
+    multikeychain: KeyBox,
+    rmc_network: RmcNetwork<B>,
+) -> Task
+where
+    B: Block,
+    C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
+    C::Api: aleph_primitives::AlephSessionApi<B>,
+    BE: Backend<B> + 'static,
+{
+    let AuthoritySubtaskCommon {
+        spawn_handle,
+        session_id,
+    } = subtask_common;
+    let (stop, exit) = oneshot::channel();
+    let task = {
+        async move {
+            let aggregator =
+                BlockSignatureAggregator::new(rmc_network, &multikeychain, metrics.clone());
+            debug!(target: "aleph-party", "Running the aggregator task for {:?}", session_id);
+            run_aggregator(aggregator, io, client, last_block, metrics, exit).await;
+            debug!(target: "aleph-party", "Aggregator task stopped for {:?}", session_id);
+        }
+    };
+
+    let handle = spawn_handle.spawn_essential("aleph/consensus_session_aggregator", task);
+    Task::new(handle, stop)
+}

--- a/finality-aleph/src/party/aggregator.rs
+++ b/finality-aleph/src/party/aggregator.rs
@@ -20,6 +20,7 @@ use sp_api::NumberFor;
 use sp_runtime::traits::{Block, Header};
 use std::sync::Arc;
 
+/// IO channels used by the aggregator task.
 pub struct IO<B: Block> {
     pub ordered_units_from_aleph: mpsc::UnboundedReceiver<AlephDataFor<B>>,
     pub justifications_for_chain: mpsc::UnboundedSender<JustificationNotification<B>>,
@@ -98,6 +99,7 @@ async fn run_aggregator<B, C, BE>(
     let _ = exit_rx.await;
 }
 
+/// Runs the justification signature aggregator within a single session.
 pub fn task<B, C, BE>(
     subtask_common: AuthoritySubtaskCommon,
     client: Arc<C>,

--- a/finality-aleph/src/party/authority.rs
+++ b/finality-aleph/src/party/authority.rs
@@ -1,0 +1,86 @@
+use crate::{
+    party::{Handle, Task as PureTask},
+    NodeIndex, SpawnHandle,
+};
+use futures::channel::oneshot;
+
+pub struct Task {
+    task: PureTask,
+    node_id: NodeIndex,
+}
+
+impl Task {
+    pub fn new(handle: Handle, node_id: NodeIndex, exit: oneshot::Sender<()>) -> Self {
+        Task {
+            task: PureTask::new(handle, exit),
+            node_id,
+        }
+    }
+
+    pub async fn stop(self) {
+        self.task.stop().await
+    }
+
+    pub async fn stopped(&mut self) -> NodeIndex {
+        self.task.stopped().await;
+        self.node_id
+    }
+}
+
+pub struct Subtasks {
+    exit: oneshot::Receiver<()>,
+    member: PureTask,
+    aggregator: PureTask,
+    forwarder: PureTask,
+    refresher: PureTask,
+    data_store: PureTask,
+}
+
+impl Subtasks {
+    pub fn new(
+        exit: oneshot::Receiver<()>,
+        member: PureTask,
+        aggregator: PureTask,
+        forwarder: PureTask,
+        refresher: PureTask,
+        data_store: PureTask,
+    ) -> Self {
+        Subtasks {
+            exit,
+            member,
+            aggregator,
+            forwarder,
+            refresher,
+            data_store,
+        }
+    }
+
+    async fn stop(self) {
+        // both member and aggregator are implicitly using forwarder,
+        // so we should force them to exit first to avoid any panics, i.e. `send on closed channel`
+        self.member.stop().await;
+        self.aggregator.stop().await;
+        self.forwarder.stop().await;
+        self.refresher.stop().await;
+        self.data_store.stop().await;
+    }
+
+    pub async fn failed(mut self) -> bool {
+        let result = tokio::select! {
+            _ = &mut self.exit => false,
+            _ = self.member.stopped() => true,
+            _ = self.aggregator.stopped() => true,
+            _ = self.forwarder.stopped() => true,
+            _ = self.refresher.stopped() => true,
+            _ = self.data_store.stopped() => true,
+        };
+        self.stop().await;
+        result
+    }
+}
+
+#[derive(Clone)]
+pub struct SubtaskCommon {
+    pub spawn_handle: SpawnHandle,
+    pub session_id: u32,
+}

--- a/finality-aleph/src/party/data_store.rs
+++ b/finality-aleph/src/party/data_store.rs
@@ -1,0 +1,38 @@
+use crate::{
+    data_io::DataStore,
+    network::{AlephNetworkData, RequestBlocks},
+    party::{AuthoritySubtaskCommon, Task},
+};
+use aleph_bft::SpawnHandle;
+use futures::channel::oneshot;
+use log::debug;
+use sc_client_api::Backend;
+use sp_runtime::traits::Block;
+
+pub fn task<B, C, BE, RB>(
+    subtask_common: AuthoritySubtaskCommon,
+    mut data_store: DataStore<B, C, BE, RB, AlephNetworkData<B>>,
+) -> Task
+where
+    B: Block,
+    C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
+    C::Api: aleph_primitives::AlephSessionApi<B>,
+    BE: Backend<B> + 'static,
+    RB: RequestBlocks<B> + 'static,
+{
+    let AuthoritySubtaskCommon {
+        spawn_handle,
+        session_id,
+    } = subtask_common;
+    let (stop, exit) = oneshot::channel();
+    let task = {
+        async move {
+            debug!(target: "aleph-party", "Running the data store task for {:?}", session_id);
+            data_store.run(exit).await;
+            debug!(target: "aleph-party", "Data store task stopped for {:?}", session_id);
+        }
+    };
+
+    let handle = spawn_handle.spawn_essential("aleph/consensus_session_data_store", task);
+    Task::new(handle, stop)
+}

--- a/finality-aleph/src/party/data_store.rs
+++ b/finality-aleph/src/party/data_store.rs
@@ -9,6 +9,7 @@ use log::debug;
 use sc_client_api::Backend;
 use sp_runtime::traits::Block;
 
+/// Runs the data store within a single session.
 pub fn task<B, C, BE, RB>(
     subtask_common: AuthoritySubtaskCommon,
     mut data_store: DataStore<B, C, BE, RB, AlephNetworkData<B>>,

--- a/finality-aleph/src/party/forwarder.rs
+++ b/finality-aleph/src/party/forwarder.rs
@@ -6,6 +6,7 @@ use aleph_bft::SpawnHandle;
 use futures::{channel::oneshot, future::select, pin_mut};
 use log::debug;
 
+/// Runs the forwarder within a single session.
 pub fn task<F: Future<Output = ()> + Send + 'static>(
     subtask_common: AuthoritySubtaskCommon,
     forwarder: F,

--- a/finality-aleph/src/party/forwarder.rs
+++ b/finality-aleph/src/party/forwarder.rs
@@ -1,0 +1,27 @@
+use crate::{
+    party::{AuthoritySubtaskCommon, Task},
+    Future,
+};
+use aleph_bft::SpawnHandle;
+use futures::{channel::oneshot, future::select, pin_mut};
+use log::debug;
+
+pub fn task<F: Future<Output = ()> + Send + 'static>(
+    subtask_common: AuthoritySubtaskCommon,
+    forwarder: F,
+) -> Task {
+    let AuthoritySubtaskCommon {
+        spawn_handle,
+        session_id,
+    } = subtask_common;
+    let (stop, exit) = oneshot::channel();
+    let task = async move {
+        debug!(target: "aleph-party", "Running the forwarder task for {:?}", session_id);
+        pin_mut!(forwarder);
+        select(forwarder, exit).await;
+        debug!(target: "aleph-party", "Forwarder task stopped for {:?}", session_id);
+    };
+
+    let handle = spawn_handle.spawn_essential("aleph/consensus_session_forwarder", task);
+    Task::new(handle, stop)
+}

--- a/finality-aleph/src/party/member.rs
+++ b/finality-aleph/src/party/member.rs
@@ -9,6 +9,7 @@ use futures::channel::oneshot;
 use log::debug;
 use sp_runtime::traits::Block;
 
+/// Runs the member within a single session.
 pub fn task<B: Block>(
     subtask_common: AuthoritySubtaskCommon,
     multikeychain: KeyBox,

--- a/finality-aleph/src/party/member.rs
+++ b/finality-aleph/src/party/member.rs
@@ -1,0 +1,45 @@
+use crate::{
+    crypto::KeyBox,
+    data_io::{DataProvider, FinalizationHandler},
+    network::AlephNetwork,
+    party::{AuthoritySubtaskCommon, Task},
+};
+use aleph_bft::{Config, SpawnHandle};
+use futures::channel::oneshot;
+use log::debug;
+use sp_runtime::traits::Block;
+
+pub fn task<B: Block>(
+    subtask_common: AuthoritySubtaskCommon,
+    multikeychain: KeyBox,
+    config: Config,
+    network: AlephNetwork<B>,
+    data_provider: DataProvider<B>,
+    finalization_handler: FinalizationHandler<B>,
+) -> Task {
+    let AuthoritySubtaskCommon {
+        spawn_handle,
+        session_id,
+    } = subtask_common;
+    let (stop, exit) = oneshot::channel();
+    let task = {
+        let spawn_handle = spawn_handle.clone();
+        async move {
+            debug!(target: "aleph-party", "Running the member task for {:?}", session_id);
+            aleph_bft::run_session(
+                config,
+                network,
+                data_provider,
+                finalization_handler,
+                multikeychain,
+                spawn_handle,
+                exit,
+            )
+            .await;
+            debug!(target: "aleph-party", "Member task stopped for {:?}", session_id);
+        }
+    };
+
+    let handle = spawn_handle.spawn_essential("aleph/consensus_session_member", task);
+    Task::new(handle, stop)
+}

--- a/finality-aleph/src/party/mod.rs
+++ b/finality-aleph/src/party/mod.rs
@@ -1,23 +1,17 @@
 use crate::{
-    aggregator::BlockSignatureAggregator,
     crypto::{AuthorityPen, AuthorityVerifier, KeyBox},
-    data_io::{
-        reduce_header_to_num, refresh_best_chain, AlephData, AlephDataFor, DataProvider, DataStore,
-    },
+    data_io::{reduce_header_to_num, AlephData, DataProvider, DataStore},
     default_aleph_config,
-    finalization::should_finalize,
     justification::{
         AlephJustification, JustificationHandler, JustificationNotification,
         JustificationRequestDelay, SessionInfo, SessionInfoProvider,
     },
-    last_block_of_session,
-    metrics::Checkpoint,
-    network,
+    last_block_of_session, network,
     network::{
         split_network, AlephNetworkData, ConsensusNetwork, DataNetwork, NetworkData, SessionManager,
     },
-    session_id_from_block_num, AuthorityId, Future, Metrics, MillisecsPerBlock, NodeIndex,
-    SessionId, SessionMap, SessionPeriod, UnitCreationDelay,
+    session_id_from_block_num, AuthorityId, Metrics, MillisecsPerBlock, NodeIndex, SessionId,
+    SessionMap, SessionPeriod, UnitCreationDelay,
 };
 use sp_keystore::CryptoStore;
 
@@ -25,11 +19,7 @@ use aleph_bft::{DelayConfig, SpawnHandle};
 use aleph_primitives::{AlephSessionApi, KEY_TYPE};
 use futures_timer::Delay;
 
-use futures::{
-    channel::{mpsc, oneshot},
-    future::select,
-    pin_mut, StreamExt,
-};
+use futures::channel::mpsc;
 use log::{debug, error, info, trace, warn};
 
 use crate::data_io::FinalizationHandler;
@@ -52,6 +42,18 @@ use std::{
     marker::PhantomData,
     sync::Arc,
     time::Duration,
+};
+
+mod task;
+use task::{Handle, Task};
+mod aggregator;
+mod authority;
+mod data_store;
+mod forwarder;
+mod member;
+mod refresher;
+use authority::{
+    SubtaskCommon as AuthoritySubtaskCommon, Subtasks as AuthoritySubtasks, Task as AuthorityTask,
 };
 
 pub struct AlephParams<B: Block, N, C, SC> {
@@ -263,76 +265,6 @@ where
     unit_creation_delay: UnitCreationDelay,
 }
 
-async fn run_aggregator<B, C, BE>(
-    mut aggregator: BlockSignatureAggregator<'_, B, KeyBox>,
-    mut ordered_units_rx: mpsc::UnboundedReceiver<AlephDataFor<B>>,
-    justification_tx: mpsc::UnboundedSender<JustificationNotification<B>>,
-    client: Arc<C>,
-    last_block_in_session: NumberFor<B>,
-    metrics: Option<Metrics<<B::Header as Header>::Hash>>,
-    mut exit_rx: futures::channel::oneshot::Receiver<()>,
-) where
-    B: Block,
-    C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
-    C::Api: aleph_primitives::AlephSessionApi<B>,
-    BE: Backend<B> + 'static,
-{
-    let mut last_finalized = client.info().finalized_hash;
-    let mut last_block_seen = false;
-    loop {
-        tokio::select! {
-            maybe_unit = ordered_units_rx.next() => {
-                if let Some(new_block_data) = maybe_unit {
-                    trace!(target: "afa", "Received unit {:?} in aggregator.", new_block_data);
-                    if last_block_seen {
-                        //This is only for optimization purposes.
-                        continue;
-                    }
-                    if let Some(metrics) = &metrics {
-                        metrics.report_block(new_block_data.hash, std::time::Instant::now(), Checkpoint::Ordered);
-                    }
-                    if let Some(data) = should_finalize(last_finalized, new_block_data, client.as_ref(), last_block_in_session) {
-                        aggregator.start_aggregation(data.hash).await;
-                        last_finalized = data.hash;
-                        if data.number == last_block_in_session {
-                            aggregator.notify_last_hash();
-                            last_block_seen = true;
-                        }
-                    }
-                } else {
-                    debug!(target: "afa", "Units ended in aggregator. Terminating.");
-                    break;
-                }
-            }
-            multisigned_hash = aggregator.next_multisigned_hash() => {
-                if let Some((hash, multisignature)) = multisigned_hash {
-                    let number = client.number(hash).unwrap().unwrap();
-                    // The unwrap might actually fail if data availability is not implemented correctly.
-                    let notification = JustificationNotification {
-                        justification: AlephJustification{signature: multisignature},
-                        hash,
-                        number
-                    };
-                    if let Err(e) = justification_tx.unbounded_send(notification)  {
-                        error!(target: "afa", "Issue with sending justification from Aggregator to JustificationHandler {:?}.", e);
-                    }
-                } else {
-                    debug!(target: "afa", "The stream of multisigned hashes has ended. Terminating.");
-                    break;
-                }
-            }
-            _ = &mut exit_rx => {
-                debug!(target: "afa", "Aggregator received exit signal. Terminating.");
-                return;
-            }
-        }
-    }
-    debug!(target: "afa", "Aggregator awaiting an exit signal.");
-    // this allows aggregator to exit after member,
-    // otherwise it can exit too early and member complains about a channel to aggregator being closed
-    let _ = exit_rx.await;
-}
-
 impl<B, C, BE, SC, RB> ConsensusParty<B, C, BE, SC, RB>
 where
     B: Block,
@@ -342,7 +274,7 @@ where
     SC: SelectChain<B> + 'static,
     RB: network::RequestBlocks<B> + 'static,
 {
-    async fn run_session_as_authority(
+    async fn spawn_authority_subtasks(
         &self,
         node_id: NodeIndex,
         multikeychain: KeyBox,
@@ -350,13 +282,13 @@ where
         session_id: SessionId,
         authorities: Vec<AuthorityId>,
         exit_rx: futures::channel::oneshot::Receiver<()>,
-    ) -> impl Future<Output = ()> {
+    ) -> AuthoritySubtasks {
         debug!(target: "afa", "Authority task {:?}", session_id);
         let last_block = last_block_of_session::<B>(session_id, self.session_period);
-        let (ordered_units_tx, ordered_units_rx) = mpsc::unbounded();
+        let (ordered_units_for_aggregator, ordered_units_from_aleph) = mpsc::unbounded();
         let (aleph_network_tx, data_store_rx) = mpsc::unbounded();
         let (data_store_tx, aleph_network_rx) = mpsc::unbounded();
-        let mut data_store = DataStore::<B, C, BE, RB, AlephNetworkData<B>>::new(
+        let data_store = DataStore::<B, C, BE, RB, AlephNetworkData<B>>::new(
             self.client.clone(),
             self.block_requester.clone(),
             data_store_tx,
@@ -388,128 +320,89 @@ where
             metrics: self.metrics.clone(),
         };
 
-        let finalization_handler = FinalizationHandler::<B> { ordered_units_tx };
-
-        let (exit_member_tx, exit_member_rx) = oneshot::channel();
-        let (exit_data_store_tx, exit_data_store_rx) = oneshot::channel();
-        let (exit_aggregator_tx, exit_aggregator_rx) = oneshot::channel();
-        let (exit_refresher_tx, exit_refresher_rx) = oneshot::channel();
-        let (exit_forwarder_tx, exit_forwarder_rx) = oneshot::channel();
-
-        let member_task = {
-            let spawn_handle = self.spawn_handle.clone();
-            let multikeychain = multikeychain.clone();
-            async move {
-                debug!(target: "afa", "Running the member task for {:?}", session_id.0);
-                aleph_bft::run_session(
-                    consensus_config,
-                    aleph_network,
-                    data_provider,
-                    finalization_handler,
-                    multikeychain,
-                    spawn_handle,
-                    exit_member_rx,
-                )
-                .await;
-                debug!(target: "afa", "Member task stopped for {:?}", session_id.0);
-            }
+        let finalization_handler = FinalizationHandler::<B> {
+            ordered_units_tx: ordered_units_for_aggregator,
         };
 
-        let data_store_task = {
-            async move {
-                debug!(target: "afa", "Running the data store task for {:?}", session_id.0);
-                data_store.run(exit_data_store_rx).await;
-                debug!(target: "afa", "Data store task stopped for {:?}", session_id.0);
-            }
+        let subtask_common = AuthoritySubtaskCommon {
+            spawn_handle: self.spawn_handle.clone(),
+            session_id: session_id.0,
+        };
+        let aggregator_io = aggregator::IO {
+            ordered_units_from_aleph,
+            justifications_for_chain: self.authority_justification_tx.clone(),
         };
 
-        let aggregator_task = {
-            let client = self.client.clone();
-            let justification_tx = self.authority_justification_tx.clone();
-            let last_block = last_block_of_session::<B>(session_id, self.session_period);
-            let metrics = self.metrics.clone();
-            let multikeychain = multikeychain.clone();
-            async move {
-                let aggregator =
-                    BlockSignatureAggregator::new(rmc_network, &multikeychain, metrics.clone());
-                debug!(target: "afa", "Running the aggregator task for {:?}", session_id.0);
-                run_aggregator(
-                    aggregator,
-                    ordered_units_rx,
-                    justification_tx,
-                    client,
-                    last_block,
-                    metrics,
-                    exit_aggregator_rx,
-                )
-                .await;
-                debug!(target: "afa", "Aggregator task stopped for {:?}", session_id.0);
-            }
-        };
-
-        let forwarder_task = async move {
-            debug!(target: "afa", "Running the forwarder task for {:?}", session_id.0);
-            pin_mut!(forwarder);
-            select(forwarder, exit_forwarder_rx).await;
-            debug!(target: "afa", "Forwarder task stopped for {:?}", session_id.0);
-        };
-
-        let refresher_task = {
-            refresh_best_chain(
+        AuthoritySubtasks::new(
+            exit_rx,
+            member::task(
+                subtask_common.clone(),
+                multikeychain.clone(),
+                consensus_config,
+                aleph_network,
+                data_provider,
+                finalization_handler,
+            ),
+            aggregator::task(
+                subtask_common.clone(),
+                self.client.clone(),
+                aggregator_io,
+                last_block,
+                self.metrics.clone(),
+                multikeychain.clone(),
+                rmc_network,
+            ),
+            forwarder::task(subtask_common.clone(), forwarder),
+            refresher::task(
+                subtask_common.clone(),
                 self.select_chain.clone(),
                 self.client.clone(),
                 proposed_block,
                 last_block,
-                exit_refresher_rx,
+            ),
+            data_store::task(subtask_common, data_store),
+        )
+    }
+
+    async fn spawn_authority_task(
+        &self,
+        session_id: SessionId,
+        node_id: NodeIndex,
+        authorities: Vec<AuthorityId>,
+    ) -> AuthorityTask {
+        let keybox = KeyBox::new(
+            node_id,
+            AuthorityVerifier::new(authorities.clone()),
+            AuthorityPen::new(authorities[node_id.0].clone(), self.keystore.clone())
+                .await
+                .expect("The keys should sign successfully"),
+        );
+        let data_network = self
+            .session_manager
+            .start_session(session_id, keybox.clone())
+            .await;
+
+        let (exit, exit_rx) = futures::channel::oneshot::channel();
+        let authority_subtasks = self
+            .spawn_authority_subtasks(
+                node_id,
+                keybox,
+                data_network,
+                session_id,
+                authorities,
+                exit_rx,
             )
-        };
-
-        let member_handle = self
-            .spawn_handle
-            .spawn_essential("aleph/consensus_session_member", member_task);
-        let data_store_handle = self
-            .spawn_handle
-            .spawn_essential("aleph/consensus_session_data_store", data_store_task);
-        let aggregator_handle = self
-            .spawn_handle
-            .spawn_essential("aleph/consensus_session_aggregator", aggregator_task);
-        let forwarder_handle = self
-            .spawn_handle
-            .spawn_essential("aleph/consensus_session_forwarder", forwarder_task);
-        let refresher_handle = self
-            .spawn_handle
-            .spawn_essential("aleph/consensus_session_refresher", refresher_task);
-
-        async move {
-            let _ = exit_rx.await;
-            // both member and aggregator are implicitly using forwarder,
-            // so we should force them to exit first to avoid any panics, i.e. `send on closed channel`
-            if let Err(e) = exit_member_tx.send(()) {
-                debug!(target: "afa", "member was closed before terminating it manually: {:?}", e)
-            }
-            let _ = member_handle.await;
-
-            if let Err(e) = exit_aggregator_tx.send(()) {
-                debug!(target: "afa", "aggregator was closed before terminating it manually: {:?}", e)
-            }
-            let _ = aggregator_handle.await;
-
-            if let Err(e) = exit_forwarder_tx.send(()) {
-                debug!(target: "afa", "forwarder was closed before terminating it manually: {:?}", e)
-            }
-            let _ = forwarder_handle.await;
-
-            if let Err(e) = exit_refresher_tx.send(()) {
-                debug!(target: "afa", "refresh was closed before terminating it manually: {:?}", e)
-            }
-            let _ = refresher_handle.await;
-
-            if let Err(e) = exit_data_store_tx.send(()) {
-                debug!(target: "afa", "data store was closed before terminating it manually: {:?}", e)
-            }
-            let _ = data_store_handle.await;
-            info!(target: "afa", "Terminated authority run of session {:?}", session_id);
-        }
+            .await;
+        AuthorityTask::new(
+            self.spawn_handle
+                .spawn_essential("aleph/session_authority", async move {
+                    if authority_subtasks.failed().await {
+                        warn!(target: "aleph-party", "Authority subtasks failed.");
+                    }
+                }),
+            node_id,
+            exit,
+        )
     }
 
     async fn run_session(&mut self, session_id: SessionId) {
@@ -561,38 +454,18 @@ where
             }
         }
         trace!(target: "afa", "Authorities for session {:?}: {:?}", session_id, authorities);
-        let maybe_node_id = get_node_index(&authorities, self.keystore.clone()).await;
-
-        let (exit_authority_tx, exit_authority_rx) = futures::channel::oneshot::channel();
-        if let Some(node_id) = maybe_node_id {
+        let mut maybe_authority_task = if let Some(node_id) =
+            get_node_index(&authorities, self.keystore.clone()).await
+        {
             debug!(target: "afa", "Running session {:?} as authority id {:?}", session_id, node_id);
-            let keybox = KeyBox::new(
-                node_id,
-                AuthorityVerifier::new(authorities.clone()),
-                AuthorityPen::new(authorities[node_id.0].clone(), self.keystore.clone())
-                    .await
-                    .expect("The keys should sign successfully"),
-            );
-            let data_network = self
-                .session_manager
-                .start_session(session_id, keybox.clone())
-                .await;
-
-            let authority_task = self
-                .run_session_as_authority(
-                    node_id,
-                    keybox,
-                    data_network,
-                    session_id,
-                    authorities,
-                    exit_authority_rx,
-                )
-                .await;
-            self.spawn_handle
-                .spawn("aleph/session_authority", authority_task);
+            Some(
+                self.spawn_authority_task(session_id, node_id, authorities.clone())
+                    .await,
+            )
         } else {
             debug!(target: "afa", "Running session {:?} as non-authority", session_id);
-        }
+            None
+        };
         loop {
             let last_finalized_number = self.client.info().finalized_number;
             debug!(target: "afa", "Highest finalized: {:?} session {:?}", last_finalized_number, session_id);
@@ -600,11 +473,21 @@ where
                 debug!(target: "afa", "Terminating session {:?}", session_id);
                 break;
             }
-            Delay::new(Duration::from_millis(1000)).await;
+            tokio::select! {
+                _ = Delay::new(Duration::from_millis(1000)) => (),
+                Some(node_id) = async {
+                    match maybe_authority_task.as_mut() {
+                        Some(task) => Some(task.stopped().await),
+                        None => None,
+                    } } => {
+                    warn!(target: "afa", "Authority task ended prematurely, restarting.");
+                    maybe_authority_task = Some(self.spawn_authority_task(session_id, node_id, authorities.clone()).await);
+                },
+            }
         }
-        if maybe_node_id.is_some() {
-            debug!(target: "afa", "Sending exit signal to the authority task.");
-            let _ = exit_authority_tx.send(());
+        if let Some(task) = maybe_authority_task {
+            debug!(target: "afa", "Stopping the authority task.");
+            task.stop().await;
             self.session_manager.stop_session(session_id);
         }
     }

--- a/finality-aleph/src/party/mod.rs
+++ b/finality-aleph/src/party/mod.rs
@@ -265,6 +265,8 @@ where
     unit_creation_delay: UnitCreationDelay,
 }
 
+const SESSION_STATUS_CHECK_PERIOD_MS: u64 = 1000;
+
 impl<B, C, BE, SC, RB> ConsensusParty<B, C, BE, SC, RB>
 where
     B: Block,
@@ -474,7 +476,7 @@ where
                 break;
             }
             tokio::select! {
-                _ = Delay::new(Duration::from_millis(1000)) => (),
+                _ = Delay::new(Duration::from_millis(SESSION_STATUS_CHECK_PERIOD_MS)) => (),
                 Some(node_id) = async {
                     match maybe_authority_task.as_mut() {
                         Some(task) => Some(task.stopped().await),

--- a/finality-aleph/src/party/refresher.rs
+++ b/finality-aleph/src/party/refresher.rs
@@ -12,6 +12,7 @@ use sp_consensus::SelectChain;
 use sp_runtime::traits::Block;
 use std::sync::Arc;
 
+/// Runs the latest block refresher within a single session.
 pub fn task<B, BE, SC, C>(
     subtask_common: AuthoritySubtaskCommon,
     select_chain: SC,

--- a/finality-aleph/src/party/refresher.rs
+++ b/finality-aleph/src/party/refresher.rs
@@ -1,0 +1,42 @@
+use crate::{
+    data_io::{refresh_best_chain, AlephDataFor},
+    party::{AuthoritySubtaskCommon, Task},
+};
+use aleph_bft::SpawnHandle;
+use futures::channel::oneshot;
+use log::debug;
+use parking_lot::Mutex;
+use sc_client_api::Backend;
+use sp_api::NumberFor;
+use sp_consensus::SelectChain;
+use sp_runtime::traits::Block;
+use std::sync::Arc;
+
+pub fn task<B, BE, SC, C>(
+    subtask_common: AuthoritySubtaskCommon,
+    select_chain: SC,
+    client: Arc<C>,
+    proposed_block: Arc<Mutex<AlephDataFor<B>>>,
+    last_block: NumberFor<B>,
+) -> Task
+where
+    B: Block,
+    C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
+    C::Api: aleph_primitives::AlephSessionApi<B>,
+    BE: Backend<B> + 'static,
+    SC: SelectChain<B> + 'static,
+{
+    let AuthoritySubtaskCommon {
+        spawn_handle,
+        session_id,
+    } = subtask_common;
+    let (stop, exit) = oneshot::channel();
+    let task = async move {
+        debug!(target: "aleph-party", "Running the chain refresh task for {:?}", session_id);
+        refresh_best_chain(select_chain, client, proposed_block, last_block, exit).await;
+        debug!(target: "aleph-party", "Chain refresh task stopped for {:?}", session_id);
+    };
+
+    let handle = spawn_handle.spawn_essential("aleph/consensus_session_refresher", task);
+    Task::new(handle, stop)
+}

--- a/finality-aleph/src/party/task.rs
+++ b/finality-aleph/src/party/task.rs
@@ -3,18 +3,22 @@ use futures::channel::oneshot;
 use log::warn;
 use std::{boxed::Box, pin::Pin};
 
+/// A single handle that can be waited on, as returned by spawning an essential task.
 pub type Handle = Pin<Box<(dyn Future<Output = sc_service::Result<(), ()>> + Send + 'static)>>;
 
+/// A task that can be stopped or awaited until it stops itself.
 pub struct Task {
     handle: Handle,
     exit: oneshot::Sender<()>,
 }
 
 impl Task {
+    /// Create a new task.
     pub fn new(handle: Handle, exit: oneshot::Sender<()>) -> Self {
         Task { handle, exit }
     }
 
+    /// Cleanly stop the task.
     pub async fn stop(self) {
         if let Err(e) = self.exit.send(()) {
             warn!(target: "aleph-party", "Failed to send exit signal to authority: {:?}", e);
@@ -22,6 +26,8 @@ impl Task {
         let _ = self.handle.await;
     }
 
+    /// Await the task to stop by itself. Should usually just block forever, unless something went
+    /// wrong.
     pub async fn stopped(&mut self) {
         let _ = (&mut self.handle).await;
     }

--- a/finality-aleph/src/party/task.rs
+++ b/finality-aleph/src/party/task.rs
@@ -1,0 +1,28 @@
+use crate::Future;
+use futures::channel::oneshot;
+use log::warn;
+use std::{boxed::Box, pin::Pin};
+
+pub type Handle = Pin<Box<(dyn Future<Output = sc_service::Result<(), ()>> + Send + 'static)>>;
+
+pub struct Task {
+    handle: Handle,
+    exit: oneshot::Sender<()>,
+}
+
+impl Task {
+    pub fn new(handle: Handle, exit: oneshot::Sender<()>) -> Self {
+        Task { handle, exit }
+    }
+
+    pub async fn stop(self) {
+        if let Err(e) = self.exit.send(()) {
+            warn!(target: "aleph-party", "Failed to send exit signal to authority: {:?}", e);
+        }
+        let _ = self.handle.await;
+    }
+
+    pub async fn stopped(&mut self) {
+        let _ = (&mut self.handle).await;
+    }
+}

--- a/finality-aleph/src/testing/network.rs
+++ b/finality-aleph/src/testing/network.rs
@@ -16,7 +16,6 @@ use futures::{
 };
 use parking_lot::Mutex;
 use sc_network::{Event, ObservedRole, PeerId as ScPeerId, ReputationChange};
-use sp_api::NumberFor;
 use sp_core::Encode;
 use sp_keystore::{testing::KeyStore, CryptoStore};
 use sp_runtime::traits::Block as BlockT;
@@ -43,7 +42,6 @@ struct TestNetwork<B: BlockT> {
     announce: Channel<(B::Hash, Option<Vec<u8>>)>,
     add_set_reserved: Channel<(PeerId, Cow<'static, str>)>,
     remove_set_reserved: Channel<(PeerId, Cow<'static, str>)>,
-    request_justification: Channel<(B::Hash, NumberFor<B>)>,
     peer_id: PeerId,
 }
 
@@ -58,7 +56,6 @@ impl<B: BlockT> TestNetwork<B> {
             announce: channel(),
             add_set_reserved: channel(),
             remove_set_reserved: channel(),
-            request_justification: channel(),
             peer_id,
         }
     }


### PR DESCRIPTION
Also splits up party.rs a tad to make it more readable.

Main change is needed for a strange fail case of the new network, which shouldn't happen with proper usage when the committee actually changes, but right now would break everything. It is also actually useful in general, we want to restart if something breaks this way anyway.