### PR TITLE
AZ-579: refactor time constants to use the actual value of the `millis_per_block` param

### DIFF
--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Run e2e test suite
         shell: bash
-        timeout-minutes: 1
+        timeout-minutes: 10
         run: ./.github/scripts/run_e2e_tests.sh
 
 

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Run e2e test suite
         shell: bash
-        timeout-minutes: 10
+        timeout-minutes: 1
         run: ./.github/scripts/run_e2e_tests.sh
 
 

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -123,10 +123,14 @@ pub const MILLISECS_PER_BLOCK: u64 = 1000;
 
 pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
 
-// Time is measured by number of blocks.
-pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
-pub const HOURS: BlockNumber = MINUTES * 60;
-pub const DAYS: BlockNumber = HOURS * 24;
+pub const MILLISECS_PER_MINUTE: u64 = 60_000; // milliseconds
+pub const MILLISECS_PER_HOUR: u64 = MILLISECS_PER_MINUTE * 60;
+pub const MILLISECS_PER_DAY: u64 = MILLISECS_PER_HOUR * 24;
+
+/// Get the number of blocks produced in the period given by `hours`
+pub const fn hours_as_block_num(hours: u64) -> BlockNumber {
+    (MILLISECS_PER_HOUR * hours / MILLISECS_PER_BLOCK) as BlockNumber
+}
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
@@ -453,7 +457,7 @@ pub const TREASURY_PROPOSAL_BOND: u32 = 0;
 // The proposer should deposit max{`TREASURY_PROPOSAL_BOND`% of the proposal value, $10}.
 pub const TREASURY_MINIMUM_BOND: Balance = 1000 * CENTS;
 // Every 4h we implement accepted proposals.
-pub const TREASURY_SPEND_PERIOD: BlockNumber = 4 * HOURS;
+pub const TREASURY_SPEND_PERIOD: BlockNumber = hours_as_block_num(4);
 // We allow at most 20 approvals in the queue at once.
 pub const TREASURY_MAX_APPROVALS: u32 = 20;
 

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -128,8 +128,8 @@ pub const MILLISECS_PER_HOUR: u64 = MILLISECS_PER_MINUTE * 60;
 pub const MILLISECS_PER_DAY: u64 = MILLISECS_PER_HOUR * 24;
 
 /// Get the number of blocks produced in the period given by `hours`
-pub const fn hours_as_block_num(hours: u64) -> BlockNumber {
-    (MILLISECS_PER_HOUR * hours / MILLISECS_PER_BLOCK) as BlockNumber
+pub fn hours_as_block_num(hours: u64) -> BlockNumber {
+    (MILLISECS_PER_HOUR * hours / Aleph::millisecs_per_block()) as BlockNumber
 }
 
 /// The version information used to identify this runtime when compiled natively.
@@ -457,7 +457,9 @@ pub const TREASURY_PROPOSAL_BOND: u32 = 0;
 // The proposer should deposit max{`TREASURY_PROPOSAL_BOND`% of the proposal value, $10}.
 pub const TREASURY_MINIMUM_BOND: Balance = 1000 * CENTS;
 // Every 4h we implement accepted proposals.
-pub const TREASURY_SPEND_PERIOD: BlockNumber = hours_as_block_num(4);
+pub fn treasury_spend_period() -> BlockNumber {
+    hours_as_block_num(4)
+}
 // We allow at most 20 approvals in the queue at once.
 pub const TREASURY_MAX_APPROVALS: u32 = 20;
 
@@ -466,7 +468,7 @@ parameter_types! {
     pub const ProposalBond: Permill = Permill::from_percent(TREASURY_PROPOSAL_BOND);
     pub const ProposalBondMinimum: Balance = TREASURY_MINIMUM_BOND;
     pub const MaxApprovals: u32 = TREASURY_MAX_APPROVALS;
-    pub const SpendPeriod: BlockNumber = TREASURY_SPEND_PERIOD;
+    pub SpendPeriod: BlockNumber = treasury_spend_period();
     pub const TreasuryPalletId: PalletId = PalletId(*b"a0/trsry");
 }
 


### PR DESCRIPTION
Exposes a function `hours_as_block_num :: u64 -> BlockNumber` that calculates the time period as the corresponding number of blocks, taking into account the `millis_per_block` parameter supplied when creating the chain.