### PR TITLE
AZ-569: Replace the afa logging target

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -61,7 +61,7 @@ if [[ -n "${RESERVED_ONLY:-}" ]]; then
 fi
 
 if [[ -n "${FLAG_LAFA:-}" ]]; then
-  ARGS+=(-lafa=debug)
+  ARGS+=(-laleph-party=debug -laleph-network=debug -laleph-finality=debug -laleph-justification=debug -laleph-data-store=debug -laleph-metrics=debug)
 fi
 
 if [[ -n "${FLAG_L_ALEPH_BFT:-}" ]]; then

--- a/finality-aleph/src/aggregator.rs
+++ b/finality-aleph/src/aggregator.rs
@@ -86,7 +86,7 @@ impl<
     }
 
     pub(crate) async fn start_aggregation(&mut self, hash: B::Hash) {
-        debug!(target: "afa", "Started aggregation for block hash {:?}", hash);
+        debug!(target: "aleph-party", "Started aggregation for block hash {:?}", hash);
         if !self.started_hashes.insert(hash) {
             return;
         }
@@ -105,7 +105,7 @@ impl<
         &mut self,
     ) -> Option<(B::Hash, MK::PartialMultisignature)> {
         loop {
-            trace!(target: "afa", "Entering next_multisigned_hash loop.");
+            trace!(target: "aleph-party", "Entering next_multisigned_hash loop.");
             match self.hash_queue.front() {
                 Some(hash) => {
                     if let Some(multisignature) = self.signatures.remove(hash) {
@@ -118,7 +118,7 @@ impl<
                 }
                 None => {
                     if self.last_hash_placed {
-                        debug!(target: "afa", "Terminating next_multisigned_hash because the last hash has been signed.");
+                        debug!(target: "aleph-party", "Terminating next_multisigned_hash because the last hash has been signed.");
                         return None;
                     }
                 }
@@ -128,24 +128,24 @@ impl<
                     multisigned_hash = self.rmc.next_multisigned_hash() => {
                         let hash = multisigned_hash.as_signable().hash;
                         let unchecked = multisigned_hash.into_unchecked().signature();
-                            debug!(target: "afa", "New multisigned_hash {:?}.", unchecked);
+                            debug!(target: "aleph-party", "New multisigned_hash {:?}.", unchecked);
                             self.signatures.insert(hash, unchecked);
                             break;
                     }
                     message_from_rmc = self.messages_from_rmc.next() => {
-                        trace!(target: "afa", "Our rmc message {:?}.", message_from_rmc);
+                        trace!(target: "aleph-party", "Our rmc message {:?}.", message_from_rmc);
                         if let Some(message_from_rmc) = message_from_rmc {
                             self.network.send(message_from_rmc, Recipient::Everyone).expect("sending message from rmc failed")
                         } else {
-                            warn!(target: "afa", "the channel of messages from rmc closed");
+                            warn!(target: "aleph-party", "the channel of messages from rmc closed");
                         }
                     }
                     message_from_network = self.network.next() => {
                         if let Some(message_from_network) = message_from_network {
-                            trace!(target: "afa", "Received message for rmc: {:?}", message_from_network);
+                            trace!(target: "aleph-party", "Received message for rmc: {:?}", message_from_network);
                             self.messages_for_rmc.unbounded_send(message_from_network).expect("sending message to rmc failed");
                         } else {
-                            warn!(target: "afa", "the network channel closed");
+                            warn!(target: "aleph-party", "the network channel closed");
                             // In case the network is down we can terminate (?).
                             return None;
                         }

--- a/finality-aleph/src/data_io/data_interpreter.rs
+++ b/finality-aleph/src/data_io/data_interpreter.rs
@@ -75,7 +75,7 @@ impl<B: BlockT, C: HeaderBackend<B>> OrderedDataInterpreter<B, C> {
                 {
                     proposal
                 } else {
-                    warn!(target:"afa", "Incorrect proposal {:?} passed through data availability, session bounds: {:?}", unvalidated_proposal, self.session_boundaries);
+                    warn!(target: "aleph-finality", "Incorrect proposal {:?} passed through data availability, session bounds: {:?}", unvalidated_proposal, self.session_boundaries);
                     return None;
                 };
 
@@ -87,7 +87,7 @@ impl<B: BlockT, C: HeaderBackend<B>> OrderedDataInterpreter<B, C> {
                 match status {
                     Finalize(block) => Some(block),
                     Ignore => {
-                        debug!(target:"afa", "HopelessFork {:?} encountered in Data. Skipping.", proposal);
+                        debug!(target: "aleph-finality", "HopelessFork {:?} encountered in Data. Skipping.", proposal);
                         None
                     }
                     Pending(pending_status) => {
@@ -113,7 +113,7 @@ impl<B: BlockT, C: HeaderBackend<B> + Send + 'static> aleph_bft::FinalizationHan
                 .inner()
                 .update_aux_finalized(block.clone());
             if let Err(err) = self.blocks_to_finalize_tx.unbounded_send(block) {
-                error!(target: "afa", "Error in sending a block from FinalizationHandler, {}", err);
+                error!(target: "aleph-finality", "Error in sending a block from FinalizationHandler, {}", err);
             }
         }
     }

--- a/finality-aleph/src/data_io/data_provider.rs
+++ b/finality-aleph/src/data_io/data_provider.rs
@@ -50,7 +50,7 @@ where
     {
         Some((*header.parent_hash(), block.num - <NumberFor<B>>::one()).into())
     } else {
-        warn!(target: "afa", "Trying to fetch the parent of an unknown block {:?}.", block);
+        warn!(target: "aleph-data-store", "Trying to fetch the parent of an unknown block {:?}.", block);
         None
     }
 }
@@ -84,7 +84,7 @@ where
     } else {
         // By backtracking from the best block we reached a block conflicting with best finalized.
         // This is most likely a bug, or some extremely unlikely synchronization issue of the client.
-        warn!(target: "afa", "Error computing proposal. Conflicting blocks: {:?}, finalized {:?}", curr_block, finalized_block);
+        warn!(target: "aleph-data-store", "Error computing proposal. Conflicting blocks: {:?}, finalized {:?}", curr_block, finalized_block);
         Err(())
     }
 }
@@ -173,7 +173,7 @@ where
         }
         if best_block_in_session.num < finalized_block.num {
             // Because of the client synchronization, in extremely rare cases this could happen.
-            warn!(target: "afa", "Error updating data. best_block {:?} is lower than finalized {:?}.", best_block_in_session, finalized_block);
+            warn!(target: "aleph-data-store", "Error updating data. best_block {:?} is lower than finalized {:?}.", best_block_in_session, finalized_block);
             return;
         }
 
@@ -256,7 +256,7 @@ where
 
                 }
                 _ = &mut exit => {
-                    debug!(target: "afa", "Task for refreshing best chain received exit signal. Terminating.");
+                    debug!(target: "aleph-data-store", "Task for refreshing best chain received exit signal. Terminating.");
                     return;
                 }
             }
@@ -293,7 +293,7 @@ impl<B: BlockT> aleph_bft::DataProvider<AlephData<B>> for DataProvider<B> {
                 );
             }
         }
-        debug!(target: "afa", "Outputting {:?} in get_data", data);
+        debug!(target: "aleph-data-store", "Outputting {:?} in get_data", data);
         data
     }
 }

--- a/finality-aleph/src/finalization.rs
+++ b/finality-aleph/src/finalization.rs
@@ -55,11 +55,11 @@ where
     ) -> Result<(), Error> {
         let status = self.client.info();
         if status.finalized_number >= block_number {
-            warn!(target: "afa", "trying to finalize a block with hash {} and number {}
+            warn!(target: "aleph-finality", "trying to finalize a block with hash {} and number {}
                that is not greater than already finalized {}", hash, block_number, status.finalized_number);
         }
 
-        debug!(target: "afa", "Finalizing block with hash {:?} and number {:?}. Previous best: #{:?}.", hash, block_number, status.finalized_number);
+        debug!(target: "aleph-finality", "Finalizing block with hash {:?} and number {:?}. Previous best: #{:?}.", hash, block_number, status.finalized_number);
 
         let update_res = self.client.lock_import_and_run(|import_op| {
             // NOTE: all other finalization logic should come here, inside the lock
@@ -67,7 +67,7 @@ where
                 .apply_finality(import_op, BlockId::Hash(hash), justification, true)
         });
         let status = self.client.info();
-        debug!(target: "afa", "Attempted to finalize block with hash {:?}. Current best: #{:?}.", hash, status.finalized_number);
+        debug!(target: "aleph-finality", "Attempted to finalize block with hash {:?}. Current best: #{:?}.", hash, status.finalized_number);
         update_res
     }
 }

--- a/finality-aleph/src/metrics.rs
+++ b/finality-aleph/src/metrics.rs
@@ -26,7 +26,7 @@ struct Inner<H: Key> {
 
 impl<H: Key> Inner<H> {
     fn report_block(&mut self, hash: H, checkpoint_time: Instant, checkpoint_type: Checkpoint) {
-        trace!(target: "afa", "Reporting block stage: {:?} (hash: {:?}, at: {:?}", checkpoint_type, hash, checkpoint_time);
+        trace!(target: "aleph-metrics", "Reporting block stage: {:?} (hash: {:?}, at: {:?}", checkpoint_type, hash, checkpoint_time);
 
         self.starts.entry(checkpoint_type).and_modify(|starts| {
             starts.put(hash, checkpoint_time);
@@ -42,7 +42,7 @@ impl<H: Key> Inner<H> {
                 let duration = match checkpoint_time.checked_duration_since(*start) {
                     Some(duration) => duration,
                     None => {
-                        warn!(target: "afa", "Earlier metrics time {:?} is later that current one \
+                        warn!(target: "aleph-metrics", "Earlier metrics time {:?} is later that current one \
                         {:?}. Checkpoint type {:?}, block: {:?}",
                             *start, checkpoint_time, checkpoint_type, hash);
                         Duration::new(0, 0)

--- a/run_nodes.sh
+++ b/run_nodes.sh
@@ -94,9 +94,12 @@ for i in $(seq 0 "$(( N_VALIDATORS + N_NON_VALIDATORS - 1 ))"); do
     --execution Native \
     --rpc-cors=all \
     --no-mdns \
-    -lafa=debug \
     -laleph-party=debug \
     -laleph-network=debug \
+    -laleph-finality=debug \
+    -laleph-justification=debug \
+    -laleph-data-store=debug \
+    -laleph-metrics=debug \
     "$@" \
     2> $auth.log > /dev/null & \
 done


### PR DESCRIPTION
Create new logging targets `aleph-data-store`, `aleph-finality`, and
`aleph-metrics`. Remove logging target `afa`.

Replace uses of logging targets:
* (18) `afa` -> `aleph-party`
* (11) `afa` -> `aleph-data-store`
* (10) `afa` -> `aleph-justification`
* (8) `afa` -> `aleph-finality`
* (2) `afa` -> `aleph-metrics`