### PR TITLE
Highest caching bug

### DIFF
--- a/finality-aleph/src/data_io/data_store.rs
+++ b/finality-aleph/src/data_io/data_store.rs
@@ -273,14 +273,14 @@ where
     }
 
     // Updates our highest known and highest finalized block info directly from the client.
-    fn update_highest_blocks(&mut self) {
-        let highest = self.chain_info_provider.get_highest();
-        self.on_block_imported(highest.imported);
-        self.on_block_finalized(highest.finalized);
+    fn update_highest_finalized(&mut self) {
+        let highest_finalized = self.chain_info_provider.get_highest_finalized();
+        self.on_block_imported(highest_finalized.clone());
+        self.on_block_finalized(highest_finalized);
     }
 
     fn run_maintenance(&mut self) {
-        self.update_highest_blocks();
+        self.update_highest_finalized();
 
         let proposals_with_timestamps: Vec<_> = self
             .pending_proposals

--- a/finality-aleph/src/data_io/status_provider.rs
+++ b/finality-aleph/src/data_io/status_provider.rs
@@ -18,7 +18,7 @@ where
     use crate::data_io::proposal::PendingProposalStatus::*;
     use crate::data_io::proposal::ProposalStatus::*;
 
-    if chain_info_provider.get_highest().finalized.num >= proposal.number_top_block() {
+    if chain_info_provider.get_highest_finalized().num >= proposal.number_top_block() {
         return Ignore;
     }
 


### PR DESCRIPTION
Get rid of keeping track of highest imported block in the cached chain info provider. The information we get from client apparently is not enough to track this block correctly which resulted in a bug.