### PR TITLE
Whole state is downloaded and the new spec is applied on top of it.

### DIFF
--- a/fork-off/Cargo.lock
+++ b/fork-off/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "sp-runtime",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-std",
 ]
 
 [[package]]
@@ -39,7 +39,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
  "sp-runtime",
  "thiserror",
 ]
@@ -51,9 +51,9 @@ source = "git+https://github.com/Cardinal-Cryptography/substrate-api-client.git?
 dependencies = [
  "hex",
  "parity-scale-codec",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
  "sp-runtime",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-std",
 ]
 
 [[package]]
@@ -187,12 +187,6 @@ dependencies = [
 
 [[package]]
 name = "base58"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
-
-[[package]]
-name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
@@ -306,9 +300,6 @@ name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -365,15 +356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,22 +400,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -443,7 +415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -455,7 +427,7 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -468,7 +440,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -594,15 +566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56047058e1ab118075ca22f9ecd737bcc961aa3566a3019cb71388afa280bd8a"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +606,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-off"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -651,10 +614,11 @@ dependencies = [
  "futures",
  "hex",
  "log",
+ "parking_lot 0.12.0",
  "reqwest",
+ "serde",
  "serde_json",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
+ "sp-io",
  "substrate-api-client",
  "tokio",
 ]
@@ -682,11 +646,11 @@ dependencies = [
  "paste",
  "scale-info",
  "sp-api",
- "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-io",
  "sp-runtime",
- "sp-runtime-interface 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-storage 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
@@ -729,15 +693,15 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-arithmetic",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
  "sp-core-hashing-proc-macro",
  "sp-inherents",
- "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-state-machine 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-tracing 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
  "tt-call",
 ]
 
@@ -785,10 +749,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
+ "sp-io",
  "sp-runtime",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-std",
  "sp-version",
 ]
 
@@ -1024,16 +988,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
-]
-
-[[package]]
-name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
@@ -1050,17 +1004,6 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
  "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
-dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
 ]
 
 [[package]]
@@ -1247,15 +1190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,22 +1240,6 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
-dependencies = [
- "arrayref",
- "crunchy",
- "digest 0.8.1",
- "hmac-drbg 0.2.0",
- "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.4.1",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0452aac8bab02242429380e9b2f94ea20cea2b37e2c1777a1358799bbe97f37"
@@ -1329,7 +1247,7 @@ dependencies = [
  "arrayref",
  "base64",
  "digest 0.9.0",
- "hmac-drbg 0.3.0",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
@@ -1347,7 +1265,7 @@ checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -1380,18 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1772,7 +1681,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1786,10 +1695,10 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
+ "sp-io",
  "sp-runtime",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1852,37 +1761,23 @@ checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.5",
+ "lock_api",
  "parking_lot_core 0.8.5",
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.7.2"
+name = "parking_lot"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -1894,9 +1789,22 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2154,12 +2062,6 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
@@ -2285,16 +2187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cada0ef59efa6a5f4dc5e491f93d9f31e3fc7758df421ff1de8a706338e1100"
-dependencies = [
- "byteorder",
- "twox-hash",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,7 +2242,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "sha2 0.8.2",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -2359,15 +2251,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "secrecy"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0673d6a6449f5e7d12a1caf424fd9363e2af3a4953023ed455e3c4beef4597c0"
-dependencies = [
- "zeroize",
-]
 
 [[package]]
 name = "secrecy"
@@ -2542,15 +2425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
-name = "slog"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
-dependencies = [
- "erased-serde",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,10 +2449,10 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "sp-api-proc-macro",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
  "sp-runtime",
- "sp-state-machine 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-state-machine",
+ "sp-std",
  "sp-version",
  "thiserror",
 ]
@@ -2603,9 +2477,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
@@ -2618,8 +2492,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-debug-derive 4.0.0-dev",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-debug-derive",
+ "sp-std",
  "static_assertions",
 ]
 
@@ -2628,7 +2502,7 @@ name = "sp-core"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13#afb74de23dfe2994e7ce38c0870efb9734e966f7"
 dependencies = [
- "base58 0.2.0",
+ "base58",
  "bitflags",
  "blake2-rfc",
  "byteorder",
@@ -2640,7 +2514,7 @@ dependencies = [
  "hex",
  "impl-serde",
  "lazy_static",
- "libsecp256k1 0.7.0",
+ "libsecp256k1",
  "log",
  "merlin",
  "num-traits",
@@ -2652,60 +2526,16 @@ dependencies = [
  "regex",
  "scale-info",
  "schnorrkel",
- "secrecy 0.8.0",
+ "secrecy",
  "serde",
  "sha2 0.9.8",
  "sp-core-hashing",
- "sp-debug-derive 4.0.0-dev",
- "sp-externalities 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-runtime-interface 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-storage 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
  "ss58-registry",
- "substrate-bip39",
- "thiserror",
- "tiny-bip39",
- "tiny-keccak",
- "twox-hash",
- "wasmi",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "base58 0.1.0",
- "blake2-rfc",
- "byteorder",
- "dyn-clonable",
- "ed25519-dalek",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "hex",
- "impl-serde",
- "lazy_static",
- "libsecp256k1 0.3.5",
- "log",
- "merlin",
- "num-traits",
- "parity-scale-codec",
- "parity-util-mem",
- "parking_lot 0.11.2",
- "primitive-types",
- "rand 0.7.3",
- "regex",
- "schnorrkel",
- "secrecy 0.7.0",
- "serde",
- "sha2 0.9.8",
- "sp-debug-derive 3.0.0",
- "sp-externalities 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-runtime-interface 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-storage 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
  "substrate-bip39",
  "thiserror",
  "tiny-bip39",
@@ -2723,7 +2553,7 @@ dependencies = [
  "blake2-rfc",
  "byteorder",
  "sha2 0.9.8",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-std",
  "tiny-keccak",
  "twox-hash",
 ]
@@ -2741,16 +2571,6 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sp-debug-derive"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13#afb74de23dfe2994e7ce38c0870efb9734e966f7"
 dependencies = [
@@ -2766,19 +2586,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-storage 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-storage 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
@@ -2789,9 +2598,9 @@ dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
  "sp-runtime",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-std",
  "thiserror",
 ]
 
@@ -2802,44 +2611,19 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "futures",
  "hash-db",
- "libsecp256k1 0.7.0",
+ "libsecp256k1",
  "log",
  "parity-scale-codec",
  "parking_lot 0.11.2",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-externalities 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-keystore 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-runtime-interface 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-state-machine 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-tracing 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-trie 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-wasm-interface 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "sp-io"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "futures",
- "hash-db",
- "libsecp256k1 0.3.5",
- "log",
- "parity-scale-codec",
- "parking_lot 0.11.2",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-externalities 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-keystore 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-maybe-compressed-blob",
- "sp-runtime-interface 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-state-machine 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-tracing 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-trie 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-wasm-interface 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
+ "sp-core",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie",
+ "sp-wasm-interface",
  "tracing",
  "tracing-core",
 ]
@@ -2856,41 +2640,8 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.2",
  "schnorrkel",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-externalities 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "async-trait",
- "derive_more",
- "futures",
- "merlin",
- "parity-scale-codec",
- "parking_lot 0.11.2",
- "schnorrkel",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-externalities 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
-]
-
-[[package]]
-name = "sp-maybe-compressed-blob"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "ruzstd",
- "zstd",
-]
-
-[[package]]
-name = "sp-panic-handler"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "backtrace",
+ "sp-core",
+ "sp-externalities",
 ]
 
 [[package]]
@@ -2910,7 +2661,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "rustc-hash",
  "serde",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
 ]
 
 [[package]]
@@ -2930,9 +2681,9 @@ dependencies = [
  "serde",
  "sp-application-crypto",
  "sp-arithmetic",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
@@ -2943,29 +2694,12 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-runtime-interface-proc-macro 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-storage 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-tracing 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-wasm-interface 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "primitive-types",
- "sp-externalities 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-runtime-interface-proc-macro 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-storage 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-tracing 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-wasm-interface 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
+ "sp-externalities",
+ "sp-runtime-interface-proc-macro",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
 ]
 
@@ -2973,18 +2707,6 @@ dependencies = [
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13#afb74de23dfe2994e7ce38c0870efb9734e966f7"
-dependencies = [
- "Inflector",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -3001,7 +2723,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-std",
 ]
 
 [[package]]
@@ -3016,34 +2738,11 @@ dependencies = [
  "parking_lot 0.11.2",
  "rand 0.7.3",
  "smallvec",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-externalities 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-panic-handler 4.0.0-dev",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-trie 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "thiserror",
- "tracing",
- "trie-db",
- "trie-root",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "hash-db",
- "log",
- "num-traits",
- "parity-scale-codec",
- "parking_lot 0.11.2",
- "rand 0.7.3",
- "smallvec",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-externalities 0.10.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-panic-handler 3.0.0",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-trie 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-std",
+ "sp-trie",
  "thiserror",
  "tracing",
  "trie-db",
@@ -3056,11 +2755,6 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13#afb74de23dfe2994e7ce38c0870efb9734e966f7"
 
 [[package]]
-name = "sp-std"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-
-[[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13#afb74de23dfe2994e7ce38c0870efb9734e966f7"
@@ -3069,21 +2763,8 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 4.0.0-dev",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
-]
-
-[[package]]
-name = "sp-storage"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 3.0.0",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
+ "sp-debug-derive",
+ "sp-std",
 ]
 
 [[package]]
@@ -3092,25 +2773,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13#afb74de23dfe2994e7ce38c0870efb9734e966f7"
 dependencies = [
  "parity-scale-codec",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "erased-serde",
- "log",
- "parity-scale-codec",
- "parking_lot 0.10.2",
- "serde",
- "serde_json",
- "slog",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
+ "sp-std",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -3125,22 +2788,8 @@ dependencies = [
  "memory-db",
  "parity-scale-codec",
  "scale-info",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "trie-db",
- "trie-root",
-]
-
-[[package]]
-name = "sp-trie"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "hash-db",
- "memory-db",
- "parity-scale-codec",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
+ "sp-core",
+ "sp-std",
  "trie-db",
  "trie-root",
 ]
@@ -3156,7 +2805,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-runtime",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-std",
  "sp-version-proc-macro",
  "thiserror",
 ]
@@ -3179,18 +2828,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
- "wasmi",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.9)",
+ "sp-std",
  "wasmi",
 ]
 
@@ -3253,10 +2891,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-application-crypto",
- "sp-core 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-core",
  "sp-rpc",
  "sp-runtime",
- "sp-std 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13)",
+ "sp-std",
  "sp-version",
  "thiserror",
  "ws",
@@ -3274,12 +2912,6 @@ dependencies = [
  "sha2 0.9.8",
  "zeroize",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -3325,7 +2957,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.4",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -3841,6 +3473,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
 name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3903,33 +3578,4 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zstd"
-version = "0.6.1+zstd.1.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de55e77f798f205d8561b8fe2ef57abfb6e0ff2abe7fd3c089e119cdb5631a3"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "3.0.1+zstd.1.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1387cabcd938127b30ce78c4bf00b30387dddf704e3f0881dbc4ff62b5566f8c"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "1.4.20+zstd.1.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd5b733d7cf2d9447e2c3e76a5589b4f5e5ae065c22a2bc0b023cbc331b6c8e"
-dependencies = [
- "cc",
- "libc",
 ]

--- a/fork-off/Cargo.toml
+++ b/fork-off/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fork-off"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # client
@@ -10,8 +10,7 @@ tag = "polkadot-v0.9.13.b2bfc0c3"
 
 [dependencies]
 # Substrate dependencies
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.9", features = ["full_crypto"] }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.9" }
+sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13" }
 
 # other
 anyhow = "1.0.52"
@@ -21,5 +20,7 @@ futures = "0.3.17"
 hex = "0.4.3"
 log = "0.4"
 reqwest = { version = "0.11", features = ["json"] }
-serde_json = "1.0"
+serde = "1"
+serde_json = "1"
 tokio = { version = "1.0", features = ["full"]}
+parking_lot = "0.12.0"

--- a/fork-off/README.md
+++ b/fork-off/README.md
@@ -26,15 +26,24 @@ Alternatively, if you have a chainspec in a human-readable format, you can conve
 aleph-node convert-chainspec-to-raw --chain docker/data/chainspec.json
 ```
 
-Tool will query the target chain for storage pairs (by default "Aura" and "Aleph") and copy them over to the target fork chainspec, which is finally written out to the specified path:
+The tool will perform the following actions, in this order:
+1. Download the whole state (key-value pairs) of the chain via the provided rpc endpoint `http-rpc-endpoint`. More specifically it will first query the best block and then download the state at this block.
+2. Dump the state to a json file. You can provide a path via `--snapshot-path`.
+3. Read the state from the snapshot json file. This is because steps 1. and 2. can be omitted by running with `--use-snapshot-file` -- see example below.
+4. Read the chainspec provided via `--initial-spec-path` you should pass here the one generated via `the bootstrap-chain` command, so `--initial-spec-path=chainspec.json` if it is in the same directory.
+5. Replace the genesis state in the chainspec by the one from the snapshot WITH THE EXCEPTION of states of pallets provided via a comma separated list using `--pallets`. The default setting is `--pallets=Aura,Aleph,Sudo,Staking,Session,Elections` and it's likely you don't want to change it.
+6. The final, new chainspec is saved to the path provided via `--combined-spec-path`.
+
+So for instance to generate a new spec keeping the storage of testnet (note that in that case you should use the same binary as running on testnet to `bootstrap-chain`) we would run:
 
 ```bash
-RUST_LOG=info target/release/fork-off --http-rpc-endpoint http://127.0.0.1:9933 --fork-spec-path chainspec.json --write-to-path chainspec.fork.json --prefixes <Pallet1,Pallet2,...>
+target/release/fork-off --http-rpc-endpoint=https://rpc.test.azero.dev --initial-spec-path=chainspec.json --combined-spec-path=combined.json
 ```
 
-where:
+This will also create a `snapshot.json` file containing the state downloaded from testnet. In case the state downloaded correctly (easy to see from logs) but something went wrong when combining the specs (e.g. you want to use a different set of pallets) then you can rerun without the need of downloading the state again (it might be time consuming):
 
-* `http-rpc-endpoint`: is an URL address of an RPC endpoint of a target chain node (for querying current state).
-* `fork-spec-path`: a path to the generated chainspec, the basis for creating the fork.
-* `write-to-path`: where to write the resulting chainspec to.
-* `prefixes`: which storage items to migrate ("Aura" and "Aleph" by default), e.g. , `--prefixes Aura,Aleph,Treasury,Vesting`
+```bash
+target/release/fork-off --http-rpc-endpoint=https://rpc.test.azero.dev --initial-spec-path=chainspec.json --combined-spec-path=combined.json --use-snapshot-file
+```
+
+Finally, there is also an optional parameter `--num-workers` with default value `5` which you can increase to parallelize better the process of downloading the state. Note however that this might increase the risk of being banned for too many RPC requests, so use with caution. The default value seems to be safe.

--- a/fork-off/README.md
+++ b/fork-off/README.md
@@ -31,7 +31,7 @@ The tool will perform the following actions, in this order:
 2. Dump the state to a json file. You can provide a path via `--snapshot-path`.
 3. Read the state from the snapshot json file. This is because steps 1. and 2. can be omitted by running with `--use-snapshot-file` -- see example below.
 4. Read the chainspec provided via `--initial-spec-path` you should pass here the one generated via `the bootstrap-chain` command, so `--initial-spec-path=chainspec.json` if it is in the same directory.
-5. Replace the genesis state in the chainspec by the one from the snapshot WITH THE EXCEPTION of states of pallets provided via a comma separated list using `--pallets`. The default setting is `--pallets=Aura,Aleph,Sudo,Staking,Session,Elections` and it's likely you don't want to change it.
+5. Replace the genesis state in the chainspec by the one from the snapshot WITH THE EXCEPTION of states of pallets provided via a comma separated list using `--pallets_keep_state`. The default setting is `--pallets_keep_state=Aura,Aleph,Sudo,Staking,Session,Elections` and it's likely you don't want to change it.
 6. The final, new chainspec is saved to the path provided via `--combined-spec-path`.
 
 So for instance to generate a new spec keeping the storage of testnet (note that in that case you should use the same binary as running on testnet to `bootstrap-chain`) we would run:

--- a/fork-off/src/main.rs
+++ b/fork-off/src/main.rs
@@ -1,9 +1,16 @@
 use clap::Parser;
-use futures::stream::{self, StreamExt};
-use log::{debug, info};
+use env_logger::Env;
+use futures::future::join_all;
+use log::info;
+use parking_lot::Mutex;
+use reqwest::Client;
 use serde_json::Value;
-use std::fs::{self, File};
-use std::io::{ErrorKind, Write};
+use std::{
+    collections::HashMap,
+    fs::{self, File},
+    io::{ErrorKind, Write},
+    sync::Arc,
+};
 
 #[derive(Debug, Parser)]
 #[clap(version = "1.0")]
@@ -12,14 +19,26 @@ pub struct Config {
     #[clap(long, default_value = "http://127.0.0.1:9933")]
     pub http_rpc_endpoint: String,
 
-    /// path to write the initial chainspec of the fork
-    /// as generated with the `bootstrap-chain` command
-    #[clap(long, default_value = "../docker/data/chainspec.json")]
-    pub fork_spec_path: String,
+    /// path of the initial chainspec (generated with the `bootstrap-chain` command)
+    #[clap(long, default_value = "./initial_chainspec.json")]
+    pub initial_spec_path: String,
+
+    /// where to write the snapshot of the state
+    #[clap(long, default_value = "./snapshot.json")]
+    pub snapshot_path: String,
 
     /// where to write the forked genesis chainspec
-    #[clap(long, default_value = "../docker/data/chainspec.fork.json")]
-    pub write_to_path: String,
+    #[clap(long, default_value = "./chainspec_from_snapshot.json")]
+    pub combined_spec_path: String,
+
+    /// where to write the forked genesis chainspec
+    #[clap(long)]
+    pub use_snapshot_file: bool,
+
+    /// how many parallel processes to download values -- note that large values might result in bans because
+    /// of rate-limiting mechanisms
+    #[clap(long, default_value_t = 5)]
+    pub num_workers: u32,
 
     /// which modules to set in forked spec
     #[clap(
@@ -27,79 +46,25 @@ pub struct Config {
         multiple_occurrences = true,
         takes_value = true,
         value_delimiter = ',',
-        default_value = "Aura,Aleph"
+        default_value = "Aura,Aleph,Sudo,Staking,Session,Elections"
     )]
-    pub prefixes: Vec<String>,
+    pub pallets: Vec<String>,
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let Config {
-        http_rpc_endpoint,
-        fork_spec_path,
-        write_to_path,
-        prefixes,
-    } = Config::parse();
+const KEYS_BATCH_SIZE: u32 = 1000;
 
-    env_logger::init();
+type BlockHash = String;
+type StorageKey = String;
+type StorageValue = String;
+type Storage = HashMap<StorageKey, StorageValue>;
 
-    info!(target: "fork",
-        "Running with config: \n\thttp_rpc_endpoint {}\n \tfork_spec_path: {}\n \twrite_to_path: {}\n \tprefixes: {:?}",
-        &http_rpc_endpoint, &fork_spec_path, &write_to_path, &prefixes
-    );
-
-    let mut fork_spec: Value = serde_json::from_str(
-        &fs::read_to_string(&fork_spec_path).expect("Could not read chainspec file"),
-    )?;
-
-    let hashed_prefixes = prefixes
-        .iter()
-        .map(|prefix| {
-            let hash = format!("0x{}", prefix_as_hex(prefix));
-            info!(target: "fork", "prefix: {}, hash: {}", prefix, hash);
-            hash
-        })
-        .chain([format!("0x{}", hex::encode(":code"))])
-        .collect::<Vec<String>>();
-
-    let storage = get_chain_state(&http_rpc_endpoint, &hashed_prefixes).await;
-
-    info!("Succesfully retrieved chain state {:?}", storage);
-
-    storage.into_iter().for_each(|(key, value)| {
-        info!(target: "fork","Moving {} to the fork", key);
-        fork_spec["genesis"]["raw"]["top"][key] = value.into();
-    });
-
-    // write out the fork spec
-    let json = serde_json::to_string_pretty(&fork_spec)?;
-    info!(target: "fork", "Writing forked chain spec to {}", &write_to_path);
-    write_to_file(write_to_path, json.as_bytes());
-
-    info!("Done!");
-    Ok(())
-}
-
-async fn get_key(http_rpc_endpoint: &str, key: &str, start_key: Option<&str>) -> Option<String> {
-    let body = match start_key {
-        Some(start_key) => {
-            serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "state_getKeysPaged",
-                "params": [ key, 1, start_key ]
-            })
-        }
-        None => serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "state_getKeysPaged",
-            "params": [ key, 1 ]
-        }),
-    };
-
-    let response: Value = reqwest::Client::new()
-        .post(http_rpc_endpoint)
+async fn make_request_and_parse_result<T: serde::de::DeserializeOwned>(
+    client: &Client,
+    endpoint: &str,
+    body: Value,
+) -> T {
+    let mut response: Value = client
+        .post(endpoint)
         .json(&body)
         .send()
         .await
@@ -107,73 +72,283 @@ async fn get_key(http_rpc_endpoint: &str, key: &str, start_key: Option<&str>) ->
         .json()
         .await
         .expect("Could not deserialize response as JSON");
+    let result = response["result"].take();
+    serde_json::from_value(result).expect("Incompatible type of the result")
+}
 
-    debug!(target: "fork", "get_key response: {}", response);
+fn construct_json_body(method_name: &str, params: Value) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method_name,
+        "params": params
+    })
+}
 
-    let result = response["result"]
-        .as_array()
-        .expect("No result in response");
+fn block_hash_body(block_num: Option<u32>) -> Value {
+    let params = serde_json::json!([block_num]);
+    construct_json_body("chain_getBlockHash", params)
+}
 
-    if !result.is_empty() {
-        return Some(
-            result
-                .first()
-                .expect("No key in result")
-                .as_str()
-                .expect("Not a string")
-                .to_owned(),
+fn get_keys_paged_body(
+    prefix: StorageKey,
+    count: u32,
+    start_key: Option<StorageKey>,
+    block_hash: Option<BlockHash>,
+) -> Value {
+    let params = serde_json::json!([prefix, count, start_key, block_hash]);
+    construct_json_body("state_getKeysPaged", params)
+}
+
+fn get_storage_value_body(key: StorageKey, block_hash: Option<BlockHash>) -> Value {
+    let params = serde_json::json!([key, block_hash]);
+    construct_json_body("state_getStorage", params)
+}
+
+struct StateFetcher {
+    client: Client,
+    http_rpc_endpoint: String,
+}
+
+impl StateFetcher {
+    fn new(http_rpc_endpoint: String) -> Self {
+        StateFetcher {
+            client: Client::new(),
+            http_rpc_endpoint,
+        }
+    }
+
+    async fn value_fetching_worker(
+        http_rpc_endpoint: String,
+        id: usize,
+        block: BlockHash,
+        input: Arc<Mutex<Vec<StorageKey>>>,
+        output: Arc<Mutex<Storage>>,
+    ) {
+        let fetcher = StateFetcher::new(http_rpc_endpoint);
+        loop {
+            let maybe_key: Option<StorageKey> = {
+                let mut keys = input.lock();
+                keys.pop()
+            };
+            if let Some(key) = maybe_key {
+                let value = fetcher.get_value(key.clone(), block.clone()).await;
+                let mut output_guard = output.lock();
+                output_guard.insert(key, value);
+                if output_guard.len() % 500 == 0 {
+                    info!("Fetched {} values", output_guard.len());
+                }
+            } else {
+                break;
+            }
+        }
+        info!("Worker {:?} finished", id);
+    }
+
+    async fn make_request<T: serde::de::DeserializeOwned>(&self, body: Value) -> T {
+        make_request_and_parse_result::<T>(&self.client, &self.http_rpc_endpoint, body).await
+    }
+
+    pub async fn get_most_recent_block(&self) -> BlockHash {
+        let body = block_hash_body(None);
+        let block: String = self.make_request(body).await;
+        block
+    }
+
+    // The start_key is not included in the range. The result is `count` keys that appear after `start_key` in the
+    // lexicographic ordering of all keys in storage.
+    async fn get_keys_range(
+        &self,
+        count: u32,
+        start_key: Option<StorageKey>,
+        block_hash: Option<BlockHash>,
+    ) -> Vec<StorageKey> {
+        let prefix = String::from("");
+        let body = get_keys_paged_body(prefix, count, start_key, block_hash);
+        let keys: Vec<StorageKey> = self.make_request(body).await;
+        keys
+    }
+
+    async fn get_all_keys(&self, block_hash: BlockHash) -> Vec<StorageKey> {
+        let mut last_key_fetched = None;
+        let mut all_keys = Vec::new();
+        loop {
+            let new_keys = self
+                .get_keys_range(KEYS_BATCH_SIZE, last_key_fetched, Some(block_hash.clone()))
+                .await;
+            all_keys.extend_from_slice(&new_keys);
+            info!(
+                "Got {} new keys and have {} in total",
+                new_keys.len(),
+                all_keys.len()
+            );
+            if new_keys.len() < KEYS_BATCH_SIZE as usize {
+                break;
+            } else {
+                last_key_fetched = Some(new_keys.last().unwrap().clone());
+            }
+        }
+        all_keys
+    }
+
+    async fn get_value(&self, key: StorageKey, block_hash: BlockHash) -> StorageValue {
+        let body = get_storage_value_body(key, Some(block_hash));
+        self.make_request(body).await
+    }
+
+    async fn get_values(
+        &self,
+        keys: Vec<StorageKey>,
+        block_hash: BlockHash,
+        num_workers: u32,
+    ) -> Storage {
+        let n_keys = keys.len();
+        let input = Arc::new(Mutex::new(keys));
+        let output = Arc::new(Mutex::new(HashMap::with_capacity(n_keys)));
+        let mut workers = Vec::new();
+
+        for id in 0..(num_workers as usize) {
+            workers.push(StateFetcher::value_fetching_worker(
+                self.http_rpc_endpoint.clone(),
+                id,
+                block_hash.clone(),
+                input.clone(),
+                output.clone(),
+            ));
+        }
+        info!("Started {} workers to download values.", workers.len());
+        join_all(workers).await;
+        assert!(input.lock().is_empty(), "Not all keys were fetched");
+        let mut guard = output.lock();
+        std::mem::take(&mut guard)
+    }
+
+    pub async fn get_full_state(&self, num_workers: u32) -> Storage {
+        let best_block = self.get_most_recent_block().await;
+        let keys = self.get_all_keys(best_block.clone()).await;
+        self.get_values(keys, best_block, num_workers).await
+    }
+}
+
+fn save_snapshot_to_file(snapshot: Storage, path: String) {
+    let data = serde_json::to_vec_pretty(&snapshot).unwrap();
+    info!(
+        "Writing snapshot of {} key-val pairs and {} total bytes",
+        snapshot.len(),
+        data.len()
+    );
+    write_to_file(path, &data);
+}
+
+fn read_snapshot_from_file(path: String) -> Storage {
+    let snapshot: Storage =
+        serde_json::from_str(&fs::read_to_string(&path).expect("Could not read snapshot file"))
+            .expect("could not parse from snapshot");
+    info!("Read snapshot of {} key-val pairs", snapshot.len());
+    snapshot
+}
+
+fn is_prefix_of(shorter: &str, longer: &str) -> bool {
+    longer.starts_with(shorter)
+}
+
+fn combine_states(mut state: Storage, initial_state: Storage, pallets: Vec<String>) -> Storage {
+    let pallets_prefixes: Vec<(String, String)> = pallets
+        .iter()
+        .map(|pallet| {
+            let hash = format!("0x{}", prefix_as_hex(pallet));
+            (pallet.clone(), hash)
+        })
+        .collect();
+    let mut cnt_removed_per_pallet: HashMap<String, usize> = pallets_prefixes
+        .iter()
+        .map(|(pallet, _)| (pallet.clone(), 0))
+        .collect();
+    let mut cnt_added_per_pallet = cnt_removed_per_pallet.clone();
+    state.retain(|k, _v| {
+        match pallets_prefixes
+            .iter()
+            .find(|(_, prefix)| is_prefix_of(prefix, k))
+        {
+            Some((pallet, _)) => {
+                *cnt_removed_per_pallet.get_mut(pallet).unwrap() += 1;
+                false
+            }
+            None => true,
+        }
+    });
+    for (k, v) in initial_state.iter() {
+        if let Some((pallet, _)) = pallets_prefixes
+            .iter()
+            .find(|(_, prefix)| is_prefix_of(prefix, k))
+        {
+            *cnt_added_per_pallet.get_mut(pallet).unwrap() += 1;
+            state.insert(k.clone(), v.clone());
+        }
+    }
+    for (pallet, prefix) in pallets_prefixes {
+        info!(
+            "For pallet {} (prefix {}) Replaced {} entries by {} entries from initial_spec",
+            pallet, prefix, cnt_removed_per_pallet[&pallet], cnt_added_per_pallet[&pallet]
         );
     }
-    None
+    state
 }
 
-async fn get_value(http_rpc_endpoint: &str, key: &str) -> String {
-    let response: Value = reqwest::Client::new()
-        .post(http_rpc_endpoint)
-        .json(&serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "state_getStorage",
-            "params": [ &key ]
-        }))
-        .send()
-        .await
-        .expect("Storage request has failed")
-        .json()
-        .await
-        .expect("Could not deserialize response as JSON");
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let Config {
+        http_rpc_endpoint,
+        initial_spec_path,
+        snapshot_path,
+        combined_spec_path,
+        use_snapshot_file,
+        pallets,
+        num_workers,
+    } = Config::parse();
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
-    debug!(target: "fork", "get_value response: {}", response);
+    info!(target: "fork",
+        "Running with config: \n\
+        \thttp_rpc_endpoint: {}\n\
+        \tinitial_spec_path: {}\n\
+        \tsnapshot_path: {}\n\
+        \tcombined_spec_path: {}\n\
+        \tuse_snapshot_file: {}\n\
+        \tpallets: {:?}",
+        &http_rpc_endpoint, &initial_spec_path, &snapshot_path, &combined_spec_path, &use_snapshot_file, &pallets
+    );
 
-    response["result"]
-        .as_str()
-        .expect("Not a string")
-        .to_owned()
-}
+    let mut initial_spec: Value = serde_json::from_str(
+        &fs::read_to_string(&initial_spec_path).expect("Could not read chainspec file"),
+    )?;
 
-async fn get_chain_state(
-    http_rpc_endpoint: &str,
-    hashed_prefixes: &[String],
-) -> Vec<(String, String)> {
-    stream::iter(hashed_prefixes.to_owned())
-        .then(|prefix| async move {
-            // collect storage pairs for this prefix
-            let mut pairs = vec![];
-            let mut first_key = get_key(http_rpc_endpoint, &prefix, None).await;
-            debug!(target: "fork", "hashed prefix: {}, first key: {:?}", &prefix, &first_key);
+    assert_ne!(
+        initial_spec["genesis"]["raw"],
+        Value::Null,
+        "The initial provided chainspec must be raw! Make sure you use --raw when generating it."
+    );
+    if !use_snapshot_file {
+        let fetcher = StateFetcher::new(http_rpc_endpoint);
+        let block = fetcher.get_most_recent_block().await;
+        info!("Fetching state at block {:?}", block);
+        let state = fetcher.get_full_state(num_workers).await;
+        save_snapshot_to_file(state, snapshot_path.clone());
+    }
+    let state = read_snapshot_from_file(snapshot_path);
 
-            while let Some(key) = first_key {
-                let value = get_value(http_rpc_endpoint, &key).await;
-                pairs.push((key.clone(), value));
-                first_key = get_key(http_rpc_endpoint, &prefix, Some(&key)).await;
-                debug!(target: "fork", "hashed prefix: {}, next key: {:?}", &prefix, &first_key);
-            }
+    let initial_state: Storage =
+        serde_json::from_value(initial_spec["genesis"]["raw"]["top"].take())
+            .expect("Deserialization of state from given chainspec file failed");
+    let state = combine_states(state, initial_state, pallets);
+    let json_state = serde_json::to_value(state).expect("Failed to convert a storage map to json");
+    initial_spec["genesis"]["raw"]["top"] = json_state;
+    let new_spec = serde_json::to_vec_pretty(&initial_spec)?;
+    info!(target: "fork", "Writing new chainspec to {}", &combined_spec_path);
+    write_to_file(combined_spec_path, &new_spec);
 
-            stream::iter(pairs)
-        })
-        .flatten()
-        .collect()
-        .await
+    info!("Done!");
+    Ok(())
 }
 
 fn write_to_file(write_to_path: String, data: &[u8]) {


### PR DESCRIPTION
Changes to the fork off tool:
-- One block is used as a reference point to download the state
-- The whole state is downloaded and only certain prefixes are replaced from the provided spec
-- The downloaded state is dumped to a file
-- There are workers that allow to parallelize downloading values.