### PR TITLE
Make protocol implicit

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "log",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # client

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -55,12 +55,34 @@ pub fn create_connection(address: &str) -> Connection {
     create_custom_connection(address).expect("Connection should be created")
 }
 
+enum Protocol {
+    WS,
+    WSS,
+}
+
+impl Default for Protocol {
+    fn default() -> Self {
+        Protocol::WS
+    }
+}
+
+impl ToString for Protocol {
+    fn to_string(&self) -> String {
+        match self {
+            Protocol::WS => String::from("ws://"),
+            Protocol::WSS => String::from("wss://"),
+        }
+    }
+}
+
 /// Unless `address` already contains protocol, we prepend to it `ws://`.
 fn ensure_protocol(address: &str) -> String {
-    if address.starts_with("ws://") || address.starts_with("wss://") {
+    if address.starts_with(&Protocol::WS.to_string())
+        || address.starts_with(&Protocol::WSS.to_string())
+    {
         return address.to_string();
     }
-    format!("ws://{}", address)
+    format!("{}{}", Protocol::default().to_string(), address)
 }
 
 pub fn create_custom_connection<Client: FromStr + RpcClient>(

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "log",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "log",

--- a/bin/cliain/src/lib.rs
+++ b/bin/cliain/src/lib.rs
@@ -4,7 +4,7 @@ mod staking;
 mod transfer;
 mod validators;
 
-use aleph_client::{create_connection, Connection, KeyPair, Protocol};
+use aleph_client::{create_connection, Connection, KeyPair};
 pub use keys::{
     prepare as prepare_keys, rotate_keys_command as rotate_keys, set_keys_command as set_keys,
 };
@@ -20,15 +20,13 @@ pub use validators::change as change_validators;
 pub struct ConnectionConfig {
     node_endpoint: String,
     signer_seed: String,
-    protocol: Protocol,
 }
 
 impl ConnectionConfig {
-    pub fn new(node_endpoint: String, signer_seed: String, protocol: Protocol) -> Self {
+    pub fn new(node_endpoint: String, signer_seed: String) -> Self {
         ConnectionConfig {
             node_endpoint,
             signer_seed,
-            protocol,
         }
     }
 }
@@ -37,6 +35,6 @@ impl From<ConnectionConfig> for Connection {
     fn from(cfg: ConnectionConfig) -> Self {
         let key = KeyPair::from_string(&cfg.signer_seed, None)
             .expect("Can't create pair from seed value");
-        create_connection(cfg.node_endpoint.as_str(), cfg.protocol).set_signer(key)
+        create_connection(cfg.node_endpoint.as_str()).set_signer(key)
     }
 }

--- a/bin/cliain/src/main.rs
+++ b/bin/cliain/src/main.rs
@@ -1,4 +1,4 @@
-use aleph_client::{from as parse_to_protocol, KeyPair, Protocol};
+use aleph_client::KeyPair;
 use clap::{Parser, Subcommand};
 use log::{error, info};
 use sp_core::Pair;
@@ -16,10 +16,6 @@ struct Config {
     /// WS endpoint address of the node to connect to
     #[clap(long, default_value = "127.0.0.1:9944")]
     pub node: String,
-
-    /// Protocol to be used for connecting to node (`ws` or `wss`)
-    #[clap(name = "use_ssl", parse(from_flag = parse_to_protocol))]
-    pub protocol: Protocol,
 
     /// The seed of the key to use for signing calls
     /// If not given, an user is prompted to provide seed
@@ -106,7 +102,6 @@ fn main() {
 
     let Config {
         node,
-        protocol,
         seed,
         command,
     } = Config::parse();
@@ -121,7 +116,7 @@ fn main() {
             }
         },
     };
-    let cfg = ConnectionConfig::new(node, seed.clone(), protocol);
+    let cfg = ConnectionConfig::new(node, seed.clone());
     match command {
         Command::ChangeValidators { validators } => change_validators(cfg.into(), validators),
         Command::PrepareKeys => {

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "log",

--- a/e2e-tests/src/config.rs
+++ b/e2e-tests/src/config.rs
@@ -1,17 +1,11 @@
 use clap::Parser;
 
-use aleph_client::{from as parse_to_protocol, Protocol};
-
 #[derive(Debug, Parser, Clone)]
 #[clap(version = "1.0")]
 pub struct Config {
     /// WS endpoint address of the node to connect to
     #[clap(long, default_value = "127.0.0.1:9943")]
     pub node: String,
-
-    /// Protocol to be used for connecting to node (`ws` or `wss`)
-    #[clap(name = "use_ssl", parse(from_flag = parse_to_protocol))]
-    pub protocol: Protocol,
 
     /// seed values to create accounts
     #[clap(long)]

--- a/e2e-tests/src/test/finalization.rs
+++ b/e2e-tests/src/test/finalization.rs
@@ -3,6 +3,6 @@ use aleph_client::{create_connection, wait_for_finalized_block};
 use crate::config::Config;
 
 pub fn finalization(config: &Config) -> anyhow::Result<u32> {
-    let connection = create_connection(&config.node, config.protocol);
+    let connection = create_connection(&config.node);
     wait_for_finalized_block(&connection, 1)
 }

--- a/e2e-tests/src/test/treasury.rs
+++ b/e2e-tests/src/test/treasury.rs
@@ -123,15 +123,12 @@ fn check_treasury_balance(
 
 pub fn treasury_access(config: &Config) -> anyhow::Result<()> {
     let Config {
-        ref node,
-        seeds,
-        protocol,
-        ..
+        ref node, seeds, ..
     } = config;
 
     let proposer = accounts_from_seeds(seeds)[0].clone();
     let beneficiary = AccountId::from(proposer.public());
-    let connection = create_connection(node, *protocol).set_signer(proposer);
+    let connection = create_connection(node).set_signer(proposer);
 
     propose_treasury_spend(10u128, &beneficiary, &connection);
     propose_treasury_spend(100u128, &beneficiary, &connection);

--- a/e2e-tests/src/test/validators_change.rs
+++ b/e2e-tests/src/test/validators_change.rs
@@ -12,16 +12,13 @@ use substrate_api_client::{AccountId, XtStatus};
 
 pub fn change_validators(config: &Config) -> anyhow::Result<()> {
     let Config {
-        ref node,
-        seeds,
-        protocol,
-        ..
+        ref node, seeds, ..
     } = config;
 
     let mut accounts = accounts_from_seeds(seeds);
     let sudo = get_sudo(config);
 
-    let connection = create_connection(node, *protocol).set_signer(sudo);
+    let connection = create_connection(node).set_signer(sudo);
 
     let members_before: Vec<AccountId> = connection
         .get_storage_value("Elections", "Members", None)?

--- a/e2e-tests/src/transfer.rs
+++ b/e2e-tests/src/transfer.rs
@@ -5,15 +5,12 @@ use substrate_api_client::AccountId;
 
 pub fn setup_for_transfer(config: &Config) -> (Connection, KeyPair, AccountId) {
     let Config {
-        ref node,
-        seeds,
-        protocol,
-        ..
+        ref node, seeds, ..
     } = config;
 
     let accounts = accounts_from_seeds(seeds);
     let (from, to) = (accounts[0].clone(), accounts[1].clone());
-    let connection = create_connection(node, *protocol).set_signer(from.clone());
+    let connection = create_connection(node).set_signer(from.clone());
     let to = AccountId::from(to.public());
     (connection, from, to)
 }

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "log",

--- a/flooder/src/config.rs
+++ b/flooder/src/config.rs
@@ -1,4 +1,3 @@
-use aleph_client::{from as parse_to_protocol, Protocol};
 use clap::Parser;
 use std::{fs, path::PathBuf};
 
@@ -8,10 +7,6 @@ pub struct Config {
     /// URL address(es) of the nodes to send transactions to
     #[clap(long, default_value = "127.0.0.1:9944")]
     pub nodes: Vec<String>,
-
-    /// Protocol to be used for connecting to node (`ws` or `wss`)
-    #[clap(name = "use_ssl", parse(from_flag = parse_to_protocol))]
-    pub protocol: Protocol,
 
     /// how many transactions to send
     #[clap(long, default_value = "10000")]

--- a/flooder/src/main.rs
+++ b/flooder/src/main.rs
@@ -1,7 +1,7 @@
 mod config;
 mod ws_rpc_client;
 
-use aleph_client::{create_custom_connection, Protocol};
+use aleph_client::create_custom_connection;
 use clap::Parser;
 use codec::{Compact, Decode, Encode};
 use config::Config;
@@ -76,7 +76,7 @@ fn main() -> Result<(), anyhow::Error> {
         "creating connection-pool: {}ms",
         time_stats.elapsed().as_millis()
     );
-    let pool = create_connection_pool(&config.nodes, threads, config.protocol);
+    let pool = create_connection_pool(&config.nodes, threads);
     info!(
         "connection-pool created: {}ms",
         time_stats.elapsed().as_millis()
@@ -497,7 +497,6 @@ fn send_tx<Call>(
 fn create_connection_pool(
     nodes: &[String],
     threads: usize,
-    protocol: Protocol,
 ) -> Vec<Vec<Api<sr25519::Pair, WsRpcClient>>> {
     repeat(nodes)
         .cycle()
@@ -505,8 +504,7 @@ fn create_connection_pool(
         .map(|urls| {
             urls.iter()
                 .map(|url| {
-                    create_custom_connection(url, protocol)
-                        .expect("it should return initialized connection")
+                    create_custom_connection(url).expect("it should return initialized connection")
                 })
                 .collect()
         })
@@ -551,7 +549,6 @@ mod tests {
         let url = "127.0.0.1:9944".to_string();
         let mut config = Config {
             nodes: vec![url.clone()],
-            protocol: Default::default(),
             transactions: 313,
             phrase: None,
             seed: None,
@@ -566,7 +563,7 @@ mod tests {
             interval_secs: None,
             transactions_in_interval: None,
         };
-        let conn = create_custom_connection(&url, config.protocol).unwrap();
+        let conn = create_custom_connection(&url).unwrap();
 
         let txs_gen = prepare_txs(&config, &conn);
 

--- a/local-tests/send-runtime/Cargo.lock
+++ b/local-tests/send-runtime/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "log",

--- a/local-tests/send-runtime/src/main.rs
+++ b/local-tests/send-runtime/src/main.rs
@@ -1,6 +1,6 @@
 // A minimal tool for sending a setCode extrinsic to some node.
 
-use aleph_client::{create_connection, from as parse_to_protocol, Protocol};
+use aleph_client::create_connection;
 use sp_core::{sr25519, Pair};
 use std::fs;
 use structopt::StructOpt;
@@ -23,10 +23,6 @@ struct Args {
     /// Path to a file with WASM runtime.
     #[structopt(name = "FILE")]
     runtime: String,
-
-    /// Protocol to be used for connecting to node (`ws` or `wss`)
-    #[structopt(name = "use_ssl", parse(from_flag = parse_to_protocol))]
-    protocol: Protocol,
 }
 
 fn main() {
@@ -34,7 +30,7 @@ fn main() {
 
     let runtime = fs::read(args.runtime).expect("File not found");
     let sudo = keypair_from_string(&args.sudo_phrase);
-    let connection = create_connection(&args.url, args.protocol).set_signer(sudo);
+    let connection = create_connection(&args.url).set_signer(sudo);
 
     let call = compose_call!(connection.metadata, "System", "set_code", runtime);
     let tx = compose_extrinsic!(connection, "Sudo", "sudo_unchecked_weight", call, 0_u64);


### PR DESCRIPTION
After some suggestions, we make passing protocol (either `ws` or `wss`) implicit. This means that if you want to connect without ssl, you can either pass a bare address like `127.0.0.1:9943` or `ws://127.0.0.1:9943`. In order to use ssl, pass `wss://127.0.0.1:9943`.