### PR TITLE
fix caching for unit tests workflow

### DIFF
--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -33,7 +33,7 @@ runs:
         echo "SCCACHE_PATH=${{ inputs.sccache-path }}" >> $GITHUB_ENV
 
     - name: Restore cargo cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/bin/
@@ -42,7 +42,8 @@ runs:
           ~/.cargo/git/db/
           target/
           ${{ inputs.cargo-targets }}
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          ${{ inputs.sccache-path }}
+        key: ${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Install sccache for ubuntu-latest
       shell: bash
@@ -56,11 +57,11 @@ runs:
 
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-    - name: Restore sccache
-      uses: actions/cache@v2
-      with:
-        path: ${{ inputs.sccache-path }}
-        key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
+    # - name: Restore sccache
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: ${{ inputs.sccache-path }}
+    #     key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Start sccache server
       shell: bash

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -43,7 +43,7 @@ runs:
           target/
           ${{ inputs.cargo-targets }}
           ${{ inputs.sccache-path }}
-        key: ${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-v1-${{ hashFiles('**/Cargo.lock') }} # bump cache version if you need to clear it, see https://github.com/actions/cache/issues/485 and https://stackoverflow.com/questions/63521430/clear-cache-in-github-actions
 
     - name: Install sccache for ubuntu-latest
       shell: bash

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -57,12 +57,6 @@ runs:
 
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-    # - name: Restore sccache
-    #   uses: actions/cache@v3
-    #   with:
-    #     path: ${{ inputs.sccache-path }}
-    #     key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
-
     - name: Start sccache server
       shell: bash
       run: sccache --start-server

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -45,7 +45,7 @@ jobs:
           command: clippy
           args: -- --no-deps -D warnings
 
-      - name: Stop cache
+      - name: Stop sccache
         uses: ./.github/actions/post-cache
 
       - name: Run Unit Test Suite

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install WASM target
         run: rustup target add wasm32-unknown-unknown
-        
+
       - name: Restore cache
         uses: ./.github/actions/restore-cache
 
@@ -45,14 +45,14 @@ jobs:
           command: clippy
           args: -- --no-deps -D warnings
 
-      - name: Stop sccache
-        uses: ./.github/actions/post-cache
-
       - name: Run Unit Test Suite
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --lib
+
+      - name: Stop sccache
+        uses: ./.github/actions/post-cache
 
       - name: Send Slack Notification
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
# Description

Fixing `Unable to reserve cache with key X, another job may be creating this cache.`
Use one, versioned cache. This will hopefully fix any potential race conditions between different jobs and makes it easy to invalidate cache.

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

## Before
![before](https://user-images.githubusercontent.com/468572/161238995-3b0f1ccd-b449-4ff9-a060-a462c8333cce.jpg)

## After

![after](https://user-images.githubusercontent.com/468572/161239930-37ae996e-999f-41f9-8af6-28cce96a3782.jpg)

