### PR TITLE
conditional compilation of patched rocksdb

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,7 @@
                      useSnappy = false;
                      patchVerifyChecksum = true;
                      patchPath = ./nix/rocksdb.patch;
+                     enableJemalloc = true;
                    }
 }:
 let
@@ -52,11 +53,12 @@ let
        "-DUSE_RTTI=0"
        "-DFORCE_SSE42=1"
        "-DROCKSDB_BUILD_SHARED=0"
+       "-DWITH_JEMALLOC=${if rocksDbOptions.enableJemalloc then "1" else "0"}"
     ];
 
     propagatedBuildInputs = [];
 
-    buildInputs = nixpkgs.lib.optional rocksDbOptions.useSnappy nixpkgs.snappy;
+    buildInputs = nixpkgs.lib.optional rocksDbOptions.useSnappy nixpkgs.snappy ++ nixpkgs.lib.optional rocksDbOptions.enableJemalloc nixpkgs.jemalloc;
   });
 
   # declares a build environment where C and C++ compilers are delivered by the llvm/clang project

--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,7 @@ let
   });
 
   # we use a newer version of rocksdb than the one provided by nixpkgs
-  # we disable all compression algorithms and force to use SSE 4.2 cpu instruction set
+  # we disable all compression algorithms and force it to use SSE 4.2 cpu instruction set
   customRocksdb = nixpkgs.rocksdb.overrideAttrs (_: {
 
     src = builtins.fetchGit {

--- a/default.nix
+++ b/default.nix
@@ -58,7 +58,7 @@ let
 
     propagatedBuildInputs = [];
 
-    buildInputs = nixpkgs.lib.optional rocksDbOptions.useSnappy nixpkgs.snappy ++ nixpkgs.lib.optional rocksDbOptions.enableJemalloc nixpkgs.jemalloc;
+    buildInputs = [nixpkgs.git] ++ nixpkgs.lib.optional rocksDbOptions.useSnappy nixpkgs.snappy ++ nixpkgs.lib.optional rocksDbOptions.enableJemalloc nixpkgs.jemalloc;
   });
 
   # declares a build environment where C and C++ compilers are delivered by the llvm/clang project

--- a/default.nix
+++ b/default.nix
@@ -95,6 +95,7 @@ with nixpkgs; env.mkDerivation rec {
     git
     findutils
     patchelf
+    jemalloc
   ] ++ nixpkgs.lib.optional useCustomRocksDb customRocksdb;
 
   shellHook = ''

--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@
                      patchPath = ./nix/rocksdb.patch;
                      enableJemalloc = true;
                    }
+, rustflags ? "-C target-cpu=native"
 }:
 let
   # this overlay allows us to use a specified version of the rust toolchain
@@ -120,6 +121,7 @@ with nixpkgs; env.mkDerivation rec {
         $BINDGEN_EXTRA_CLANG_ARGS
     "
     ${rocksDbShellHook}
+    export RUSTFLAGS="${rustflags}"
   '';
 
   buildPhase = ''

--- a/nix/rocksdb.patch
+++ b/nix/rocksdb.patch
@@ -1,0 +1,26 @@
+diff --git a/include/rocksdb/transaction_log.h b/include/rocksdb/transaction_log.h
+index 2519f3a58..8bed507ef 100644
+--- a/include/rocksdb/transaction_log.h
++++ b/include/rocksdb/transaction_log.h
+@@ -112,7 +112,7 @@ class TransactionLogIterator {
+     // Default: true
+     bool verify_checksums_;
+ 
+-    ReadOptions() : verify_checksums_(true) {}
++    ReadOptions() : verify_checksums_(false) {}
+ 
+     explicit ReadOptions(bool verify_checksums)
+         : verify_checksums_(verify_checksums) {}
+diff --git a/options/options.cc b/options/options.cc
+index a64e1e7b9..8590efd3d 100644
+--- a/options/options.cc
++++ b/options/options.cc
+@@ -652,7 +652,7 @@ ReadOptions::ReadOptions()
+       readahead_size(0),
+       max_skippable_internal_keys(0),
+       read_tier(kReadAllTier),
+-      verify_checksums(true),
++      verify_checksums(false),
+       fill_cache(true),
+       tailing(false),
+       managed(false),


### PR DESCRIPTION
# Description

It turns off compilation of patched version of rocksdb. By default it uses rocksdb compiled by custom build script by one of our dependencies, librocksdb-sys. In order to use the patched and risky version use: `nix-build --arg useCustomRocksDb true`. You can also choose subset of patches by calling `nix-build --arg useCustomRocksDb true --arg rocksDbOptions '{ version = "6.29.3"; useSnappy = false; patchVerifyChecksum = true; patchPath = ./nix/rocksdb.patch; enableJemalloc = true }'`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Infrastructure updated accordingly
- [ ] I have made corresponding changes to the documentation
- [ ] New documentation created
- [ ] Bump `spec_version` and `transaction_version` if relevant
- [ ] Bump `aleph-client` version if relevant
