### PR TITLE
Add parameter expansion to the hook endpoint

### DIFF
--- a/docker-runtime-hook/entrypoint.sh
+++ b/docker-runtime-hook/entrypoint.sh
@@ -6,8 +6,8 @@ NETRC_CREDS="./_netrc"
 CLIAIN="./cliain"
 SUDO_PHRASE=${RUNTIME_PHRASE}
 
-RPC_ADDR="rpc.dev.azero.dev"
-WS_ADDR="ws.dev.azero.dev"
+RPC_ADDR="${RPC_ENVIRONMENT_ENDPOINT:-rpc.dev.azero.dev}"
+WS_ADDR="${WS_ENVIRONMENT_ENDPOINT:-ws.dev.azero.dev}"
 
 echo -n  $(date +"%d-%b-%y %T") "   Checking runtime version on devnet: "
 OLD_VER=$(curl -sS -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "state_getRuntimeVersion"}' $RPC_ADDR | jq .result.specVersion)


### PR DESCRIPTION
This PR prepares endpoint.sh script of the postsync hook for the feature environments. It let you set WS and RPC endpoint dynamically from the docker env block in the manifest.