### PR TITLE
A0 824 db cache changes and make convinient using payout stakers bench in AWS tests

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -107,6 +107,7 @@ dependencies = [
  "primitives",
  "serde_json",
  "sp-core",
+ "sp-io",
  "sp-runtime",
  "substrate-api-client",
  "thiserror",

--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -107,7 +107,6 @@ dependencies = [
  "primitives",
  "serde_json",
  "sp-core",
- "sp-io",
  "sp-runtime",
  "substrate-api-client",
  "thiserror",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # Substrate dependencies
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", features = ["full_crypto"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13" }
+sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false  }
 pallet-multisig = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
 pallet-staking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
 pallet-treasury = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
@@ -31,6 +31,7 @@ default = ["std"]
 std = [
     "sp-core/std",
     "sp-runtime/std",
+    "sp-io/std",
     "pallet-staking/std",
     "pallet-treasury/std",
     "pallet-aleph/std",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 # Substrate dependencies
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", features = ["full_crypto"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false  }
 pallet-multisig = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
 pallet-staking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
 pallet-treasury = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
@@ -31,7 +30,6 @@ default = ["std"]
 std = [
     "sp-core/std",
     "sp-runtime/std",
-    "sp-io/std",
     "pallet-staking/std",
     "pallet-treasury/std",
     "pallet-aleph/std",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 
@@ -8,6 +8,7 @@ edition = "2021"
 # Substrate dependencies
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", features = ["full_crypto"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13" }
 pallet-multisig = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
 pallet-staking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }
 pallet-treasury = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", default-features = false }

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -163,8 +163,8 @@ pub fn account_from_keypair(keypair: &KeyPair) -> AccountId {
 }
 
 fn storage_key(module: &str, version: &str) -> [u8; 32] {
-    let pallet_name = sp_io::hashing::twox_128(module.as_bytes());
-    let postfix = sp_io::hashing::twox_128(version.as_bytes());
+    let pallet_name = sp_core::hashing::twox_128(module.as_bytes());
+    let postfix = sp_core::hashing::twox_128(version.as_bytes());
     let mut final_key = [0u8; 32];
     final_key[..16].copy_from_slice(&pallet_name);
     final_key[16..].copy_from_slice(&postfix);

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -3,6 +3,7 @@ use std::{thread::sleep, time::Duration};
 use codec::Encode;
 use log::{info, warn};
 use sp_core::{sr25519, Pair, H256};
+use sp_core::storage::StorageKey;
 use sp_runtime::{generic::Header as GenericHeader, traits::BlakeTwo256};
 use substrate_api_client::{
     rpc::ws_client::WsRpcClient, std::error::Error, AccountId, Api, ApiResult, RpcClient,
@@ -159,4 +160,40 @@ pub fn keypair_from_string(seed: &str) -> KeyPair {
 
 pub fn account_from_keypair(keypair: &KeyPair) -> AccountId {
     AccountId::from(keypair.public())
+}
+
+fn storage_key(module: &str, version: &str) -> [u8; 32] {
+    let pallet_name = sp_io::hashing::twox_128(module.as_bytes());
+    let postfix = sp_io::hashing::twox_128(version.as_bytes());
+    let mut final_key = [0u8; 32];
+    final_key[..16].copy_from_slice(&pallet_name);
+    final_key[16..].copy_from_slice(&postfix);
+    final_key
+}
+
+/// Computes hash of given pallet's call. You can use that to pass result to `state.getKeys` RPC call.
+/// * `pallet` name of the pallet
+/// * `call` name of the pallet's call
+///
+/// # Example
+/// ```
+/// let staking_nominate_storage_key = get_storage_key("Staking", "Nominators");
+/// assert_eq!(staking_nominate_storage_key, String::from("5f3e4907f716ac89b6347d15ececedca9c6a637f62ae2af1c7e31eed7e96be04"));
+/// ```
+pub fn get_storage_key(pallet: &str, call: &str) -> String {
+    let bytes = storage_key(pallet, call);
+    let storage_key = StorageKey(bytes.into());
+    hex::encode(storage_key.0)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn given_staking_nominate_call_when_get_storage_key_then_hash_is_correct() {
+        let staking_nominate_storage_key = get_storage_key("Staking", "Nominators");
+        assert_eq!(staking_nominate_storage_key, String::from("5f3e4907f716ac89b6347d15ececedca9c6a637f62ae2af1c7e31eed7e96be04"));
+    }
 }

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -185,15 +185,3 @@ pub fn get_storage_key(pallet: &str, call: &str) -> String {
     let storage_key = StorageKey(bytes.into());
     hex::encode(storage_key.0)
 }
-
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn given_staking_nominate_call_when_get_storage_key_then_hash_is_correct() {
-        let staking_nominate_storage_key = get_storage_key("Staking", "Nominators");
-        assert_eq!(staking_nominate_storage_key, String::from("5f3e4907f716ac89b6347d15ececedca9c6a637f62ae2af1c7e31eed7e96be04"));
-    }
-}

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -107,7 +107,6 @@ dependencies = [
  "primitives",
  "serde_json",
  "sp-core",
- "sp-io",
  "sp-runtime",
  "substrate-api-client",
  "thiserror",

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -77,7 +77,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "once_cell",
  "version_check",
 ]
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -107,6 +107,7 @@ dependencies = [
  "primitives",
  "serde_json",
  "sp-core",
+ "sp-io",
  "sp-runtime",
  "substrate-api-client",
  "thiserror",
@@ -123,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "approx"
@@ -165,9 +166,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -193,9 +194,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
@@ -341,6 +342,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aad2534fad53df1cc12519c5cda696dd3e20e6118a027e24054aea14a0bdcbe"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,18 +394,18 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -384,10 +424,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
@@ -397,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -517,15 +558,15 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
 
 [[package]]
 name = "ed25519"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed12bbf7b5312f8da1c2722bc06d8c6b12c2d86a7fb35a194c7f3e6fc2bbe39"
+checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
 dependencies = [
  "signature",
 ]
@@ -901,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -948,6 +989,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -997,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
+checksum = "6330e8a36bd8c859f3fa6d9382911fbb7147ec39807f63b923933a247240b9ba"
 
 [[package]]
 name = "humantime"
@@ -1048,6 +1095,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,15 +1133,21 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1119,9 +1182,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "libm"
@@ -1189,18 +1252,19 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1275,12 +1339,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -1393,6 +1456,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-format"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+dependencies = [
+ "arrayvec 0.4.12",
+ "itoa 0.4.8",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,18 +1520,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"
@@ -1498,6 +1571,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "pallet-aleph"
@@ -1736,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "payout-stakers"
@@ -1746,11 +1825,13 @@ version = "0.1.0"
 dependencies = [
  "aleph_client",
  "anyhow",
+ "clap",
  "env_logger",
  "hex",
  "log",
  "parity-scale-codec",
  "primitives",
+ "rand 0.8.5",
  "rayon",
  "sp-core",
  "sp-keyring",
@@ -1795,9 +1876,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -1844,19 +1925,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.36"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -1927,7 +2032,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -1966,9 +2071,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1978,22 +2083,21 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -2020,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2138,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 
 [[package]]
 name = "serde"
@@ -2168,7 +2272,7 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -2239,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
@@ -2722,11 +2826,12 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9799e6d412271cb2414597581128b03f3285f260ea49f5363d07df6a332b3e"
+checksum = "7b84a70894df7a73666e0694f44b41a9571625e9546fb58a0818a565d2c7e084"
 dependencies = [
  "Inflector",
+ "num-format",
  "proc-macro2",
  "quote",
  "serde",
@@ -2754,6 +2859,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "strum"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,7 +2879,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -2825,9 +2936,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2854,12 +2965,18 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -2935,18 +3052,18 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.31"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2956,9 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2967,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.22"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -3146,9 +3263,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3156,9 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3171,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3181,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3194,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmi"
@@ -3302,9 +3419,9 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50344758e2f40e3a1fcfc8f6f91aa57b5f8ebd8d27919fe6451f15aaaf9ee608"
+checksum = "7eb5728b8afd3f280a869ce1d4c554ffaed35f45c231fc41bfbd0381bef50317"
 dependencies = [
  "zeroize_derive",
 ]

--- a/benches/payout-stakers/Cargo.toml
+++ b/benches/payout-stakers/Cargo.toml
@@ -11,11 +11,11 @@ primitives = { path = "../../primitives" }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13", features = ["full_crypto"] }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.13" }
 codec = { package = 'parity-scale-codec', version = "2.0.0", features = ['derive'] }
-
+rand="0.8.5"
 substrate-api-client = { git = "https://github.com/Cardinal-Cryptography/substrate-api-client.git", tag = "polkadot-v0.9.13.b2bfc0c3" }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
-
+clap = {version = "3.0.0", features = ["derive"]}
 anyhow = "^1.0"
 env_logger = "0.8"
 log = "0.4"

--- a/benches/payout-stakers/src/main.rs
+++ b/benches/payout-stakers/src/main.rs
@@ -19,8 +19,8 @@ use primitives::{
 use sp_core::crypto::AccountId32;
 
 // testcase parameters
-const NOMINATOR_COUNT: u64 = MAX_NOMINATORS_REWARDED_PER_VALIDATOR as u64;
-const ERAS_TO_WAIT: u64 = 100;
+const NOMINATOR_COUNT: u32 = MAX_NOMINATORS_REWARDED_PER_VALIDATOR;
+const ERAS_TO_WAIT: u32 = 100;
 
 // we need to schedule batches for limited call count, otherwise we'll exhaust a block max weight
 const BOND_CALL_BATCH_LIMIT: usize = 256;
@@ -46,7 +46,7 @@ struct Config {
 
     /// number of testcase validators
     #[clap(long, default_value = "10")]
-    pub validator_count: u64,
+    pub validator_count: u32,
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -67,7 +67,7 @@ fn main() -> Result<(), anyhow::Error> {
     };
 
     env_logger::init();
-    info!("Make sure you have exactly {} nodes run in the background, otherwise you'll see extrinsic send failed errors.", validator_count);
+    warn!("Make sure you have exactly {} nodes run in the background, otherwise you'll see extrinsic send failed errors.", validator_count);
 
     let connection = create_connection(&address).set_signer(sudoer);
     let validators = set_validators(&address, validators_seed_file, validator_count);
@@ -75,15 +75,13 @@ fn main() -> Result<(), anyhow::Error> {
         create_test_validators_and_its_nominators(&connection, validators, validator_count);
     wait_for_eras(&address, &connection, validators_and_its_nominators)?;
 
-    // spam_accounts(&connection);
-
     Ok(())
 }
 
 fn create_test_validators_and_its_nominators(
     connection: &Connection,
     validators: Vec<KeyPair>,
-    validators_count: u64,
+    validators_count: u32,
 ) -> Vec<(KeyPair, Vec<AccountId32>)> {
     validators
         .iter()
@@ -91,7 +89,7 @@ fn create_test_validators_and_its_nominators(
         .map(|(validator_index, validator_pair)| {
             let nominator_accounts = generate_nominator_accounts_with_minimal_bond(
                 &connection,
-                validator_index as u64,
+                validator_index as u32,
                 validators_count,
             );
             let nominee_account = AccountId::from(validator_pair.public());
@@ -102,7 +100,7 @@ fn create_test_validators_and_its_nominators(
         .collect()
 }
 
-pub fn derive_user_account_from_numeric_seed(seed: u64) -> KeyPair {
+pub fn derive_user_account_from_numeric_seed(seed: u32) -> KeyPair {
     trace!("Generating account from numeric seed {}", seed);
     keypair_from_string(&format!("//{}", seed))
 }
@@ -174,7 +172,7 @@ fn nominate_validator(
 fn set_validators(
     address: &str,
     validators_seed_file: Option<String>,
-    validators_count: u64,
+    validators_count: u32,
 ) -> Vec<KeyPair> {
     let validators = match validators_seed_file {
         Some(validators_seed_file) => {
@@ -210,8 +208,8 @@ fn set_validators(
 
 fn generate_nominator_accounts_with_minimal_bond(
     connection: &Connection,
-    validator_number: u64,
-    validators_count: u64,
+    validator_number: u32,
+    validators_count: u32,
 ) -> Vec<AccountId> {
     info!(
         "Generating nominator accounts for validator {}",

--- a/benches/payout-stakers/src/main.rs
+++ b/benches/payout-stakers/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use log::{info, trace};
+use log::{info, trace, warn};
 use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use sp_core::{sr25519::Pair as KeyPair, Pair};

--- a/benches/payout-stakers/src/main.rs
+++ b/benches/payout-stakers/src/main.rs
@@ -1,4 +1,6 @@
+use clap::Parser;
 use log::{info, trace};
+use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use sp_core::{sr25519::Pair as KeyPair, Pair};
 use sp_keyring::AccountKeyring;
@@ -10,33 +12,70 @@ use aleph_client::{
     payout_stakers_and_assert_locked_balance, staking_batch_bond, staking_batch_nominate,
     staking_bond, staking_validate, wait_for_next_era, Connection,
 };
-use primitives::staking::{
-    MAX_NOMINATORS_REWARDED_PER_VALIDATOR, MIN_NOMINATOR_BOND, MIN_VALIDATOR_BOND,
+use primitives::{
+    staking::{MAX_NOMINATORS_REWARDED_PER_VALIDATOR, MIN_NOMINATOR_BOND, MIN_VALIDATOR_BOND},
+    TOKEN,
 };
 use sp_core::crypto::AccountId32;
 
 // testcase parameters
 const NOMINATOR_COUNT: u64 = MAX_NOMINATORS_REWARDED_PER_VALIDATOR as u64;
-const VALIDATOR_COUNT: u64 = 10;
-const ERAS_TO_WAIT: u64 = 10;
+const ERAS_TO_WAIT: u64 = 100;
 
 // we need to schedule batches for limited call count, otherwise we'll exhaust a block max weight
 const BOND_CALL_BATCH_LIMIT: usize = 256;
-const NOMINATE_CALL_BATCH_LIMIT: usize = 192;
+const NOMINATE_CALL_BATCH_LIMIT: usize = 220;
 const TRANSFER_CALL_BATCH_LIMIT: usize = 1024;
 
+#[derive(Debug, Parser, Clone)]
+#[clap(version = "1.0")]
+struct Config {
+    /// WS endpoint address of the node to connect to. Use IP:port syntax, e.g. 127.0.0.1:9944
+    #[clap(long, default_value = "127.0.0.1:9944")]
+    pub address: String,
+
+    /// A path to a file that contains the root account seed.
+    /// If not given, Alice is assumed to be the root.
+    #[clap(long)]
+    pub root_seed_file: Option<String>,
+
+    /// A path to a file that contains seeds of validators, each in a separate line.
+    /// If not given, validators 0, 1, ..., validator_count are assumed
+    #[clap(long)]
+    pub validators_seed_file: Option<String>,
+
+    /// number of testcase validators
+    #[clap(long, default_value = "10")]
+    pub validator_count: u64,
+}
+
 fn main() -> Result<(), anyhow::Error> {
-    let address = "127.0.0.1:9944";
-    let sudoer = AccountKeyring::Alice.pair();
+    let Config {
+        address,
+        root_seed_file,
+        validators_seed_file,
+        validator_count,
+    } = Config::parse();
+
+    let sudoer = match root_seed_file {
+        Some(root_seed_file) => {
+            let root_seed = std::fs::read_to_string(&root_seed_file)
+                .expect(&format!("Failed to read file {}", root_seed_file));
+            keypair_from_string(root_seed.trim())
+        }
+        None => AccountKeyring::Alice.pair(),
+    };
 
     env_logger::init();
-    info!("Make sure you have 10 nodes run in the background, otherwise you'll see extrinsic send failed errors.");
+    info!("Make sure you have exactly {} nodes run in the background, otherwise you'll see extrinsic send failed errors.", validator_count);
 
-    let connection = create_connection(address).set_signer(sudoer);
-    let validators = set_validators(address);
+    let connection = create_connection(&address).set_signer(sudoer);
+    let validators = set_validators(&address, validators_seed_file, validator_count);
     let validators_and_its_nominators =
-        create_test_validators_and_its_nominators(&connection, validators);
-    wait_for_10_eras(address, &connection, validators_and_its_nominators)?;
+        create_test_validators_and_its_nominators(&connection, validators, validator_count);
+    wait_for_eras(&address, &connection, validators_and_its_nominators)?;
+
+    // spam_accounts(&connection);
 
     Ok(())
 }
@@ -44,13 +83,17 @@ fn main() -> Result<(), anyhow::Error> {
 fn create_test_validators_and_its_nominators(
     connection: &Connection,
     validators: Vec<KeyPair>,
+    validators_count: u64,
 ) -> Vec<(KeyPair, Vec<AccountId32>)> {
     validators
         .iter()
         .enumerate()
         .map(|(validator_index, validator_pair)| {
-            let nominator_accounts =
-                generate_nominator_accounts_with_minimal_bond(&connection, validator_index as u64);
+            let nominator_accounts = generate_nominator_accounts_with_minimal_bond(
+                &connection,
+                validator_index as u64,
+                validators_count,
+            );
             let nominee_account = AccountId::from(validator_pair.public());
             info!("Nominating validator {}", nominee_account);
             nominate_validator(&connection, nominator_accounts.clone(), nominee_account);
@@ -59,18 +102,18 @@ fn create_test_validators_and_its_nominators(
         .collect()
 }
 
-pub fn derive_user_account(seed: u64) -> KeyPair {
+pub fn derive_user_account_from_numeric_seed(seed: u64) -> KeyPair {
     trace!("Generating account from numeric seed {}", seed);
     keypair_from_string(&format!("//{}", seed))
 }
 
-fn wait_for_10_eras(
+fn wait_for_eras(
     address: &str,
     connection: &Connection,
     validators_and_its_nominators: Vec<(KeyPair, Vec<AccountId>)>,
 ) -> Result<(), anyhow::Error> {
-    // in order to have over 4k nominators we need to wait around 60 seconds all calls to be processed
-    // that means not all 4k nominators we'll make i to era 1st, hence we need to wait to 2nd era
+    // in order to have over 8k nominators we need to wait around 60 seconds all calls to be processed
+    // that means not all 8k nominators we'll make i to era 1st, hence we need to wait to 2nd era
     wait_for_next_era(connection)?;
     wait_for_next_era(connection)?;
     // then we wait another full era to test rewards
@@ -111,10 +154,11 @@ fn nominate_validator(
     stash_validators_accounts
         .chunks(BOND_CALL_BATCH_LIMIT)
         .for_each(|chunk| {
+            let mut rng = thread_rng();
             staking_batch_bond(
                 connection,
                 chunk,
-                MIN_NOMINATOR_BOND,
+                (rng.gen::<u8>() % 100) as u128 * TOKEN + MIN_NOMINATOR_BOND,
                 RewardDestination::Staked,
             )
         });
@@ -127,10 +171,25 @@ fn nominate_validator(
         .for_each(|chunk| staking_batch_nominate(connection, chunk));
 }
 
-fn set_validators(address: &str) -> Vec<KeyPair> {
-    let validators = (0..VALIDATOR_COUNT)
-        .map(|validator_number| derive_user_account(validator_number))
-        .collect::<Vec<_>>();
+fn set_validators(
+    address: &str,
+    validators_seed_file: Option<String>,
+    validators_count: u64,
+) -> Vec<KeyPair> {
+    let validators = match validators_seed_file {
+        Some(validators_seed_file) => {
+            let validators_seeds = std::fs::read_to_string(&validators_seed_file)
+                .expect(&format!("Failed to read file {}", validators_seed_file));
+            validators_seeds
+                .split("\n")
+                .filter(|seed| !seed.is_empty())
+                .map(keypair_from_string)
+                .collect()
+        }
+        None => (0..validators_count)
+            .map(|validator_number| derive_user_account_from_numeric_seed(validator_number))
+            .collect::<Vec<_>>(),
+    };
     validators.par_iter().for_each(|account| {
         let connection = create_connection(address).set_signer(account.clone());
         let controller_account_id = AccountId::from(account.public());
@@ -142,8 +201,9 @@ fn set_validators(address: &str) -> Vec<KeyPair> {
         );
     });
     validators.par_iter().for_each(|account| {
+        let mut rng = thread_rng();
         let connection = create_connection(address).set_signer(account.clone());
-        staking_validate(&connection, 10, XtStatus::InBlock);
+        staking_validate(&connection, rng.gen::<u8>() % 100, XtStatus::InBlock);
     });
     validators
 }
@@ -151,6 +211,7 @@ fn set_validators(address: &str) -> Vec<KeyPair> {
 fn generate_nominator_accounts_with_minimal_bond(
     connection: &Connection,
     validator_number: u64,
+    validators_count: u64,
 ) -> Vec<AccountId> {
     info!(
         "Generating nominator accounts for validator {}",
@@ -158,8 +219,8 @@ fn generate_nominator_accounts_with_minimal_bond(
     );
     let accounts = (0..NOMINATOR_COUNT)
         .map(|nominator_number| {
-            derive_user_account(
-                VALIDATOR_COUNT + nominator_number + NOMINATOR_COUNT * validator_number,
+            derive_user_account_from_numeric_seed(
+                validators_count + nominator_number + NOMINATOR_COUNT * validator_number,
             )
         })
         .map(|key_pair| AccountId::from(key_pair.public()))
@@ -167,7 +228,7 @@ fn generate_nominator_accounts_with_minimal_bond(
     accounts
         .chunks(TRANSFER_CALL_BATCH_LIMIT)
         .for_each(|chunk| {
-            balances_batch_transfer(connection, chunk.to_vec(), MIN_NOMINATOR_BOND);
+            balances_batch_transfer(connection, chunk.to_vec(), MIN_NOMINATOR_BOND * 10);
         });
     accounts
 }

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -107,6 +107,7 @@ dependencies = [
  "primitives",
  "serde_json",
  "sp-core",
+ "sp-io",
  "sp-runtime",
  "substrate-api-client",
  "thiserror",

--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -27,6 +27,7 @@ POOL_LIMIT=${POOL_LIMIT:-1024}
 PROMETHEUS_ENABLED=${PROMETHEUS_ENABLED:-true}
 TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-false}
 UNIT_CREATION_DELAY=${UNIT_CREATION_DELAY:-300}
+DB_CACHE=${DB_CACHE:-1024}
 
 if [[ "true" == "$PURGE_BEFORE_START" ]]; then
   echo "Purging chain (${CHAIN}) at path ${BASE_PATH}"
@@ -47,6 +48,7 @@ ARGS=(
   --ws-max-connections "${WS_MAX_CONNECTIONS}"
   --unsafe-ws-external --unsafe-rpc-external
   --enable-log-reloading
+  --db-cache "${DB_CACHE}"
 )
 
 if [[ -n "${BOOT_NODES:-}" ]]; then
@@ -106,7 +108,7 @@ if [[ -n "${UNIT_CREATION_DELAY:-}" ]]; then
 fi
 
 if [[ -n "${CUSTOM_ARGS:-}" ]]; then
-  ARGS+=("${CUSTOM_ARGS}")
+  ARGS+=(${CUSTOM_ARGS})
 fi
 
 aleph-node "${ARGS[@]}"

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -32,7 +32,7 @@ pub const DEFAULT_MILLISECS_PER_BLOCK: u64 = 1000;
 #[cfg(feature = "short_session")]
 pub const DEFAULT_SESSION_PERIOD: u32 = 30;
 #[cfg(feature = "short_session")]
-pub const DEFAULT_SESSIONS_PER_ERA: SessionIndex = 3;
+pub const DEFAULT_SESSIONS_PER_ERA: SessionIndex = 5;
 
 // Default values outside testing
 #[cfg(not(feature = "short_session"))]


### PR DESCRIPTION
# Description

This change makes it convenient of using `payout_stakers` with `Aleph-Testnet` (ie, during AWS tests). One can pass now validators seeds, sudo seed, node address from AWS nodes into the `payout_stakers` bench like below, without recompiling binary:
```
RUST_LOG=aleph_e2e_client=info,aleph_client=info,payout_stakers=info,aleph-client=info cargo run --release -- --address 18.197.227.4:9944 --root-seed-file ../../../Aleph-Testnet/accounts/sudo_sk --validators-seed-file ../../../Aleph-Testnet/validator_phrases
```

The other commit in this PR increase `--db-cache` to 1024 (MB), now it is default value which is 128 (MB). There are several reasons to do it:
* 128 MB is small already, nowadays machines have much more RAM available,
* polkadot uses 1024 MB as default in newer substrate versions (https://github.com/paritytech/substrate/blame/polkadot-v0.9.16/client/cli/src/config.rs#L488)
* monobeam recommends even 2000 as minimal sensible value,

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Infrastructure updated accordingly
- [ ] I have made corresponding changes to the documentation
- [ ] New documentation created
- [ ] Bump `spec_version` and `transaction_version` if relevant
- [x] Bump `aleph-client` version if relevant
