### PR TITLE
Chainrunner tweaks

### DIFF
--- a/local-tests/chainrunner/chain.py
+++ b/local-tests/chainrunner/chain.py
@@ -67,7 +67,7 @@ class Chain:
             for i, n in enumerate(nodes):
                 if isinstance(v, Seq):
                     n.flags[k] = v + i
-                elif isinstance(v, list) and len(v) == len(nodes):
+                elif isinstance(v, list) and i < len(v):
                     n.flags[k] = v[i]
                 else:
                     n.flags[k] = v
@@ -79,7 +79,8 @@ class Chain:
         `--my-arg some_val` in the binary call.
         Seq (type alias for int) can be used to specify numerical values that should be different
         for each node. `val=Seq(13)` results in `--val 13` for node0, `--val 14` for node1 and so
-        on."""
+        on.
+        Providing a list of values results in each node being assigned a corresponding value from the list."""
         Chain._set_flags(self.nodes, *args, **kwargs)
 
     def set_flags_validator(self, *args, **kwargs):
@@ -89,7 +90,8 @@ class Chain:
         `--my-arg some_val` in the binary call.
         Seq (type alias for int) can be used to specify numerical values that should be different
         for each node. `val=Seq(13)` results in `--val 13` for node0, `--val 14` for node1 and so
-        on."""
+        on.
+        Providing a list of values results in each node being assigned a corresponding value from the list."""
         Chain._set_flags(self.validator_nodes, *args, **kwargs)
 
     def set_flags_nonvalidator(self, *args, **kwargs):
@@ -99,7 +101,8 @@ class Chain:
         `--my-arg some_val` in the binary call.
         Seq (type alias for int) can be used to specify numerical values that should be different
         for each node. `val=Seq(13)` results in `--val 13` for node0, `--val 14` for node1 and so
-        on."""
+        on.
+        Providing a list of values results in each node being assigned a corresponding value from the list."""
         Chain._set_flags(self.nonvalidator_nodes, *args, **kwargs)
 
     def set_binary(self, binary, nodes=None):

--- a/local-tests/chainrunner/chain.py
+++ b/local-tests/chainrunner/chain.py
@@ -30,7 +30,7 @@ class Chain:
     def __iter__(self):
         return iter(self.nodes)
 
-    def bootstrap(self, binary, validators, nonvalidators=None, **kwargs):
+    def bootstrap(self, binary, validators, nonvalidators=None, raw=True, **kwargs):
         """Bootstrap the chain. `validator_accounts` should be a list of strings.
         Flags `--account-ids`, `--base-path` and `--raw` are added automatically.
         All other flags are taken from kwargs"""
@@ -38,7 +38,9 @@ class Chain:
         cmd = [check_file(binary),
                'bootstrap-chain',
                '--base-path', self.path,
-               '--account-ids', ','.join(validators), '--raw']
+               '--account-ids', ','.join(validators)]
+        if raw:
+            cmd.append('--raw')
         cmd += flags_from_dict(kwargs)
 
         chainspec = op.join(self.path, 'chainspec.json')
@@ -48,6 +50,7 @@ class Chain:
         def account_to_node(account):
             n = Node(binary, chainspec, op.join(self.path, account), self.path)
             n.flags['node-key-file'] = op.join(self.path, account, 'p2p_secret')
+            n.flags['enable-log-reloading'] = True
             return n
 
         self.validator_nodes = [account_to_node(a) for a in validators]
@@ -62,7 +65,12 @@ class Chain:
                 n.flags[k] = True
         for k, v in kwargs.items():
             for i, n in enumerate(nodes):
-                n.flags[k] = v + i if isinstance(v, Seq) else v
+                if isinstance(v, Seq):
+                    n.flags[k] = v + i
+                elif isinstance(v, list) and len(v) == len(nodes):
+                    n.flags[k] = v[i]
+                else:
+                    n.flags[k] = v
 
     def set_flags(self, *args, **kwargs):
         """Set common flags for all nodes.

--- a/local-tests/chainrunner/node.py
+++ b/local-tests/chainrunner/node.py
@@ -98,4 +98,4 @@ class Node:
     def set_log_level(self, target, level):
         """Change log verbosity of the chosen target.
         This method should be called on a running node."""
-        self.rpc('system_addLogFilter', [f'{target}={level}'])
+        return self.rpc('system_addLogFilter', [f'{target}={level}'])

--- a/local-tests/chainrunner/node.py
+++ b/local-tests/chainrunner/node.py
@@ -99,3 +99,17 @@ class Node:
         """Change log verbosity of the chosen target.
         This method should be called on a running node."""
         return self.rpc('system_addLogFilter', [f'{target}={level}'])
+
+    def address(self, port=None):
+        """Get the public address of this node. Returned value is of the form
+        /dns4/localhost/tcp/{PORT}/p2p/{KEY}. This method needs to know node's port -
+        if it's not supplied a as parameter, it must be present in `self.flags`.
+        """
+        if port is None:
+            if 'port' in self.flags:
+                port = self.flags['port']
+            else:
+                return None
+        cmd = [self.binary, 'key', 'inspect-node-key', '--file', op.join(self.path, 'p2p_secret')]
+        output = subprocess.check_output(cmd).decode().strip()
+        return f'/dns4/localhost/tcp/{port}/p2p/{output}'

--- a/local-tests/run_nodes.py
+++ b/local-tests/run_nodes.py
@@ -16,7 +16,7 @@ port = 30334
 ws_port = 9944
 rpc_port = 9933
 
-phrases = ['//Alice', '//Bob', '//Cedric', '//Dick', '//Ezekiel', '//Fanny', '//George', '//Hugo']
+phrases = ['//Alice', '//Bob', '//Charlie', '//Dave', '//Ezekiel', '//Fanny', '//George', '//Hugo']
 keys_dict = generate_keys(binary, phrases)
 keys = list(keys_dict.values())
 nodes = min(nodes, len(phrases))
@@ -34,7 +34,7 @@ chain.set_flags('validator',
                 port=Seq(port),
                 ws_port=Seq(ws_port),
                 rpc_port=Seq(rpc_port),
-                unit_creation_delay=200,
+                unit_creation_delay=500,
                 execution='Native',
                 rpc_cors='all',
                 rpc_methods='Unsafe')

--- a/local-tests/run_nodes.py
+++ b/local-tests/run_nodes.py
@@ -7,29 +7,39 @@
 
 from time import sleep
 
-from chainrunner import Chain, Seq, generate_keys
+from chainrunner import Chain, Seq, generate_keys, check_finalized
 
-NODES = 4
-WORKDIR = '.'
-BINARY = '../target/release/aleph-node'
+nodes = 4
+workdir = '.'
+binary = '../target/release/aleph-node'
+port = 30334
+ws_port = 9944
+rpc_port = 9933
 
 phrases = ['//Alice', '//Bob', '//Cedric', '//Dick', '//Ezekiel', '//Fanny', '//George', '//Hugo']
-keys_dict = generate_keys(BINARY, phrases)
+keys_dict = generate_keys(binary, phrases)
 keys = list(keys_dict.values())
-NODES = min(NODES, len(phrases))
+nodes = min(nodes, len(phrases))
 
-chain = Chain(WORKDIR)
+chain = Chain(workdir)
 
-print(f'Bootstrapping chain for {NODES} nodes')
-chain.bootstrap(BINARY,
-                keys[:NODES],
+print(f'Bootstrapping chain for {nodes} nodes')
+chain.bootstrap(binary,
+                keys[:nodes],
                 chain_type='local')
 chain.set_flags('validator',
-                port=Seq(30334),
-                ws_port=Seq(9944),
-                rpc_port=Seq(9933),
+                'unsafe-ws-external',
+                'unsafe-rpc-external',
+                'no-mdns',
+                port=Seq(port),
+                ws_port=Seq(ws_port),
+                rpc_port=Seq(rpc_port),
                 unit_creation_delay=200,
-                execution='Native')
+                execution='Native',
+                rpc_cors='all',
+                rpc_methods='Unsafe')
+addresses = [n.address() for n in chain]
+chain.set_flags(bootnodes=addresses[0], public_addr=addresses)
 
 print('Starting the chain')
 chain.start('node')
@@ -37,9 +47,6 @@ chain.start('node')
 print('Waiting a minute')
 sleep(60)
 
-print('Blocks seen by nodes:')
-for node in chain:
-    h, f = node.highest_block()
-    print(f'highest:{h} finalized:{f}')
+check_finalized(chain)
 
 print('Exiting script, leaving nodes running in the background')


### PR DESCRIPTION
# Description

Small tweaks in Python chainrunner:
- make raw chainspec an option when boostraping the chain
- allow passing lists of values in set_flags
- improve on-the-fly log verbosity changing
- add address method to node
- make run_nodes.py use the same config flags as run_nodes.sh

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
