### PR TITLE
A0-596: Proper staking accounts setup for local runs

### DIFF
--- a/.github/workflows/deploy-to-devnet.yml
+++ b/.github/workflows/deploy-to-devnet.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           #!/bin/bash
 
-          #setup jq
+          # setup jq
           curl -sS https://webinstall.dev/jq | bash
           export PATH=${HOME}/.local/bin:"$PATH"
 
@@ -70,22 +70,24 @@ jobs:
           COMMIT_ID=${TMP_COMMIT_ID: -7}
           echo $COMMIT_ID
 
-          if aws s3api head-object --bucket alephzero-devnet-eu-central-1-keys-bucket --key forks/chainspec-${COMMIT_ID}.json; then
-            echo "Chainspec exists"
-            aws s3 cp s3://alephzero-devnet-eu-central-1-keys-bucket/forks/chainspec-${COMMIT_ID}.json chainspec.skeleton.json
-          else
-            echo "Chainspec doesn't exist"
+          # sync all validator's keystores from S3
+          aws s3 cp s3://alephzero-devnet-eu-central-1-keys-bucket/data data --recursive
 
-            docker run -i --env RUST_BACKTRACE=1 --entrypoint "/usr/local/bin/aleph-node" public.ecr.aws/p6e8q1z1/aleph-node:${COMMIT_ID} bootstrap-chain --raw --base-path /data --chain-id a0dnet1 --account-ids 5D34dL5prEUaGNQtPPZ3yN5Y6BnkfXunKXXz6fo7ZJbLwRRH,5GBNeWRhZc2jXu7D55rBimKYDk8PGk8itRYFTPfC8RJLKG5o,5Dfis6XL8J2P6JHUnUtArnFWndn62SydeP8ee8sG2ky9nfm9,5F4H97f7nQovyrbiq4ZetaaviNwThSVcFobcA5aGab6167dK,5DiDShBWa1fQx6gLzpf3SFBhMinCoyvHM1BWjPNsmXS8hkrW,5EFb84yH9tpcFuiKUcsmdoF7xeeY3ajG1ZLQimxQoFt9HMKR,5DZLHESsfGrJ5YzT3HuRPXsSNb589xQ4Unubh1mYLodzKdVY,5GHJzqvG6tXnngCpG7B12qjUvbo5e4e9z8Xjidk3CQZHxTPZ,5CUnSsgAyLND3bxxnfNhgWXSe9Wn676JzLpGLgyJv858qhoX,5CVKn7HAZW1Ky4r7Vkgsr7VEW88C2sHgUNDiwHY9Ct2hjU8q --sudo-account-id 5F4SvwaUEQubiqkPF8YnRfcN77cLsT2DfG4vFeQmSXNjR7hD > chainspec.skeleton.json
+          # rename validator paths
+          declare -A NAMES=([aleph-node-validator-0]=5D34dL5prEUaGNQtPPZ3yN5Y6BnkfXunKXXz6fo7ZJbLwRRH [aleph-node-validator-1]=5GBNeWRhZc2jXu7D55rBimKYDk8PGk8itRYFTPfC8RJLKG5o [aleph-node-validator-2]=5Dfis6XL8J2P6JHUnUtArnFWndn62SydeP8ee8sG2ky9nfm9 [aleph-node-validator-3]=5F4H97f7nQovyrbiq4ZetaaviNwThSVcFobcA5aGab6167dK [aleph-node-validator-4]=5DiDShBWa1fQx6gLzpf3SFBhMinCoyvHM1BWjPNsmXS8hkrW [aleph-node-validator-5]=5EFb84yH9tpcFuiKUcsmdoF7xeeY3ajG1ZLQimxQoFt9HMKR [aleph-node-validator-6]=5DZLHESsfGrJ5YzT3HuRPXsSNb589xQ4Unubh1mYLodzKdVY [aleph-node-validator-7]=5GHJzqvG6tXnngCpG7B12qjUvbo5e4e9z8Xjidk3CQZHxTPZ [aleph-node-validator-8]=5CUnSsgAyLND3bxxnfNhgWXSe9Wn676JzLpGLgyJv858qhoX [aleph-node-validator-9]=5CVKn7HAZW1Ky4r7Vkgsr7VEW88C2sHgUNDiwHY9Ct2hjU8q)
 
-            aws s3 cp chainspec.skeleton.json s3://alephzero-devnet-eu-central-1-keys-bucket/forks/chainspec-${COMMIT_ID}.json
-          fi
+          for NAME in "${!NAMES[@]}"; do
+            mv -v data/$NAME data/${NAMES[$NAME]}
+          done
 
-          docker run -i -v $(pwd):/app public.ecr.aws/p6e8q1z1/fork-off:latest --http-rpc-endpoint=https://rpc.test.azero.dev --initial-spec-path=chainspec.skeleton.json --combined-spec-path=chainspec.json
+          # generate chainspec, it will reuse keys from the synced keystore
+          docker run -i -v $(pwd)/data:/data --env RUST_BACKTRACE=1 --entrypoint "/usr/local/bin/aleph-node" public.ecr.aws/p6e8q1z1/aleph-node:${COMMIT_ID} bootstrap-chain --raw --base-path /data --chain-id a0dnet1 --account-ids 5D34dL5prEUaGNQtPPZ3yN5Y6BnkfXunKXXz6fo7ZJbLwRRH,5GBNeWRhZc2jXu7D55rBimKYDk8PGk8itRYFTPfC8RJLKG5o,5Dfis6XL8J2P6JHUnUtArnFWndn62SydeP8ee8sG2ky9nfm9,5F4H97f7nQovyrbiq4ZetaaviNwThSVcFobcA5aGab6167dK,5DiDShBWa1fQx6gLzpf3SFBhMinCoyvHM1BWjPNsmXS8hkrW,5EFb84yH9tpcFuiKUcsmdoF7xeeY3ajG1ZLQimxQoFt9HMKR,5DZLHESsfGrJ5YzT3HuRPXsSNb589xQ4Unubh1mYLodzKdVY,5GHJzqvG6tXnngCpG7B12qjUvbo5e4e9z8Xjidk3CQZHxTPZ,5CUnSsgAyLND3bxxnfNhgWXSe9Wn676JzLpGLgyJv858qhoX,5CVKn7HAZW1Ky4r7Vkgsr7VEW88C2sHgUNDiwHY9Ct2hjU8q --sudo-account-id 5F4SvwaUEQubiqkPF8YnRfcN77cLsT2DfG4vFeQmSXNjR7hD > chainspec.skeleton.json
+
+          docker run -i -v $(pwd):/app public.ecr.aws/p6e8q1z1/fork-off:latest --http-rpc-endpoint=https://rpc.test.azero.dev --initial-spec-path=chainspec.skeleton.json --combined-spec-path=chainspec.json --pallets-keep-state=Aura,Aleph,Sudo,Staking,Session,Elections
 
           aws s3 cp chainspec.json s3://alephzero-devnet-eu-central-1-keys-bucket/chainspec.json
 
-          #stop and clean devnet
+          # stop and clean devnet
 
           aws eks --region eu-central-1 update-kubeconfig --name alephzero-devnet-eu-central-1-eks
 
@@ -110,7 +112,7 @@ jobs:
 
           kustomize edit add resource send-runtime-hook.yaml
           kustomize build . | kubectl apply -f -
-          
+
       - name: GIT | Commit changes to aleph-apps repository.
         uses: EndBug/add-and-commit@v5.1.0
         with:

--- a/.github/workflows/deploy-to-devnet.yml
+++ b/.github/workflows/deploy-to-devnet.yml
@@ -83,7 +83,7 @@ jobs:
           # generate chainspec, it will reuse keys from the synced keystore
           docker run -i -v $(pwd)/data:/data --env RUST_BACKTRACE=1 --entrypoint "/usr/local/bin/aleph-node" public.ecr.aws/p6e8q1z1/aleph-node:${COMMIT_ID} bootstrap-chain --raw --base-path /data --chain-id a0dnet1 --account-ids 5D34dL5prEUaGNQtPPZ3yN5Y6BnkfXunKXXz6fo7ZJbLwRRH,5GBNeWRhZc2jXu7D55rBimKYDk8PGk8itRYFTPfC8RJLKG5o,5Dfis6XL8J2P6JHUnUtArnFWndn62SydeP8ee8sG2ky9nfm9,5F4H97f7nQovyrbiq4ZetaaviNwThSVcFobcA5aGab6167dK,5DiDShBWa1fQx6gLzpf3SFBhMinCoyvHM1BWjPNsmXS8hkrW,5EFb84yH9tpcFuiKUcsmdoF7xeeY3ajG1ZLQimxQoFt9HMKR,5DZLHESsfGrJ5YzT3HuRPXsSNb589xQ4Unubh1mYLodzKdVY,5GHJzqvG6tXnngCpG7B12qjUvbo5e4e9z8Xjidk3CQZHxTPZ,5CUnSsgAyLND3bxxnfNhgWXSe9Wn676JzLpGLgyJv858qhoX,5CVKn7HAZW1Ky4r7Vkgsr7VEW88C2sHgUNDiwHY9Ct2hjU8q --sudo-account-id 5F4SvwaUEQubiqkPF8YnRfcN77cLsT2DfG4vFeQmSXNjR7hD > chainspec.skeleton.json
 
-          docker run -i -v $(pwd):/app public.ecr.aws/p6e8q1z1/fork-off:latest --http-rpc-endpoint=https://rpc.test.azero.dev --initial-spec-path=chainspec.skeleton.json --combined-spec-path=chainspec.json --pallets-keep-state=Aura,Aleph,Sudo,Staking,Session,Elections
+          docker run -i -v $(pwd):/app public.ecr.aws/p6e8q1z1/fork-off:latest --http-rpc-endpoint=https://rpc.test.azero.dev --initial-spec-path=chainspec.skeleton.json --combined-spec-path=chainspec.json --pallets-keep-state=Aura,Aleph,Sudo,Staking,Session,Elections,Balances
 
           aws s3 cp chainspec.json s3://alephzero-devnet-eu-central-1-keys-bucket/chainspec.json
 

--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -1,6 +1,6 @@
 use aleph_primitives::{
     staking::{MIN_NOMINATOR_BOND, MIN_VALIDATOR_BOND},
-    AuthorityId as AlephId, ADDRESSES_ENCODING, TOKEN_DECIMALS,
+    AuthorityId as AlephId, ADDRESSES_ENCODING, TOKEN, TOKEN_DECIMALS,
 };
 use aleph_runtime::{
     AccountId, AuraConfig, BalancesConfig, ElectionsConfig, GenesisConfig, Perbill, SessionConfig,
@@ -13,7 +13,7 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Number, Value};
 use sp_application_crypto::Ss58Codec;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{Pair, Public};
+use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use std::{collections::HashSet, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
@@ -201,28 +201,38 @@ fn system_properties(token_symbol: String) -> serde_json::map::Map<String, Value
     .collect()
 }
 
-pub fn devnet_config(
-    chain_params: ChainParams,
-    authorities: Vec<AuthorityKeys>,
-) -> Result<ChainSpec, String> {
-    // TODO fix it properly so there's a default configuration for distinct stash and controller
-    // accounts, and linked controller accounts with validators
-    // for now it's better to leave it as empty not to imply (not advised) initial staking configuration
-    // in which stash == controller == validator
-    generate_chain_spec_config(chain_params, authorities, vec![])
-}
-
+/// Generate chain spec.
 pub fn config(
     chain_params: ChainParams,
     authorities: Vec<AuthorityKeys>,
 ) -> Result<ChainSpec, String> {
-    generate_chain_spec_config(chain_params, authorities, vec![])
+    generate_chain_spec_config(chain_params, authorities, None, None)
+}
+
+/// Generate chain spec for local runs.
+/// Stash and controller accounts are generated for the specified authorities.
+pub fn local_config(
+    chain_params: ChainParams,
+    authorities: Vec<AuthorityKeys>,
+) -> Result<ChainSpec, String> {
+    let authority_accounts: Vec<AccountId> = to_account_ids(&authorities).collect();
+    let controller_accounts: Vec<AccountId> =
+        generate_staking_accounts(authority_accounts.clone(), StakingAccount::Controller);
+    let stash_accounts: Vec<AccountId> =
+        generate_staking_accounts(authority_accounts, StakingAccount::Stash);
+    generate_chain_spec_config(
+        chain_params,
+        authorities,
+        Some(controller_accounts),
+        Some(stash_accounts),
+    )
 }
 
 fn generate_chain_spec_config(
     chain_params: ChainParams,
     authorities: Vec<AuthorityKeys>,
-    stakers: Vec<AccountId>,
+    controller_accounts: Option<Vec<AccountId>>,
+    stash_accounts: Option<Vec<AccountId>>,
 ) -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
     let token_symbol = String::from(chain_params.token_symbol());
@@ -244,7 +254,8 @@ fn generate_chain_spec_config(
                 authorities.clone(), // Initial PoA authorities, will receive funds
                 sudo_account.clone(), // Sudo account, will also be pre funded
                 faucet_account.clone(), // Pre-funded faucet account
-                stakers.clone(),
+                controller_accounts.clone(), // Controller accounts for staking.
+                stash_accounts.clone(), // Stash accounts for staking.
             )
         },
         // Bootnodes
@@ -266,13 +277,44 @@ fn deduplicate(accounts: Vec<AccountId>) -> Vec<AccountId> {
     set.into_iter().collect()
 }
 
-/// Configure initial storage state for FRAME modules
+/// Type of staking account: stash or controller.
+enum StakingAccount {
+    Controller,
+    Stash,
+}
+
+/// Given a set of accounts and an account type returns the corresponding staking accounts.
+fn generate_staking_accounts(
+    accounts: Vec<AccountId>,
+    account_type: StakingAccount,
+) -> Vec<AccountId> {
+    let account_suffix = match account_type {
+        StakingAccount::Controller => "Controller",
+        StakingAccount::Stash => "Stash",
+    };
+    accounts
+        .into_iter()
+        .enumerate()
+        .map(|(index, _account)| {
+            get_account_id_from_seed::<sr25519::Public>(
+                format!("//{}//{}", index, account_suffix).as_str(),
+            )
+        })
+        .collect()
+}
+
+// to have total issuance 300M (for devnet/tests/local runs only)
+const ENDOWMENT: u128 = 60_000_000u128 * 10u128.pow(TOKEN_DECIMALS);
+
+/// Configure initial storage state for FRAME modules.
+/// Possible to provide distinct controller and stash accounts.
 fn generate_genesis_config(
     wasm_binary: &[u8],
     authorities: Vec<AuthorityKeys>,
     sudo_account: AccountId,
     faucet_account: Option<AccountId>,
-    stakers: Vec<AccountId>,
+    controller_accounts: Option<Vec<AccountId>>,
+    stash_accounts: Option<Vec<AccountId>>,
 ) -> GenesisConfig {
     let special_accounts = match faucet_account {
         Some(faucet_id) => vec![sudo_account.clone(), faucet_id],
@@ -285,37 +327,62 @@ fn generate_genesis_config(
     let unique_accounts: Vec<AccountId> = deduplicate(
         to_account_ids(&authorities)
             .chain(special_accounts)
-            .chain(stakers.iter().cloned())
             .collect(),
     );
 
-    // to have total issuance 300M (for devnet/tests/local runs only)
-    const ENDOWMENT: u128 = 60_000_000u128 * 10u128.pow(TOKEN_DECIMALS);
+    let unique_accounts_balances = unique_accounts
+        .into_iter()
+        .map(|account| (account, ENDOWMENT));
 
-    GenesisConfig {
-        system: SystemConfig {
-            // Add Wasm runtime to storage.
-            code: wasm_binary.to_vec(),
-        },
-        balances: BalancesConfig {
-            // Configure endowed accounts with an initial, significant balance
-            balances: unique_accounts
+    let (balances, members, keys, stakers) = match (controller_accounts, stash_accounts) {
+        (Some(controllers), Some(stashes)) => {
+            let balances: Vec<(AccountId, u128)> = unique_accounts_balances
+                .chain(
+                    controllers
+                        .clone()
+                        .into_iter()
+                        .map(|account| (account, TOKEN)),
+                )
+                .chain(
+                    stashes
+                        .clone()
+                        .into_iter()
+                        .map(|account| (account, MIN_VALIDATOR_BOND + TOKEN)),
+                )
+                .collect();
+            let members = stashes.clone();
+            let keys = authorities
+                .iter()
+                .zip(stashes.clone())
+                .map(|(auth, stash)| {
+                    (
+                        stash.clone(),
+                        stash,
+                        SessionKeys {
+                            aura: auth.aura_key.clone(),
+                            aleph: auth.aleph_key.clone(),
+                        },
+                    )
+                })
+                .collect();
+            let stakers = stashes
                 .into_iter()
-                .map(|account| (account, ENDOWMENT))
-                .collect(),
-        },
-        aura: AuraConfig {
-            authorities: vec![],
-        },
-        sudo: SudoConfig {
-            // Assign network admin rights.
-            key: sudo_account,
-        },
-        elections: ElectionsConfig {
-            members: to_account_ids(&authorities).collect(),
-        },
-        session: SessionConfig {
-            keys: authorities
+                .zip(controllers)
+                .map(|(stash, controller)| {
+                    (
+                        stash,
+                        controller,
+                        MIN_VALIDATOR_BOND,
+                        StakerStatus::Validator,
+                    )
+                })
+                .collect();
+            (balances, members, keys, stakers)
+        }
+        (_, _) => {
+            let balances = unique_accounts_balances.collect();
+            let members = to_account_ids(&authorities).collect();
+            let keys = authorities
                 .iter()
                 .map(|auth| {
                     (
@@ -327,26 +394,40 @@ fn generate_genesis_config(
                         },
                     )
                 })
-                .collect(),
+                .collect();
+            let stakers = vec![];
+            (balances, members, keys, stakers)
+        }
+    };
+
+    GenesisConfig {
+        system: SystemConfig {
+            // Add Wasm runtime to storage.
+            code: wasm_binary.to_vec(),
         },
+        balances: BalancesConfig {
+            // Configure endowed accounts with an initial, significant balance
+            balances,
+        },
+        aura: AuraConfig {
+            authorities: vec![],
+        },
+        sudo: SudoConfig {
+            // Assign network admin rights.
+            key: sudo_account,
+        },
+        elections: ElectionsConfig {
+            members: members.clone(),
+        },
+        session: SessionConfig { keys },
         staking: StakingConfig {
             force_era: Forcing::NotForcing,
             validator_count: authorities.len() as u32,
             // to satisfy some e2e tests as this cannot be changed during runtime
             minimum_validator_count: 4,
-            invulnerables: to_account_ids(&authorities).collect(),
+            invulnerables: members,
             slash_reward_fraction: Perbill::from_percent(10),
-            stakers: stakers
-                .into_iter()
-                .map(|account_id| {
-                    (
-                        account_id.clone(),
-                        account_id,
-                        MIN_VALIDATOR_BOND,
-                        StakerStatus::Validator,
-                    )
-                })
-                .collect(),
+            stakers,
             min_validator_bond: MIN_VALIDATOR_BOND,
             min_nominator_bond: MIN_NOMINATOR_BOND,
             ..Default::default()

--- a/bin/node/src/commands.rs
+++ b/bin/node/src/commands.rs
@@ -122,7 +122,7 @@ pub struct BootstrapChainCmd {
 
 impl BootstrapChainCmd {
     pub fn run(&self) -> Result<(), Error> {
-        let genesis_authorities: Vec<AuthorityKeys> = self
+        let genesis_authorities = self
             .chain_params
             .account_ids()
             .iter()

--- a/bin/node/src/commands.rs
+++ b/bin/node/src/commands.rs
@@ -37,7 +37,7 @@ fn aleph_key(keystore: &impl SyncCryptoStore) -> AlephId {
         .into()
 }
 
-/// Returns peer id, if not p2p key found under base_path/account-id/node-key-file a new provate key gets generated
+/// Returns peer id, if not p2p key found under base_path/account-id/node-key-file a new private key gets generated
 fn p2p_key(chain_params: &ChainParams, account_id: &AccountId) -> SerializablePeerId {
     let authority = account_id.to_string();
     let file = chain_params
@@ -122,7 +122,7 @@ pub struct BootstrapChainCmd {
 
 impl BootstrapChainCmd {
     pub fn run(&self) -> Result<(), Error> {
-        let genesis_authorities = self
+        let genesis_authorities: Vec<AuthorityKeys> = self
             .chain_params
             .account_ids()
             .iter()
@@ -132,8 +132,8 @@ impl BootstrapChainCmd {
             })
             .collect();
 
-        let chain_spec = match self.is_devnet() {
-            true => chain_spec::devnet_config(self.chain_params.clone(), genesis_authorities)?,
+        let chain_spec = match self.is_local_run() {
+            true => chain_spec::local_config(self.chain_params.clone(), genesis_authorities)?,
             false => chain_spec::config(self.chain_params.clone(), genesis_authorities)?,
         };
 
@@ -145,7 +145,7 @@ impl BootstrapChainCmd {
         Ok(())
     }
 
-    fn is_devnet(&self) -> bool {
+    fn is_local_run(&self) -> bool {
         self.chain_params.chain_id() == DEFAULT_CHAIN_ID
     }
 }

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "hex",

--- a/fork-off/src/main.rs
+++ b/fork-off/src/main.rs
@@ -40,7 +40,7 @@ pub struct Config {
     #[clap(long, default_value_t = 5)]
     pub num_workers: u32,
 
-    /// which modules to set in forked spec
+    /// which modules to keep in forked spec
     #[clap(
         long,
         multiple_occurrences = true,


### PR DESCRIPTION
# Description

This introduces a setup in which we have separate stash and controller accounts for local runs. The final effect is that _validator_, _stash_ and _controller_ are distinct accounts. The _e2e_ test setup remains unchanged with an implicit assumption that _validator_ == _stash_ == _controller_.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Infrastructure updated accordingly
- [ ] I have made corresponding changes to the documentation
- [ ] New documentation created
- [ ] Bump `spec_version` and `transaction_version` if relevant
- [ ] Bump `aleph-client` version if relevant
