### PR TITLE
Disable treasury proposals

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -527,9 +527,9 @@ pub const TREASURY_BURN: u32 = 0;
 // The percentage of the amount of the proposal that the proposer should deposit.
 // We agreed on non-progressive deposit.
 pub const TREASURY_PROPOSAL_BOND: u32 = 0;
-// The proposer should deposit max{`TREASURY_PROPOSAL_BOND`% of the proposal value, 1B tokens}.
+// The proposer should deposit max{`TREASURY_PROPOSAL_BOND`% of the proposal value, 100B tokens}.
 // This should effectively block making proposals.
-pub const TREASURY_MINIMUM_BOND: Balance = 1_000_000_000_000_000_000_000;
+pub const TREASURY_MINIMUM_BOND: Balance = 100_000_000_000_000_000_000_000;
 // Every 4h we implement accepted proposals.
 pub fn treasury_spend_period() -> BlockNumber {
     hours_as_block_num(4)

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -25,11 +25,6 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
-use frame_support::sp_runtime::Perquintill;
-use frame_support::traits::EqualPrivilegeOnly;
-use frame_support::traits::SortedMembers;
-use frame_support::weights::constants::WEIGHT_PER_MILLIS;
-use frame_support::PalletId;
 pub use frame_support::{
     construct_runtime, parameter_types,
     traits::{
@@ -41,6 +36,12 @@ pub use frame_support::{
         IdentityFee, Weight,
     },
     StorageValue,
+};
+use frame_support::{
+    sp_runtime::Perquintill,
+    traits::{EqualPrivilegeOnly, SortedMembers},
+    weights::constants::WEIGHT_PER_MILLIS,
+    PalletId,
 };
 use frame_system::{EnsureRoot, EnsureSignedBy};
 pub use primitives::Balance;
@@ -526,8 +527,9 @@ pub const TREASURY_BURN: u32 = 0;
 // The percentage of the amount of the proposal that the proposer should deposit.
 // We agreed on non-progressive deposit.
 pub const TREASURY_PROPOSAL_BOND: u32 = 0;
-// The proposer should deposit max{`TREASURY_PROPOSAL_BOND`% of the proposal value, $10}.
-pub const TREASURY_MINIMUM_BOND: Balance = 1000 * CENTS;
+// The proposer should deposit max{`TREASURY_PROPOSAL_BOND`% of the proposal value, 1B tokens}.
+// This should effectively block making proposals.
+pub const TREASURY_MINIMUM_BOND: Balance = 1_000_000_000_000_000_000_000;
 // Every 4h we implement accepted proposals.
 pub fn treasury_spend_period() -> BlockNumber {
     hours_as_block_num(4)

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 11,
+    spec_version: 12,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,


### PR DESCRIPTION
# Description

For initial phase we don't want users to make proposals to the treasury and become exposed to slashing funds. Thus we increase the deposit value to an unachievable level.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] Bump `spec_version` and `transaction_version` if relevant


![const](https://user-images.githubusercontent.com/27450471/165072530-338c2911-1b3c-420a-b883-1687c82c3152.png)
![propo](https://user-images.githubusercontent.com/27450471/165072533-4bbc349a-078d-471e-8080-9fdf9163c3e2.png)
