### PR TITLE
Stick with 1.23.6 version of kubectl.

### DIFF
--- a/.github/workflows/deploy-to-devnet.yml
+++ b/.github/workflows/deploy-to-devnet.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Setup kubectl
         uses: azure/setup-kubectl@v2.0
+        with:
+          version: 'v1.23.6'
 
       - name: Run fork-off update
         env:


### PR DESCRIPTION
Fix for:
`error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"`
because of bug in aws-cli: https://github.com/aws/aws-cli/issues/6920