### PR TITLE
A0-873: Vesting module for `aleph-client`

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
+ "pallet-vesting",
  "parity-scale-codec",
  "primitives",
  "serde_json",
@@ -1602,6 +1603,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-vesting"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,7 +2938,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "hex",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 [dependencies]

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -14,6 +14,7 @@ pallet-staking = { git = "https://github.com/paritytech/substrate.git", branch =
 pallet-treasury = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19", default-features = false }
 pallet-aleph = { path = "../pallets/aleph", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19", default-features = false }
+pallet-vesting = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19", default-features = false }
 primitives = { path = "../primitives", default-features = false }
 
 # other dependencies
@@ -35,4 +36,5 @@ std = [
     "primitives/std",
     "pallet-balances/std",
     "pallet-multisig/std",
+    "pallet-vesting/std",
 ]

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -180,7 +180,9 @@ fn storage_key(module: &str, version: &str) -> [u8; 32] {
 /// * `call` name of the pallet's call
 ///
 /// # Example
-/// ```
+/// ```no_run
+/// use aleph_client::get_storage_key;
+///
 /// let staking_nominate_storage_key = get_storage_key("Staking", "Nominators");
 /// assert_eq!(staking_nominate_storage_key, String::from("5f3e4907f716ac89b6347d15ececedca9c6a637f62ae2af1c7e31eed7e96be04"));
 /// ```

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -180,7 +180,7 @@ fn storage_key(module: &str, version: &str) -> [u8; 32] {
 /// * `call` name of the pallet's call
 ///
 /// # Example
-/// ```no_run
+/// ```
 /// use aleph_client::get_storage_key;
 ///
 /// let staking_nominate_storage_key = get_storage_key("Staking", "Nominators");

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -2,8 +2,7 @@ use std::{thread::sleep, time::Duration};
 
 use codec::Encode;
 use log::{info, warn};
-use sp_core::{sr25519, Pair, H256};
-use sp_core::storage::StorageKey;
+use sp_core::{sr25519, storage::StorageKey, Pair, H256};
 use sp_runtime::{generic::Header as GenericHeader, traits::BlakeTwo256};
 use substrate_api_client::{
     rpc::ws_client::WsRpcClient, std::error::Error, AccountId, Api, ApiResult, RpcClient,
@@ -34,6 +33,10 @@ pub use system::set_code;
 pub use transfer::{
     batch_transfer as balances_batch_transfer, transfer as balances_transfer, TransferTransaction,
 };
+pub use vesting::{
+    get_schedules, merge_schedules, vest, vest_other, vested_transfer, VestingError,
+    VestingSchedule,
+};
 pub use waiting::{wait_for_event, wait_for_finalized_block};
 
 mod account;
@@ -45,6 +48,7 @@ mod session;
 mod staking;
 mod system;
 mod transfer;
+mod vesting;
 mod waiting;
 
 pub trait FromStr: Sized {

--- a/aleph-client/src/vesting.rs
+++ b/aleph-client/src/vesting.rs
@@ -1,4 +1,4 @@
-use anyhow::Result as AnyResult;
+use anyhow::{ensure, Result as AnyResult};
 use log::info;
 pub use pallet_vesting::VestingInfo;
 use sp_core::Pair;
@@ -14,45 +14,49 @@ use crate::{account_from_keypair, try_send_xt, AccountId, BlockNumber, Connectio
 pub enum VestingError {
     #[error("🦺❌ Account has no active vesting schedules.")]
     NotVesting,
+    #[error("🦺❌ The connection should be signed.")]
+    UnsignedConnection,
 }
 
 pub type VestingSchedule = VestingInfo<Balance, BlockNumber>;
 
 const PALLET: &str = "Vesting";
 
-/// Calls `pallet_vesting::vest` for `who`, i.e. makes all unlocked balances transferable.
+/// Checks whether `connection` is signed. If so, returns the signer keypair.
+fn ensure_signed(connection: &Connection) -> AnyResult<KeyPair> {
+    let maybe_signer = connection.signer.clone();
+    ensure!(maybe_signer.is_some(), VestingError::UnsignedConnection);
+    Ok(maybe_signer.expect("Must be `Some(_)`: just checked."))
+}
+
+/// Calls `pallet_vesting::vest` for the signer of `connection`, i.e. makes all unlocked balances
+/// transferable.
 ///
-/// Does not expect `connection` to be signed. Fails if transaction could not have been sent.
+/// Fails if `connection` is unsigned or transaction could not have been sent.
 ///
 /// *Note*: This function returns `Ok(_)` even if the account has no active vesting schedules
 /// and thus the extrinsic was not successful. However, semantically it is still correct.
-pub fn vest(connection: Connection, who: KeyPair) -> AnyResult<()> {
-    // Ensure that we make a call as `account`.
-    let connection = connection.set_signer(who.clone());
+pub fn vest(connection: Connection) -> AnyResult<()> {
+    let vester = ensure_signed(&connection)?;
     let xt = compose_extrinsic!(connection, PALLET, "vest");
     let block_hash = try_send_xt(&connection, xt, Some("Vesting"), Finalized)?
         .expect("For `Finalized` status a block hash should be returned");
     info!(
         target: "aleph-client", "Vesting for the account {:?}. Finalized in block {:?}",
-        account_from_keypair(&who), block_hash
+        account_from_keypair(&vester), block_hash
     );
     Ok(())
 }
 
-/// Calls `pallet_vesting::vest_other` by `caller` on behalf of `vest_account`, i.e. makes all
-/// unlocked balances of `vest_account` transferable.
+/// Calls `pallet_vesting::vest_other` by the signer of `connection` on behalf of `vest_account`,
+/// i.e. makes all unlocked balances of `vest_account` transferable.
 ///
-/// Does not expect `connection` to be signed. Fails if transaction could not have been sent.
+/// Fails if `connection` is not signed or transaction could not have been sent.
 ///
 /// *Note*: This function returns `Ok(_)` even if the account has no active vesting schedules
 /// and thus the extrinsic was not successful. However, semantically it is still correct.
-pub fn vest_other(
-    connection: Connection,
-    caller: KeyPair,
-    vest_account: AccountId,
-) -> AnyResult<()> {
-    // Ensure that we make a call as `caller`.
-    let connection = connection.set_signer(caller);
+pub fn vest_other(connection: Connection, vest_account: AccountId) -> AnyResult<()> {
+    ensure_signed(&connection)?;
     let xt = compose_extrinsic!(
         connection,
         PALLET,
@@ -65,17 +69,16 @@ pub fn vest_other(
     Ok(())
 }
 
-/// Performs a vested transfer from `receiver` to `sender` according to `schedule`.
+/// Performs a vested transfer from the signer of `connection` to `receiver` according to
+/// `schedule`.
 ///
-/// Does not expect `connection` to be signed. Fails if transaction could not have been sent.
+/// Fails if `connection` is unsigned or transaction could not have been sent.
 pub fn vested_transfer(
     connection: Connection,
-    sender: KeyPair,
     receiver: AccountId,
     schedule: VestingSchedule,
 ) -> AnyResult<()> {
-    // Ensure that we make a call as `sender`.
-    let connection = connection.set_signer(sender);
+    ensure_signed(&connection)?;
     let xt = compose_extrinsic!(
         connection,
         PALLET,
@@ -99,20 +102,14 @@ pub fn get_schedules(connection: &Connection, who: AccountId) -> AnyResult<Vec<V
         .ok_or_else(|| VestingError::NotVesting.into())
 }
 
-/// Merges two vesting schedules (at indices `idx1` and `idx2`) of `who`.
+/// Merges two vesting schedules (at indices `idx1` and `idx2`) of the signer of `connection`.
 ///
-/// Does not expect `connection` to be signed. Fails if transaction could not have been sent.
+/// Fails if `connection` is unsigned or transaction could not have been sent.
 ///
 /// *Note*: This function returns `Ok(_)` even if the account has no active vesting schedules, or
 /// it has fewer schedules than `max(idx1, idx2) - 1` and thus the extrinsic was not successful.
-pub fn merge_schedules(
-    connection: Connection,
-    who: KeyPair,
-    idx1: u32,
-    idx2: u32,
-) -> AnyResult<()> {
-    // Ensure that we make a call as `who`.
-    let connection = connection.set_signer(who.clone());
+pub fn merge_schedules(connection: Connection, idx1: u32, idx2: u32) -> AnyResult<()> {
+    let who = ensure_signed(&connection)?;
     let xt = compose_extrinsic!(connection, PALLET, "merge_schedules", idx1, idx2);
     let block_hash = try_send_xt(&connection, xt, Some("Merge vesting schedules"), Finalized)?
         .expect("For `Finalized` status a block hash should be returned");

--- a/aleph-client/src/vesting.rs
+++ b/aleph-client/src/vesting.rs
@@ -73,8 +73,7 @@ pub fn vested_transfer(
 
 pub fn get_schedules(connection: &Connection, who: AccountId) -> AnyResult<Vec<VestingSchedule>> {
     connection
-        .get_storage_map::<AccountId, Option<Vec<VestingSchedule>>>(PALLET, "Vesting", who, None)?
-        .flatten()
+        .get_storage_map::<AccountId, Vec<VestingSchedule>>(PALLET, "Vesting", who, None)?
         .ok_or_else(|| VestingError::NotVesting.into())
 }
 

--- a/aleph-client/src/vesting.rs
+++ b/aleph-client/src/vesting.rs
@@ -73,7 +73,8 @@ pub fn vested_transfer(
 
 pub fn get_schedules(connection: &Connection, who: AccountId) -> AnyResult<Vec<VestingSchedule>> {
     connection
-        .get_storage_map::<AccountId, Vec<VestingSchedule>>(PALLET, "Vesting", who, None)?
+        .get_storage_map::<AccountId, Option<Vec<VestingSchedule>>>(PALLET, "Vesting", who, None)?
+        .flatten()
         .ok_or_else(|| VestingError::NotVesting.into())
 }
 

--- a/aleph-client/src/vesting.rs
+++ b/aleph-client/src/vesting.rs
@@ -1,0 +1,96 @@
+use anyhow::Result as AnyResult;
+use log::info;
+pub use pallet_vesting::VestingInfo;
+use sp_core::Pair;
+use substrate_api_client::{compose_extrinsic, GenericAddress, XtStatus::Finalized};
+use thiserror::Error;
+
+use primitives::Balance;
+
+use crate::{account_from_keypair, try_send_xt, AccountId, BlockNumber, Connection, KeyPair};
+
+/// Gathers errors from this module.
+#[derive(Debug, Error)]
+pub enum VestingError {
+    #[error("🦺❌ Account has no active vesting schedules.")]
+    NotVesting,
+}
+const PALLET: &str = "Vesting";
+pub type VestingSchedule = VestingInfo<Balance, BlockNumber>;
+
+pub fn vest(connection: &Connection, who: KeyPair) -> AnyResult<()> {
+    // Ensure that we make a call as `account`.
+    let connection = connection.clone().set_signer(who.clone());
+    let xt = compose_extrinsic!(connection, "Vesting", "vest");
+    let block_hash = try_send_xt(&connection, xt, Some("Vesting"), Finalized)?
+        .expect("For `Finalized` status a block hash should be returned");
+    info!(
+        target: "aleph-client", "Vesting for the account {:?}. Finalized in block {:?}",
+        account_from_keypair(&who), block_hash
+    );
+    Ok(())
+}
+
+pub fn vest_other(
+    connection: &Connection,
+    caller: KeyPair,
+    vest_account: AccountId,
+) -> AnyResult<()> {
+    // Ensure that we make a call as `caller`.
+    let connection = connection.clone().set_signer(caller);
+    let xt = compose_extrinsic!(
+        connection,
+        PALLET,
+        "vest_other",
+        GenericAddress::Id(vest_account.clone())
+    );
+    let block_hash = try_send_xt(&connection, xt, Some("Vesting on behalf"), Finalized)?
+        .expect("For `Finalized` status a block hash should be returned");
+    info!(target: "aleph-client", "Vesting on behalf of the account {:?}. Finalized in block {:?}", vest_account, block_hash);
+    Ok(())
+}
+
+pub fn vested_transfer(
+    connection: &Connection,
+    sender: KeyPair,
+    receiver: AccountId,
+    schedule: VestingSchedule,
+) -> AnyResult<()> {
+    // Ensure that we make a call as `sender`.
+    let connection = connection.clone().set_signer(sender);
+    let xt = compose_extrinsic!(
+        connection,
+        PALLET,
+        "vested_transfer",
+        GenericAddress::Id(receiver.clone()),
+        schedule
+    );
+    let block_hash = try_send_xt(&connection, xt, Some("Vested transfer"), Finalized)?
+        .expect("For `Finalized` status a block hash should be returned");
+    info!(target: "aleph-client", "Vested transfer to the account {:?}. Finalized in block {:?}", receiver, block_hash);
+    Ok(())
+}
+
+pub fn get_schedules(connection: &Connection, who: AccountId) -> AnyResult<Vec<VestingSchedule>> {
+    connection
+        .get_storage_map::<AccountId, Option<Vec<VestingSchedule>>>(PALLET, "Vesting", who, None)?
+        .flatten()
+        .ok_or_else(|| VestingError::NotVesting.into())
+}
+
+pub fn merge_schedules(
+    connection: &Connection,
+    who: KeyPair,
+    idx1: u32,
+    idx2: u32,
+) -> AnyResult<()> {
+    // Ensure that we make a call as `who`.
+    let connection = connection.clone().set_signer(who.clone());
+    let xt = compose_extrinsic!(connection, PALLET, "merge_schedules", idx1, idx2);
+    let block_hash = try_send_xt(&connection, xt, Some("Merge vesting schedules"), Finalized)?
+        .expect("For `Finalized` status a block hash should be returned");
+    info!(target: "aleph-client", 
+        "Merging vesting schedules (indices: {} and {}) for the account {:?}. Finalized in block {:?}", 
+        idx1, idx2, account_from_keypair(&who), block_hash);
+    Ok(())
+}

--- a/aleph-client/src/vesting.rs
+++ b/aleph-client/src/vesting.rs
@@ -26,10 +26,10 @@ const PALLET: &str = "Vesting";
 ///
 /// *Note*: This function returns `Ok(_)` even if the account has no active vesting schedules
 /// and thus the extrinsic was not successful. However, semantically it is still correct.
-pub fn vest(connection: &Connection, who: KeyPair) -> AnyResult<()> {
+pub fn vest(connection: Connection, who: KeyPair) -> AnyResult<()> {
     // Ensure that we make a call as `account`.
-    let connection = connection.clone().set_signer(who.clone());
-    let xt = compose_extrinsic!(connection, "Vesting", "vest");
+    let connection = connection.set_signer(who.clone());
+    let xt = compose_extrinsic!(connection, PALLET, "vest");
     let block_hash = try_send_xt(&connection, xt, Some("Vesting"), Finalized)?
         .expect("For `Finalized` status a block hash should be returned");
     info!(
@@ -47,12 +47,12 @@ pub fn vest(connection: &Connection, who: KeyPair) -> AnyResult<()> {
 /// *Note*: This function returns `Ok(_)` even if the account has no active vesting schedules
 /// and thus the extrinsic was not successful. However, semantically it is still correct.
 pub fn vest_other(
-    connection: &Connection,
+    connection: Connection,
     caller: KeyPair,
     vest_account: AccountId,
 ) -> AnyResult<()> {
     // Ensure that we make a call as `caller`.
-    let connection = connection.clone().set_signer(caller);
+    let connection = connection.set_signer(caller);
     let xt = compose_extrinsic!(
         connection,
         PALLET,
@@ -69,13 +69,13 @@ pub fn vest_other(
 ///
 /// Does not expect `connection` to be signed. Fails if transaction could not have been sent.
 pub fn vested_transfer(
-    connection: &Connection,
+    connection: Connection,
     sender: KeyPair,
     receiver: AccountId,
     schedule: VestingSchedule,
 ) -> AnyResult<()> {
     // Ensure that we make a call as `sender`.
-    let connection = connection.clone().set_signer(sender);
+    let connection = connection.set_signer(sender);
     let xt = compose_extrinsic!(
         connection,
         PALLET,
@@ -106,13 +106,13 @@ pub fn get_schedules(connection: &Connection, who: AccountId) -> AnyResult<Vec<V
 /// *Note*: This function returns `Ok(_)` even if the account has no active vesting schedules, or
 /// it has fewer schedules than `max(idx1, idx2) - 1` and thus the extrinsic was not successful.
 pub fn merge_schedules(
-    connection: &Connection,
+    connection: Connection,
     who: KeyPair,
     idx1: u32,
     idx2: u32,
 ) -> AnyResult<()> {
     // Ensure that we make a call as `who`.
-    let connection = connection.clone().set_signer(who.clone());
+    let connection = connection.set_signer(who.clone());
     let xt = compose_extrinsic!(connection, PALLET, "merge_schedules", idx1, idx2);
     let block_hash = try_send_xt(&connection, xt, Some("Merge vesting schedules"), Finalized)?
         .expect("For `Finalized` status a block hash should be returned");

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "hex",

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
+ "pallet-vesting",
  "parity-scale-codec",
  "primitives",
  "serde_json",
@@ -1762,6 +1763,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-vesting"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3211,7 +3226,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "hex",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
+ "pallet-vesting",
  "parity-scale-codec",
  "primitives",
  "serde_json",
@@ -1759,6 +1760,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-vesting"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,7 +3173,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/bin/cliain/src/lib.rs
+++ b/bin/cliain/src/lib.rs
@@ -4,6 +4,7 @@ mod secret;
 mod staking;
 mod transfer;
 mod validators;
+mod vesting;
 
 pub use keys::{prepare_keys, rotate_keys, set_keys};
 pub use runtime::update_runtime;
@@ -11,9 +12,9 @@ pub use secret::prompt_password_hidden;
 pub use staking::{bond, force_new_era, set_staking_limits, validate};
 pub use transfer::transfer;
 pub use validators::change_validators;
+pub use vesting::{vest, vest_other, vested_transfer};
 
-use aleph_client::{create_connection, Connection, KeyPair};
-use sp_core::Pair;
+use aleph_client::{create_connection, keypair_from_string, Connection};
 
 pub struct ConnectionConfig {
     node_endpoint: String,
@@ -31,8 +32,7 @@ impl ConnectionConfig {
 
 impl From<ConnectionConfig> for Connection {
     fn from(cfg: ConnectionConfig) -> Self {
-        let key = KeyPair::from_string(&cfg.signer_seed, None)
-            .expect("Can't create pair from seed value");
+        let key = keypair_from_string(&cfg.signer_seed);
         create_connection(cfg.node_endpoint.as_str()).set_signer(key)
     }
 }

--- a/bin/cliain/src/main.rs
+++ b/bin/cliain/src/main.rs
@@ -1,7 +1,4 @@
-use aleph_client::{
-    account_from_keypair, get_schedules, keypair_from_string, merge_schedules, print_storages,
-    BlockNumber, Connection,
-};
+use aleph_client::{keypair_from_string, print_storages, BlockNumber};
 use clap::{Parser, Subcommand};
 use log::{error, info};
 use sp_core::Pair;
@@ -147,7 +144,6 @@ enum Command {
 
     /// Print debug info of storage
     DebugStorage,
-    Check,
 }
 
 fn main() {
@@ -225,15 +221,6 @@ fn main() {
             per_block,
             starting_block,
         ),
-        Command::Check => {
-            let c: Connection = cfg.into();
-            let caller = c.signer.clone().unwrap();
-            let x = get_schedules(&c, account_from_keypair(&caller));
-            error!("{:?}", x);
-            merge_schedules(&c, caller.clone(), 0, 1).unwrap();
-            let x = get_schedules(&c, account_from_keypair(&caller));
-            error!("{:?}", x);
-        }
     }
 }
 

--- a/bin/cliain/src/main.rs
+++ b/bin/cliain/src/main.rs
@@ -1,4 +1,7 @@
-use aleph_client::{keypair_from_string, print_storages, BlockNumber};
+use aleph_client::{
+    account_from_keypair, get_schedules, keypair_from_string, merge_schedules, print_storages,
+    BlockNumber, Connection,
+};
 use clap::{Parser, Subcommand};
 use log::{error, info};
 use sp_core::Pair;
@@ -144,6 +147,7 @@ enum Command {
 
     /// Print debug info of storage
     DebugStorage,
+    Check,
 }
 
 fn main() {
@@ -221,6 +225,15 @@ fn main() {
             per_block,
             starting_block,
         ),
+        Command::Check => {
+            let c: Connection = cfg.into();
+            let caller = c.signer.clone().unwrap();
+            let x = get_schedules(&c, account_from_keypair(&caller));
+            error!("{:?}", x);
+            merge_schedules(&c, caller.clone(), 0, 1).unwrap();
+            let x = get_schedules(&c, account_from_keypair(&caller));
+            error!("{:?}", x);
+        }
     }
 }
 

--- a/bin/cliain/src/vesting.rs
+++ b/bin/cliain/src/vesting.rs
@@ -1,25 +1,14 @@
 use aleph_client::{
-    account_from_keypair, keypair_from_string, BlockNumber, Connection, KeyPair, VestingSchedule,
+    account_from_keypair, keypair_from_string, BlockNumber, Connection, VestingSchedule,
 };
 use log::{error, info};
 use primitives::{Balance, TOKEN};
-
-/// Retrieves signer from `connection`.
-///
-/// Panics if `connection` is not signed.
-fn get_caller(connection: &Connection) -> KeyPair {
-    connection
-        .signer
-        .clone()
-        .expect("Connection should be signed")
-}
 
 /// Delegates to `aleph_client::vest`.
 ///
 /// `connection` should be signed: the vesting is performed for the signer.
 pub fn vest(connection: Connection) {
-    let caller = get_caller(&connection);
-    match aleph_client::vest(connection, caller) {
+    match aleph_client::vest(connection) {
         Ok(_) => info!("Vesting has succeeded"),
         Err(e) => error!("Vesting has failed with:\n {:?}", e),
     }
@@ -30,9 +19,8 @@ pub fn vest(connection: Connection) {
 /// `connection` should be signed: the vesting is performed by the signer for
 /// `vesting_account_seed`.
 pub fn vest_other(connection: Connection, vesting_account_seed: String) {
-    let caller = get_caller(&connection);
     let vester = account_from_keypair(&keypair_from_string(vesting_account_seed.as_str()));
-    match aleph_client::vest_other(connection, caller, vester) {
+    match aleph_client::vest_other(connection, vester) {
         Ok(_) => info!("Vesting on behalf has succeeded"),
         Err(e) => error!("Vesting on behalf has failed with:\n {:?}", e),
     }
@@ -50,11 +38,10 @@ pub fn vested_transfer(
     per_block: Balance,
     starting_block: BlockNumber,
 ) {
-    let sender = get_caller(&connection);
     let receiver = account_from_keypair(&keypair_from_string(target_seed.as_str()));
     let schedule =
         VestingSchedule::new(amount_in_tokens as u128 * TOKEN, per_block, starting_block);
-    match aleph_client::vested_transfer(connection, sender, receiver, schedule) {
+    match aleph_client::vested_transfer(connection, receiver, schedule) {
         Ok(_) => info!("Vested transfer has succeeded"),
         Err(e) => error!("Vested transfer has failed with:\n {:?}", e),
     }

--- a/bin/cliain/src/vesting.rs
+++ b/bin/cliain/src/vesting.rs
@@ -19,7 +19,7 @@ fn get_caller(connection: &Connection) -> KeyPair {
 /// `connection` should be signed: the vesting is performed for the signer.
 pub fn vest(connection: Connection) {
     let caller = get_caller(&connection);
-    match aleph_client::vest(&connection, caller) {
+    match aleph_client::vest(connection, caller) {
         Ok(_) => info!("Vesting has succeeded"),
         Err(e) => error!("Vesting has failed with:\n {:?}", e),
     }
@@ -32,7 +32,7 @@ pub fn vest(connection: Connection) {
 pub fn vest_other(connection: Connection, vesting_account_seed: String) {
     let caller = get_caller(&connection);
     let vester = account_from_keypair(&keypair_from_string(vesting_account_seed.as_str()));
-    match aleph_client::vest_other(&connection, caller, vester) {
+    match aleph_client::vest_other(connection, caller, vester) {
         Ok(_) => info!("Vesting on behalf has succeeded"),
         Err(e) => error!("Vesting on behalf has failed with:\n {:?}", e),
     }
@@ -54,7 +54,7 @@ pub fn vested_transfer(
     let receiver = account_from_keypair(&keypair_from_string(target_seed.as_str()));
     let schedule =
         VestingSchedule::new(amount_in_tokens as u128 * TOKEN, per_block, starting_block);
-    match aleph_client::vested_transfer(&connection, sender, receiver, schedule) {
+    match aleph_client::vested_transfer(connection, sender, receiver, schedule) {
         Ok(_) => info!("Vested transfer has succeeded"),
         Err(e) => error!("Vested transfer has failed with:\n {:?}", e),
     }

--- a/bin/cliain/src/vesting.rs
+++ b/bin/cliain/src/vesting.rs
@@ -1,0 +1,46 @@
+use aleph_client::{
+    account_from_keypair, keypair_from_string, BlockNumber, Connection, KeyPair, VestingSchedule,
+};
+use log::{error, info};
+use primitives::{Balance, TOKEN};
+
+fn get_caller(connection: &Connection) -> KeyPair {
+    connection
+        .signer
+        .clone()
+        .expect("Connection should be signed")
+}
+
+pub fn vest(connection: Connection) {
+    let caller = get_caller(&connection);
+    match aleph_client::vest(&connection, caller) {
+        Ok(_) => info!("Vesting has succeeded"),
+        Err(e) => error!("Vesting has failed with:\n {:?}", e),
+    }
+}
+
+pub fn vest_other(connection: Connection, vesting_account_seed: String) {
+    let caller = get_caller(&connection);
+    let vester = account_from_keypair(&keypair_from_string(vesting_account_seed.as_str()));
+    match aleph_client::vest_other(&connection, caller, vester) {
+        Ok(_) => info!("Vesting on behalf has succeeded"),
+        Err(e) => error!("Vesting on behalf has failed with:\n {:?}", e),
+    }
+}
+
+pub fn vested_transfer(
+    connection: Connection,
+    target_seed: String,
+    amount_in_tokens: u64,
+    per_block: Balance,
+    starting_block: BlockNumber,
+) {
+    let sender = get_caller(&connection);
+    let receiver = account_from_keypair(&keypair_from_string(target_seed.as_str()));
+    let schedule =
+        VestingSchedule::new(amount_in_tokens as u128 * TOKEN, per_block, starting_block);
+    match aleph_client::vested_transfer(&connection, sender, receiver, schedule) {
+        Ok(_) => info!("Vested transfer has succeeded"),
+        Err(e) => error!("Vested transfer has failed with:\n {:?}", e),
+    }
+}

--- a/bin/cliain/src/vesting.rs
+++ b/bin/cliain/src/vesting.rs
@@ -4,6 +4,9 @@ use aleph_client::{
 use log::{error, info};
 use primitives::{Balance, TOKEN};
 
+/// Retrieves signer from `connection`.
+///
+/// Panics if `connection` is not signed.
 fn get_caller(connection: &Connection) -> KeyPair {
     connection
         .signer
@@ -11,6 +14,9 @@ fn get_caller(connection: &Connection) -> KeyPair {
         .expect("Connection should be signed")
 }
 
+/// Delegates to `aleph_client::vest`.
+///
+/// `connection` should be signed: the vesting is performed for the signer.
 pub fn vest(connection: Connection) {
     let caller = get_caller(&connection);
     match aleph_client::vest(&connection, caller) {
@@ -19,6 +25,10 @@ pub fn vest(connection: Connection) {
     }
 }
 
+/// Delegates to `aleph_client::vest_other`.
+///
+/// `connection` should be signed: the vesting is performed by the signer for
+/// `vesting_account_seed`.
 pub fn vest_other(connection: Connection, vesting_account_seed: String) {
     let caller = get_caller(&connection);
     let vester = account_from_keypair(&keypair_from_string(vesting_account_seed.as_str()));
@@ -28,6 +38,11 @@ pub fn vest_other(connection: Connection, vesting_account_seed: String) {
     }
 }
 
+/// Delegates to `aleph_client::vested_transfer`.
+///
+/// `connection` should be signed: the transfer is performed from the signer to `target_seed`.
+/// `amount_in_tokens`, `per_block` and `starting_block` corresponds to the fields of
+/// `aleph_client::VestingSchedule` struct.
 pub fn vested_transfer(
     connection: Connection,
     target_seed: String,

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
+ "pallet-vesting",
  "parity-scale-codec",
  "primitives",
  "serde_json",
@@ -1770,6 +1771,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-vesting"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3161,7 +3176,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "hex",

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
+ "pallet-vesting",
  "parity-scale-codec",
  "primitives",
  "serde_json",
@@ -1841,6 +1842,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-vesting"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,7 +3257,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "hex",


### PR DESCRIPTION
# Description

This PR introduces the vesting module to the aleph-client lib crate. It enables vesting (for self or on behalf), making vested transfers and managing vesting schedules. This is needed for implementing corresponding scenarios.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Infrastructure updated accordingly
- [x] I have made corresponding changes to the documentation
- [x] New documentation created
- [ ] Bump `spec_version` and `transaction_version` if relevant
- [x] Bump `aleph-client` version if relevant
