### PR TITLE
A0-913: One required task for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -272,7 +272,7 @@ jobs:
         timeout-minutes: 10
 
 
-  push-image:
+  all-e2e-tests-completed:
     needs: [
       run-e2e-finalization-test,
       run-e2e-token-transfer-test,
@@ -285,6 +285,12 @@ jobs:
       run-e2e-fee-calculation,
       run-e2e-members-rotate
     ]
+    name: All e2e tests completed
+    runs-on: ubuntu-latest
+
+
+  push-image:
+    needs: [all-e2e-tests-completed]
     name: Push node image to the ECR repository
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -272,7 +272,7 @@ jobs:
         timeout-minutes: 10
 
 
-  run-e2e-test-suite:
+  check-e2e-test-suite-completion:
     needs: [
       run-e2e-finalization-test,
       run-e2e-token-transfer-test,
@@ -285,7 +285,7 @@ jobs:
       run-e2e-fee-calculation,
       run-e2e-members-rotate
     ]
-    name: Run e2e test suite
+    name: Check e2e test suite completion
     runs-on: ubuntu-latest
     steps:
      - name: All e2e tests completed
@@ -293,7 +293,7 @@ jobs:
 
 
   push-image:
-    needs: [run-e2e-test-suite]
+    needs: [check-e2e-test-suite-completion]
     name: Push node image to the ECR repository
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -272,7 +272,7 @@ jobs:
         timeout-minutes: 10
 
 
-  all-e2e-tests-completed:
+  run-e2e-test-suite:
     needs: [
       run-e2e-finalization-test,
       run-e2e-token-transfer-test,
@@ -285,7 +285,7 @@ jobs:
       run-e2e-fee-calculation,
       run-e2e-members-rotate
     ]
-    name: All e2e tests completed
+    name: Run e2e test suite
     runs-on: ubuntu-latest
     steps:
      - name: All e2e tests completed
@@ -293,7 +293,7 @@ jobs:
 
 
   push-image:
-    needs: [all-e2e-tests-completed]
+    needs: [run-e2e-test-suite]
     name: Push node image to the ECR repository
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -287,6 +287,9 @@ jobs:
     ]
     name: All e2e tests completed
     runs-on: ubuntu-latest
+    steps:
+     - name: All e2e tests completed
+       run: echo "All e2e tests completed."
 
 
   push-image:


### PR DESCRIPTION
# Description

Currently, all e2e tests have to be explicitly marked as required in the repository settings. This adds an empty job which depends on all the e2e tests for easier setup of required checks.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
