### PR TITLE
A0-925 Increase delay for better consistency in data_provider tests.

### DIFF
--- a/finality-aleph/src/data_io/data_provider.rs
+++ b/finality-aleph/src/data_io/data_provider.rs
@@ -377,7 +377,7 @@ mod tests {
 
     // Sleep enough time so that the internal refreshing in ChainTracker has time to finish.
     async fn sleep_enough() {
-        sleep(REFRESH_INTERVAL + REFRESH_INTERVAL).await;
+        sleep(REFRESH_INTERVAL + REFRESH_INTERVAL + REFRESH_INTERVAL).await;
     }
 
     async fn run_test<F, S>(scenario: S)


### PR DESCRIPTION
# Description

The test `proposal_changes_with_finalization` fails from time to time. This is probably due to changes in dev dependencies that make some of the testing code slower, and since it relies on some delays being not to small, it fails on slow machines. I increased the delay as a short-term solution. In the future we probably want to make `DataProvider` more asynchronous to not rely on refresh intervals etc.

## Type of change

Bug fix (non-breaking change which fixes an issue)

