### PR TITLE
Redirect logs to file inside docker

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -111,4 +111,4 @@ if [[ -n "${CUSTOM_ARGS:-}" ]]; then
   ARGS+=(${CUSTOM_ARGS})
 fi
 
-aleph-node "${ARGS[@]}"
+aleph-node "${ARGS[@]}" 2> ${BASE_PATH}/${NAME}.log > /dev/null &


### PR DESCRIPTION
# Description

When running the `aleph-node` binary inside `docker-entrypoint.sh`, we now redirect the logs (stderr) to a log file. This is exactly the way that `scripts/run_nodes.sh` does that. By putting the log file inside `$BASE_PATH`, we are able to access it from the host as that directory is bind-mounted when running docker.