### PR TITLE
A0-941: Allow keeping part of pallet storage from initial chainspec

### DIFF
--- a/.github/workflows/deploy-to-devnet.yml
+++ b/.github/workflows/deploy-to-devnet.yml
@@ -81,7 +81,7 @@ jobs:
           # generate chainspec, it will reuse keys from the synced keystore
           docker run -i -v $(pwd)/data:/data --env RUST_BACKTRACE=1 --entrypoint "/usr/local/bin/aleph-node" public.ecr.aws/p6e8q1z1/aleph-node:${COMMIT_ID} bootstrap-chain --raw --base-path /data --chain-id a0dnet1 --account-ids 5D34dL5prEUaGNQtPPZ3yN5Y6BnkfXunKXXz6fo7ZJbLwRRH,5GBNeWRhZc2jXu7D55rBimKYDk8PGk8itRYFTPfC8RJLKG5o,5Dfis6XL8J2P6JHUnUtArnFWndn62SydeP8ee8sG2ky9nfm9,5F4H97f7nQovyrbiq4ZetaaviNwThSVcFobcA5aGab6167dK,5DiDShBWa1fQx6gLzpf3SFBhMinCoyvHM1BWjPNsmXS8hkrW,5EFb84yH9tpcFuiKUcsmdoF7xeeY3ajG1ZLQimxQoFt9HMKR,5DZLHESsfGrJ5YzT3HuRPXsSNb589xQ4Unubh1mYLodzKdVY,5GHJzqvG6tXnngCpG7B12qjUvbo5e4e9z8Xjidk3CQZHxTPZ,5CUnSsgAyLND3bxxnfNhgWXSe9Wn676JzLpGLgyJv858qhoX,5CVKn7HAZW1Ky4r7Vkgsr7VEW88C2sHgUNDiwHY9Ct2hjU8q --sudo-account-id 5F4SvwaUEQubiqkPF8YnRfcN77cLsT2DfG4vFeQmSXNjR7hD > chainspec.skeleton.json
 
-          docker run -i -v $(pwd):/app public.ecr.aws/p6e8q1z1/fork-off:latest --http-rpc-endpoint=https://rpc.test.azero.dev --initial-spec-path=chainspec.skeleton.json --combined-spec-path=chainspec.json --pallets-keep-state=Aura,Aleph,Sudo,Staking,Session,Elections,Balances
+          docker run -i -v $(pwd):/app public.ecr.aws/p6e8q1z1/fork-off:latest --http-rpc-endpoint=https://rpc.test.azero.dev --initial-spec-path=chainspec.skeleton.json --combined-spec-path=chainspec.json
 
           aws s3 cp chainspec.json s3://alephzero-devnet-eu-central-1-keys-bucket/chainspec.json
 

--- a/fork-off/Cargo.lock
+++ b/fork-off/Cargo.lock
@@ -646,7 +646,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-off"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/fork-off/Cargo.toml
+++ b/fork-off/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fork-off"
-version = "0.2.0"
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]

--- a/fork-off/README.md
+++ b/fork-off/README.md
@@ -31,7 +31,7 @@ The tool will perform the following actions, in this order:
 2. Dump the state to a json file. You can provide a path via `--snapshot-path`.
 3. Read the state from the snapshot json file. This is because steps 1. and 2. can be omitted by running with `--use-snapshot-file` -- see example below.
 4. Read the chainspec provided via `--initial-spec-path` you should pass here the one generated via `the bootstrap-chain` command, so `--initial-spec-path=chainspec.json` if it is in the same directory.
-5. Replace the genesis state in the chainspec by the one from the snapshot WITH THE EXCEPTION of states of pallets provided via a comma separated list using `--pallets_keep_state`. The default setting is `--pallets_keep_state=Aura,Aleph,Sudo,Staking,Session,Elections` and it's likely you don't want to change it.
+5. Replace the genesis state in the chainspec by the one from the snapshot WITH THE EXCEPTION of states of paths provided via a comma separated list using `--storage_keep_state`. The default setting is `--storage_keep_state=Aura,Aleph,Sudo,Staking,Session,Elections,System.Account` and it's likely you don't want to change it.
 6. The final, new chainspec is saved to the path provided via `--combined-spec-path`.
 
 So for instance to generate a new spec keeping the storage of testnet (note that in that case you should use the same binary as running on testnet to `bootstrap-chain`) we would run:

--- a/fork-off/README.md
+++ b/fork-off/README.md
@@ -31,7 +31,7 @@ The tool will perform the following actions, in this order:
 2. Dump the state to a json file. You can provide a path via `--snapshot-path`.
 3. Read the state from the snapshot json file. This is because steps 1. and 2. can be omitted by running with `--use-snapshot-file` -- see example below.
 4. Read the chainspec provided via `--initial-spec-path` you should pass here the one generated via `the bootstrap-chain` command, so `--initial-spec-path=chainspec.json` if it is in the same directory.
-5. Replace the genesis state in the chainspec by the one from the snapshot WITH THE EXCEPTION of states of paths provided via a comma separated list using `--storage_keep_state`. The default setting is `--storage_keep_state=Aura,Aleph,Sudo,Staking,Session,Elections,System.Account` and it's likely you don't want to change it.
+5. Replace the genesis state in the chainspec by the one from the snapshot WITH THE EXCEPTION of states of paths provided via a comma separated list using `--storage_keep_state`. The default setting is `--storage_keep_state=Aura,Aleph,Balances,Sudo,Staking,Session,Elections,System.Account` and it's likely you don't want to change it.
 6. The final, new chainspec is saved to the path provided via `--combined-spec-path`.
 
 So for instance to generate a new spec keeping the storage of testnet (note that in that case you should use the same binary as running on testnet to `bootstrap-chain`) we would run:
@@ -40,7 +40,7 @@ So for instance to generate a new spec keeping the storage of testnet (note that
 target/release/fork-off --http-rpc-endpoint=https://rpc.test.azero.dev --initial-spec-path=chainspec.json --combined-spec-path=combined.json
 ```
 
-This will also create a `snapshot.json` file containing the state downloaded from testnet. In case the state downloaded correctly (easy to see from logs) but something went wrong when combining the specs (e.g. you want to use a different set of pallets) then you can rerun without the need of downloading the state again (it might be time consuming):
+This will also create a `snapshot.json` file containing the state downloaded from testnet. In case the state downloaded correctly (easy to see from logs) but something went wrong when combining the specs (e.g. you want to use a different set of paths) then you can rerun without the need of downloading the state again (it might be time consuming):
 
 ```bash
 target/release/fork-off --http-rpc-endpoint=https://rpc.test.azero.dev --initial-spec-path=chainspec.json --combined-spec-path=combined.json --use-snapshot-file

--- a/fork-off/src/main.rs
+++ b/fork-off/src/main.rs
@@ -275,10 +275,7 @@ fn combine_states(
 ) -> Storage {
     let storage_prefixes: Vec<(StoragePath, StorageKeyHash)> = storage_to_keep
         .into_iter()
-        .map(|path| {
-            let hash = hash_storage_prefix(&path);
-            (path, hash)
-        })
+        .map(|path| (path.clone(), hash_storage_prefix(path)))
         .collect();
     let mut removed_per_path_count: HashMap<String, usize> = storage_prefixes
         .iter()
@@ -388,9 +385,8 @@ fn write_to_file(write_to_path: String, data: &[u8]) {
     file.write_all(data).expect("Could not write to file");
 }
 
-fn hash_storage_prefix(storage_path: &StoragePath) -> StorageKeyHash {
+fn hash_storage_prefix(storage_path: StoragePath) -> StorageKeyHash {
     let modules = storage_path.split('.');
-    let hashes = modules.map(|module| sp_io::hashing::twox_128(module.as_bytes()));
-    let concat = hashes.flatten().collect::<Vec<_>>();
-    format!("0x{}", hex::encode(concat))
+    let hashes = modules.flat_map(|module| sp_io::hashing::twox_128(module.as_bytes()));
+    format!("0x{}", hex::encode(hashes.collect::<Vec<_>>()))
 }

--- a/fork-off/src/main.rs
+++ b/fork-off/src/main.rs
@@ -12,6 +12,9 @@ use std::{
     sync::Arc,
 };
 
+type StoragePath = String;
+type StorageKeyHash = String;
+
 #[derive(Debug, Parser)]
 #[clap(version = "1.0")]
 pub struct Config {
@@ -31,7 +34,7 @@ pub struct Config {
     #[clap(long, default_value = "./chainspec_from_snapshot.json")]
     pub combined_spec_path: String,
 
-    /// where to write the forked genesis chainspec
+    /// whether to read the state from the ready snapshot json file
     #[clap(long)]
     pub use_snapshot_file: bool,
 
@@ -46,9 +49,9 @@ pub struct Config {
         multiple_occurrences = true,
         takes_value = true,
         value_delimiter = ',',
-        default_value = "Aura,Aleph,Sudo,Staking,Session,Elections"
+        default_value = "Aura,Aleph,Sudo,Staking,Session,Elections,System.Account"
     )]
-    pub pallets_keep_state: Vec<String>,
+    pub storage_keep_state: Vec<StoragePath>,
 }
 
 const KEYS_BATCH_SIZE: u32 = 1000;
@@ -265,44 +268,48 @@ fn is_prefix_of(shorter: &str, longer: &str) -> bool {
     longer.starts_with(shorter)
 }
 
-fn combine_states(mut state: Storage, initial_state: Storage, pallets: Vec<String>) -> Storage {
-    let pallets_prefixes: Vec<(String, String)> = pallets
-        .iter()
-        .map(|pallet| {
-            let hash = format!("0x{}", prefix_as_hex(pallet));
-            (pallet.clone(), hash)
+fn combine_states(
+    mut state: Storage,
+    initial_state: Storage,
+    storage_to_keep: Vec<StoragePath>,
+) -> Storage {
+    let storage_prefixes: Vec<(StoragePath, StorageKeyHash)> = storage_to_keep
+        .into_iter()
+        .map(|path| {
+            let hash = hash_storage_prefix(&path);
+            (path, hash)
         })
         .collect();
-    let mut removed_per_pallet_count: HashMap<String, usize> = pallets_prefixes
+    let mut removed_per_path_count: HashMap<String, usize> = storage_prefixes
         .iter()
-        .map(|(pallet, _)| (pallet.clone(), 0))
+        .map(|(path, _)| (path.clone(), 0))
         .collect();
-    let mut added_per_pallet_cnt = removed_per_pallet_count.clone();
+    let mut added_per_path_cnt = removed_per_path_count.clone();
     state.retain(|k, _v| {
-        match pallets_prefixes
+        match storage_prefixes
             .iter()
             .find(|(_, prefix)| is_prefix_of(prefix, k))
         {
-            Some((pallet, _)) => {
-                *removed_per_pallet_count.get_mut(pallet).unwrap() += 1;
+            Some((path, _)) => {
+                *removed_per_path_count.get_mut(path).unwrap() += 1;
                 false
             }
             None => true,
         }
     });
     for (k, v) in initial_state.iter() {
-        if let Some((pallet, _)) = pallets_prefixes
+        if let Some((pallet, _)) = storage_prefixes
             .iter()
             .find(|(_, prefix)| is_prefix_of(prefix, k))
         {
-            *added_per_pallet_cnt.get_mut(pallet).unwrap() += 1;
+            *added_per_path_cnt.get_mut(pallet).unwrap() += 1;
             state.insert(k.clone(), v.clone());
         }
     }
-    for (pallet, prefix) in pallets_prefixes {
+    for (path, prefix) in storage_prefixes {
         info!(
-            "For pallet {} (prefix {}) Replaced {} entries by {} entries from initial_spec",
-            pallet, prefix, removed_per_pallet_count[&pallet], added_per_pallet_cnt[&pallet]
+            "For storage path `{}` (prefix `{}`) Replaced {} entries by {} entries from initial_spec",
+            path, prefix, removed_per_path_count[&path], added_per_path_cnt[&path]
         );
     }
     state
@@ -316,7 +323,7 @@ async fn main() -> anyhow::Result<()> {
         snapshot_path,
         combined_spec_path,
         use_snapshot_file,
-        pallets_keep_state,
+        storage_keep_state,
         num_workers,
     } = Config::parse();
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
@@ -328,8 +335,8 @@ async fn main() -> anyhow::Result<()> {
         \tsnapshot_path: {}\n\
         \tcombined_spec_path: {}\n\
         \tuse_snapshot_file: {}\n\
-        \tpallets_keep_state: {:?}",
-        &http_rpc_endpoint, &initial_spec_path, &snapshot_path, &combined_spec_path, &use_snapshot_file, &pallets_keep_state
+        \tstorage_keep_state: {:?}",
+        &http_rpc_endpoint, &initial_spec_path, &snapshot_path, &combined_spec_path, &use_snapshot_file, &storage_keep_state
     );
 
     let mut initial_spec: Value = serde_json::from_str(
@@ -351,7 +358,7 @@ async fn main() -> anyhow::Result<()> {
     let initial_state: Storage =
         serde_json::from_value(initial_spec["genesis"]["raw"]["top"].take())
             .expect("Deserialization of state from given chainspec file failed");
-    let state = combine_states(state, initial_state, pallets_keep_state);
+    let state = combine_states(state, initial_state, storage_keep_state);
     let json_state = serde_json::to_value(state).expect("Failed to convert a storage map to json");
     initial_spec["genesis"]["raw"]["top"] = json_state;
     let new_spec = serde_json::to_vec_pretty(&initial_spec)?;
@@ -381,7 +388,9 @@ fn write_to_file(write_to_path: String, data: &[u8]) {
     file.write_all(data).expect("Could not write to file");
 }
 
-fn prefix_as_hex(module: &str) -> String {
-    let pallet_name = sp_io::hashing::twox_128(module.as_bytes());
-    hex::encode(pallet_name)
+fn hash_storage_prefix(storage_path: &StoragePath) -> StorageKeyHash {
+    let modules = storage_path.split('.');
+    let hashes = modules.map(|module| sp_io::hashing::twox_128(module.as_bytes()));
+    let concat = hashes.flatten().collect::<Vec<_>>();
+    format!("0x{}", hex::encode(concat))
 }

--- a/fork-off/src/main.rs
+++ b/fork-off/src/main.rs
@@ -49,7 +49,7 @@ pub struct Config {
         multiple_occurrences = true,
         takes_value = true,
         value_delimiter = ',',
-        default_value = "Aura,Aleph,Sudo,Staking,Session,Elections,System.Account"
+        default_value = "Aura,Aleph,Balances,Sudo,Staking,Session,Elections,System.Account"
     )]
     pub storage_keep_state: Vec<StoragePath>,
 }


### PR DESCRIPTION
# Description

Here we extend the configuration of `fork-off` tool, allowing to keep a part of some pallet storage from the initial chainspec.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Infrastructure updated accordingly
- [x] I have made corresponding changes to the documentation
- [ ] New documentation created
- [ ] Bump `spec_version` and `transaction_version` if relevant
- [ ] Bump `aleph-client` version if relevant
