### PR TITLE
Port GHA caching from traffic-maker

### DIFF
--- a/.github/actions/post-cache/action.yml
+++ b/.github/actions/post-cache/action.yml
@@ -1,12 +1,21 @@
-name: 'Tidy cache'
-description: 'Gracefully tidy cache services. To be used with `restore-cache` action.'
+name: "Rust cache cleanup"
+description: |
+  Run this at the end of your workflow if you're running `rust-cache`.
 
 runs:
   using: "composite"
   steps:
-    - name: Print sccache stats
-      run: sccache --show-stats
-      shell: bash
+    - name: Prune unused packages from cargo cache
+      uses: actions-rs/cargo@v1
+      with:
+        command: cache
+        args: clean-unref
+
+    - name: Prune sources from cargo cache
+      uses: actions-rs/cargo@v1
+      with:
+        command: cache
+        args: --autoclean
 
     - name: Stop sccache server
       run: sccache --stop-server || true

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -1,66 +1,91 @@
-name: 'Restore cache'
-description: 'Restore Cargo cache and sccache for ubuntu:latest.'
+name: "Restore rust cache"
+description: |
+  Restore/save rust caches.
+  
+  This action combines 3 caches:
+  
+    1. The ~/.cargo cache
+    2. The ./target cache
+    3. The sccache cache along with starting the sccache server
+  
+  All caches are keyed with cache_version along with a hash of all Cargo.lock files in the project. As a fallback they
+  take the newest cache with any hash of Cargo.lock files to rebuild from a partial cache in case of a Cargo.lock change.
 
 inputs:
-  sccache-version:
-    description: 'sccache version; by default: `0.2.13`'
+  cache_version:
+    description: "String indicating the version of the caches, change it to clean caches."
     required: false
-    default: '0.2.13'
-  sccache-cache-size:
-    description: 'sccache cache size; by default: `2G`'
+    default: "v1"
+  target_key:
+    description: >
+      If you have multiple workflows that generate different contents of the target directory, then you can set this key
+      differently for them, so that they don't interfere with each other.
     required: false
-    default: '2G'
-  sccache-path:
-    description: 'sccache path; by default: `/home/runner/.cache/sccache`'
+    default: ""
+  sccache_version:
+    description: "Version number of sccache to use."
     required: false
-    default: '/home/runner/.cache/sccache'
+    default: 0.2.13
+  sccache_size:
+    description: "Size specifier for scache's cache"
+    required: false
+    default: "1G"
   cargo-targets:
-    description: |
-      A list of directories to be cached and restored.
-      Already included `~/.cargo/bin/`, `~/.cargo/registry/index/`, `~/.cargo/registry/cache/`,
-      `~/.cargo/git/db/` and `target/`.
+    description: "Additional directories to include in the target cache"
     required: false
-    default: ''
+    default: ""
 
 runs:
-  using: 'composite'
-  steps:
-    - name: Set env
-      shell: bash
-      run: |
-        echo "SCCACHE_VERSION=${{ inputs.sccache-version }}" >> $GITHUB_ENV
-        echo "SCCACHE_CACHE_SIZE=${{ inputs.sccache-cache-size }}" >> $GITHUB_ENV
-        echo "SCCACHE_PATH=${{ inputs.sccache-path }}" >> $GITHUB_ENV
+  using: "composite"
 
+  steps:
     - name: Restore cargo cache
       uses: actions/cache@v3
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
+          ~/.cargo
+        key: ${{ runner.os }}-cargo-${{ inputs.cache_version }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-${{ inputs.cache_version }}
+
+    - name: Restore target cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          target
           ${{ inputs.cargo-targets }}
-          ${{ inputs.sccache-path }}
-        key: ${{ runner.os }}-cargo-v1-${{ hashFiles('**/Cargo.lock') }} # bump cache version if you need to clear it, see https://github.com/actions/cache/issues/485 and https://stackoverflow.com/questions/63521430/clear-cache-in-github-actions
+        key: ${{ runner.os }}-target-${{ inputs.target_key }}-${{ inputs.cache_version }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-target-${{ inputs.target_key }}-${{ inputs.cache_version }}
 
     - name: Install sccache for ubuntu-latest
       shell: bash
       run: |
         LINK=https://github.com/mozilla/sccache/releases/download
-        SCCACHE_FILE=sccache-${{ inputs.sccache-version }}-x86_64-unknown-linux-musl
-
+        SCCACHE_FILE=sccache-${{ inputs.sccache_version }}-x86_64-unknown-linux-musl
+        
         mkdir -p $HOME/.local/bin
-        curl -L "$LINK/${{ inputs.sccache-version }}/$SCCACHE_FILE.tar.gz" | tar xz
+        curl -L "$LINK/${{ inputs.sccache_version }}/$SCCACHE_FILE.tar.gz" | tar xz
         mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
-
+        
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+    - name: Restore sccache
+      uses: actions/cache@v3
+      with:
+        path: /home/runner/.cache/sccache
+        key: ${{ runner.os }}-sccache-${{ inputs.target_key }}-${{ inputs.cache_version }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-sccache-${{ inputs.target_key }}-${{ inputs.cache_version }}
+
     - name: Start sccache server
+      env:
+        SCCACHE_CACHE_SIZE: ${{ inputs.sccache_size }}
       shell: bash
       run: sccache --start-server
 
-    - name: Set rustc wrapper
-      shell: bash
-      run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+    - name: Install cargo-cache
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: cargo-cache

--- a/.github/workflows/build-node-and-runtime.yml
+++ b/.github/workflows/build-node-and-runtime.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: full
-      # SCCACHE_RECACHE: 1 # to clear cache uncomment this, let the workflow run once, then comment it out again
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -34,6 +33,9 @@ jobs:
 
       - name: Restore cache
         uses: ./.github/actions/restore-cache
+        with:
+          target_key: release
+          cache_version: v1
 
       - name: Build binary and runtime
         run: cargo build --release -p aleph-node
@@ -73,5 +75,5 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Stop cache
+      - name: Cleanup cache
         uses: ./.github/actions/post-cache

--- a/.github/workflows/check-excluded-packages.yml
+++ b/.github/workflows/check-excluded-packages.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Restore cache
         uses: ./.github/actions/restore-cache
         with:
+          target_key: excluded
+          cache_version: v1
           cargo-targets: "${{ steps.format_output.outputs.targets }}"
 
       - name: Check excluded packages
@@ -62,5 +64,5 @@ jobs:
             popd
           done
 
-      - name: Stop cache
+      - name: Cleanup cache
         uses: ./.github/actions/post-cache

--- a/.github/workflows/check-excluded-packages.yml
+++ b/.github/workflows/check-excluded-packages.yml
@@ -1,7 +1,14 @@
 name: Check excluded packages
 
 on:
-  pull_request
+  pull_request:
+    branches:
+      - '**'
+  push:
+    paths-ignore:
+      - '*.md'
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -103,6 +103,8 @@ jobs:
       - name: Restore cache
         uses: ./.github/actions/restore-cache
         with:
+          target_key: e2e
+          cache_version: v1
           cargo-targets: e2e-tests/target/
 
       - name: Build binary and docker image
@@ -438,6 +440,8 @@ jobs:
       - name: Restore cache
         uses: ./.github/actions/restore-cache
         with:
+          target_key: runtime-update
+          cache_version: v1
           cargo-targets: bin/cliain/target/
 
       - name: Download all artifacts
@@ -459,7 +463,7 @@ jobs:
           NEW_RUNTIME: aleph-test-runtime/aleph_runtime.compact.wasm
         run: ./.github/scripts/test_update.sh
 
-      - name: Stop cache
+      - name: Cleanup cache
         uses: ./.github/actions/post-cache
 
   test-runtime-update-if-OTHER:
@@ -478,6 +482,8 @@ jobs:
       - name: Restore cache
         uses: ./.github/actions/restore-cache
         with:
+          target_key: runtime-update
+          cache_version: v1
           cargo-targets: bin/cliain/target/
 
       - name: Download all artifacts
@@ -499,7 +505,7 @@ jobs:
           NEW_RUNTIME: aleph-test-runtime/aleph_runtime.compact.wasm
         run: ./.github/scripts/test_update.sh
 
-      - name: Stop cache
+      - name: Cleanup cache
         uses: ./.github/actions/post-cache
 
   test-catch-up:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,7 +1,14 @@
 name: unit-tests
 
 on:
-  pull_request
+  pull_request:
+    branches:
+      - '**'
+  push:
+    paths-ignore:
+      - '*.md'
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Restore cache
         uses: ./.github/actions/restore-cache
+        with:
+          target_key: debug
+          cache_version: v1
 
       - name: Run Format Checks
         uses: actions-rs/cargo@v1
@@ -51,5 +54,5 @@ jobs:
           command: test
           args: --lib
 
-      - name: Stop sccache
+      - name: Cleanup cache
         uses: ./.github/actions/post-cache


### PR DESCRIPTION
# Description

Splits GHA caching into 3 parts:

  1. The ~/.cargo cache
  2. The ./target cache
  3. The sccache cache along with starting the sccache server

All caches are keyed with cache_version along with a hash of all Cargo.lock files in the project. As a fallback they
take the newest cache with any hash of Cargo.lock files to rebuild from a partial cache in case of a Cargo.lock change.

Thanks to this, we should now correctly cache `target`. Each workflow might generate different contents in `target`, because the workflows compile different things and use or don't `--release`. However, the cache action only allows a single version of the cache under a given key. When caching `target` along with `~/.cargo`, this leads to a race condition where one workflow manages to upload the cache and then all the other workflows need to use this version. However, that version will not contain any of the files that would be useful for those other builds and they will need to rebuild those. Note that if a cache hit occurs, the cache action __wil not__ upload an updated version of that cache at the end.

Additionally, this PR triggers the `unit-test` and `check-excluded-packages` actions on pushes to `main`. This is to build the cache in the context of `main`. Caches are normally isolated per-branch with the exception of the `main` cache being available in other branches. This should lead to the first build of a PR to be fast as well.

## Type of change

- [x] CI config, no code changes
