### PR TITLE
Minor changes to `aleph-client` 

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -76,7 +76,7 @@ pub type Connection = Api<KeyPair, WsRpcClient>;
 /// Direct casting is often more handy than generic `.into()`. Justification: `Connection` objects
 /// are often passed to some macro like `compose_extrinsic!` and thus there is not enough
 /// information for type inferring required for `Into<Connection>`.
-pub trait AnyConnection: Clone {
+pub trait AnyConnection: Clone + Send {
     fn as_connection(&self) -> Connection;
 }
 

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -103,9 +103,12 @@ impl SignedConnection {
     }
 
     /// Semantically equivalent to `connection.set_signer(signer)`.
-    pub fn from_any_connection<C: AnyConnection>(connection: C, signer: KeyPair) -> Self {
+    pub fn from_any_connection<C: AnyConnection>(connection: &C, signer: KeyPair) -> Self {
         Self {
-            inner: connection.as_connection().set_signer(signer.clone()),
+            inner: connection
+                .clone()
+                .as_connection()
+                .set_signer(signer.clone()),
             signer,
         }
     }
@@ -129,7 +132,7 @@ impl TryFrom<Connection> for SignedConnection {
 
     fn try_from(connection: Connection) -> Result<Self, Self::Error> {
         if let Some(signer) = connection.signer.clone() {
-            Ok(Self::from_any_connection(connection, signer))
+            Ok(Self::from_any_connection(&connection, signer))
         } else {
             Err("Connection should be signed.")
         }

--- a/aleph-client/src/multisig.rs
+++ b/aleph-client/src/multisig.rs
@@ -209,7 +209,7 @@ impl MultisigParty {
         connection: &C,
     ) -> (SignedConnection, Vec<AccountId>) {
         let (author, other_signatories) = self.designate_representative_and_represented(author_idx);
-        let connection = SignedConnection::from_any_connection(connection.as_connection(), author);
+        let connection = SignedConnection::from_any_connection(connection, author);
         (connection, other_signatories)
     }
 
@@ -481,7 +481,7 @@ pub fn perform_multisig_with_threshold_1<C: AnyConnection, CallDetails: Encode +
     other_signatories: &[AccountId],
     call: CallDetails,
 ) -> Result<()> {
-    let connection = SignedConnection::from_any_connection(connection.clone(), author);
+    let connection = SignedConnection::from_any_connection(connection, author);
     let xt = compose_extrinsic!(
         connection.as_connection(),
         "Multisig",

--- a/aleph-client/src/vesting.rs
+++ b/aleph-client/src/vesting.rs
@@ -14,8 +14,6 @@ use crate::{
 /// Gathers errors from this module.
 #[derive(Debug, Error)]
 pub enum VestingError {
-    #[error("🦺❌ Account has no active vesting schedules.")]
-    NotVesting,
     #[error("🦺❌ The connection should be signed.")]
     UnsignedConnection,
 }
@@ -85,18 +83,18 @@ pub fn vested_transfer(
     Ok(())
 }
 
-/// Returns all active schedules of `who`.
+/// Returns all active schedules of `who`. If `who` does not have any active vesting schedules,
+/// an empty container is returned.
 ///
-/// Fails if `who` does not have any active vesting schedules.
+/// Fails if storage could have not been read.
 pub fn get_schedules<C: AnyConnection>(
     connection: &C,
     who: AccountId,
 ) -> Result<Vec<VestingSchedule>> {
     connection
         .as_connection()
-        .get_storage_map::<AccountId, Option<Vec<VestingSchedule>>>(PALLET, "Vesting", who, None)?
-        .flatten()
-        .ok_or_else(|| VestingError::NotVesting.into())
+        .get_storage_map::<AccountId, Vec<VestingSchedule>>(PALLET, "Vesting", who, None)?
+        .map_or_else(|| Ok(vec![]), Ok)
 }
 
 /// Merges two vesting schedules (at indices `idx1` and `idx2`) of the signer of `connection`.

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "hex",


### PR DESCRIPTION
# Description

We introduce three minor changes to `aleph-client` library:
 - `vesting::get_schedules` is fixed and its behavior is improved (unambiguous result)
 - `AnyConnection` trait is also `Send`
 - `SignedConnection::from_any_connection` takes a reference to `AnyConnection` instead of ownership - in `traffic-maker` every single usage required preserving original source connection and this 'proves' that the newer API is more useful

I would like to merge it soon and include these changes in a PR to `traffic-maker` for A0-1000.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Infrastructure updated accordingly
- [ ] I have made corresponding changes to the documentation
- [ ] New documentation created
- [ ] Bump `spec_version` and `transaction_version` if relevant
- [x] Bump `aleph-client` version if relevant
