### PR TITLE
A0-788: Add descriptive errors to proposal validation

### DIFF
--- a/finality-aleph/src/data_io/data_interpreter.rs
+++ b/finality-aleph/src/data_io/data_interpreter.rs
@@ -69,13 +69,13 @@ impl<B: BlockT, C: HeaderBackend<B>> OrderedDataInterpreter<B, C> {
         match new_data {
             AlephData::Empty => None,
             AlephData::HeadProposal(unvalidated_proposal) => {
-                let proposal = if let Some(proposal) =
-                    unvalidated_proposal.validate_bounds(&self.session_boundaries)
+                let proposal = match unvalidated_proposal.validate_bounds(&self.session_boundaries)
                 {
-                    proposal
-                } else {
-                    warn!(target: "aleph-finality", "Incorrect proposal {:?} passed through data availability, session bounds: {:?}", unvalidated_proposal, self.session_boundaries);
-                    return None;
+                    Ok(proposal) => proposal,
+                    Err(error) => {
+                        warn!(target: "aleph-finality", "Incorrect proposal {:?} passed through data availability, session bounds: {:?}, error: {:?}", unvalidated_proposal, self.session_boundaries, error);
+                        return None;
+                    }
                 };
 
                 // WARNING: If we ever enable pruning, this code (and the code in Data Store) must be carefully analyzed

--- a/finality-aleph/src/data_io/data_store.rs
+++ b/finality-aleph/src/data_io/data_store.rs
@@ -634,14 +634,13 @@ where
             match data {
                 Empty => {}
                 HeadProposal(unvalidated_proposal) => {
-                    if let Some(proposal) =
-                        unvalidated_proposal.validate_bounds(&self.session_boundaries)
-                    {
-                        proposals.push(proposal);
-                    } else {
-                        warn!(target: "aleph-data-store", "Message {:?} dropped as it contains \
-                            proposal {:?} not within bounds.", message, unvalidated_proposal);
-                        return;
+                    match unvalidated_proposal.validate_bounds(&self.session_boundaries) {
+                        Ok(proposal) => proposals.push(proposal),
+                        Err(error) => {
+                            warn!(target: "aleph-data-store", "Message {:?} dropped as it contains \
+                            proposal {:?} not within bounds ({:?}).", message, unvalidated_proposal, error);
+                            return;
+                        }
                     }
                 }
             }

--- a/finality-aleph/src/data_io/proposal.rs
+++ b/finality-aleph/src/data_io/proposal.rs
@@ -8,7 +8,6 @@ use crate::{
     BlockHashNum, SessionBoundaries,
 };
 use codec::{Decode, Encode};
-use derive_more::Error;
 use sp_runtime::{
     traits::{Block as BlockT, NumberFor},
     SaturatedConversion,
@@ -39,11 +38,8 @@ pub struct UnvalidatedAlephProposal<B: BlockT> {
 }
 
 /// Represents possible invalid states as described in [UnvalidatedAlephProposal].
-#[derive(Debug, PartialEq, Error)]
-pub enum ValidationError<B>
-where
-    B: BlockT,
-{
+#[derive(Debug, PartialEq)]
+pub enum ValidationError<B: BlockT> {
     BranchEmpty,
     BranchTooLarge {
         branch_size: usize,


### PR DESCRIPTION
# Description

Adds descriptive errors to proposal validation.
Closes https://cardinal-cryptography.atlassian.net/browse/A0-788

## Type of change

- Refactoring (non-breaking change)

# Checklist:

- I have added tests
- I have created new documentation