### PR TITLE
Fix runtime update test

### DIFF
--- a/local-tests/chainrunner/node.py
+++ b/local-tests/chainrunner/node.py
@@ -76,7 +76,7 @@ class Node:
         if self.running:
             print("cannot export state of a running node")
             return {}
-        cmd = [self.binary, 'export-state', '--pruning', 'archive'] + self._stdargs()
+        cmd = [self.binary, 'export-state'] + self._stdargs()
         if block is not None:
             cmd.append(str(block))
         proc = subprocess.run(cmd, capture_output=True, check=True)

--- a/local-tests/test_update.ipynb
+++ b/local-tests/test_update.ipynb
@@ -77,17 +77,29 @@
    "outputs": [],
    "source": [
     "chain = Chain(workdir)\n",
-    "chain.bootstrap(oldbin, keys.values(), sudo_account_id=keys[phrases[0]], chain_type='local')"
+    "chain.bootstrap(oldbin,\n",
+    "                keys.values(),\n",
+    "                sudo_account_id=keys[phrases[0]],\n",
+    "                chain_type='local')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "8e8af710-b10e-4c25-bbf4-3651fece2370",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "chain.set_flags('validator', port=Seq(30334), ws_port=Seq(9944), rpc_port=Seq(9933), unit_creation_delay=200, execution='Native')"
+    "chain.set_flags('validator',\n",
+    "                port=Seq(30334),\n",
+    "                ws_port=Seq(9944),\n",
+    "                rpc_port=Seq(9933),\n",
+    "                unit_creation_delay=200,\n",
+    "                execution='Native')\n",
+    "addresses = [n.address() for n in chain]\n",
+    "chain.set_flags(public_addr=addresses)"
    ]
   },
   {
@@ -143,8 +155,7 @@
    "outputs": [],
    "source": [
     "subprocess.check_call(\n",
-    "    [cliain, '--node', 'localhost:9945', '--seed', phrases[0], 'update-runtime', '--runtime', runtime],\n",
-    "    env=dict(os.environ, RUST_LOG=\"warn\"))"
+    "    [cliain, '--node', 'localhost:9945', '--seed', phrases[0], 'update-runtime', '--runtime', runtime])"
    ]
   },
   {
@@ -234,7 +245,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/local-tests/test_update.py
+++ b/local-tests/test_update.py
@@ -55,6 +55,9 @@ chain.set_flags('validator',
                 unit_creation_delay=200,
                 execution='Native')
 
+addresses = [n.address() for n in chain]
+chain.set_flags(public_addr=addresses)
+
 print('Starting the chain with old binary')
 chain.start('old')
 
@@ -80,9 +83,7 @@ oldver = query_runtime_version(chain)
 
 print('Submitting extrinsic with new runtime')
 subprocess.check_call(
-    [CLIAIN, '--node', 'localhost:9945', '--seed', phrases[0],
-        'update-runtime', '--runtime', runtime],
-    env=dict(os.environ, RUST_LOG="warn"))
+    [CLIAIN, '--node', 'localhost:9945', '--seed', phrases[0], 'update-runtime', '--runtime', runtime])
 
 print('Waiting a bit')
 sleep(10)


### PR DESCRIPTION
- Removes `--pruning archive` flag from export state command in Python chainrunner (it started crashing if the chain was run without)
- Tries to speed up the finalization when stopping/starting chain 
