### PR TITLE
Add pruning flag after substrate update

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -36,6 +36,7 @@ fi
 
 ARGS=(
   --validator
+  --pruning archive
   --execution Native
   --name "${NAME}"
   --base-path "${BASE_PATH}"

--- a/local-tests/run_nodes.py
+++ b/local-tests/run_nodes.py
@@ -37,7 +37,8 @@ chain.set_flags('validator',
                 unit_creation_delay=500,
                 execution='Native',
                 rpc_cors='all',
-                rpc_methods='Unsafe')
+                rpc_methods='Unsafe',
+                pruning='archive')
 addresses = [n.address() for n in chain]
 chain.set_flags(bootnodes=addresses[0], public_addr=addresses)
 

--- a/local-tests/test_catch_up.py
+++ b/local-tests/test_catch_up.py
@@ -26,7 +26,8 @@ chain.set_flags(port=Seq(30334),
                 ws_port=Seq(9944),
                 rpc_port=Seq(9933),
                 unit_creation_delay=200,
-                execution='Native')
+                execution='Native',
+                pruning='archive')
 
 chain.set_flags_validator('validator')
 

--- a/local-tests/test_update.ipynb
+++ b/local-tests/test_update.ipynb
@@ -97,7 +97,8 @@
     "                ws_port=Seq(9944),\n",
     "                rpc_port=Seq(9933),\n",
     "                unit_creation_delay=200,\n",
-    "                execution='Native')\n",
+    "                execution='Native',\n",
+    "                pruning='archive')\n",
     "addresses = [n.address() for n in chain]\n",
     "chain.set_flags(public_addr=addresses)"
    ]

--- a/local-tests/test_update.py
+++ b/local-tests/test_update.py
@@ -53,7 +53,8 @@ chain.set_flags('validator',
                 ws_port=Seq(9944),
                 rpc_port=Seq(9933),
                 unit_creation_delay=200,
-                execution='Native')
+                execution='Native',
+                pruning='archive')
 
 addresses = [n.address() for n in chain]
 chain.set_flags(public_addr=addresses)

--- a/scripts/run_nodes.sh
+++ b/scripts/run_nodes.sh
@@ -82,6 +82,7 @@ run_node() {
   ./target/release/aleph-node purge-chain --base-path $BASE_PATH/$account_id --chain $BASE_PATH/chainspec.json -y
   ./target/release/aleph-node \
     $validator \
+    --pruning=archive \
     --chain $BASE_PATH/chainspec.json \
     --base-path $BASE_PATH/$account_id \
     --name $auth \


### PR DESCRIPTION
# Description

After substrate update, pruning is no longer dependent on `--validator` flag (https://github.com/paritytech/substrate/commit/43d8c8787ded25dab5db55af5ab65f5d5882a51b#diff-a0791f65f4128fe45b6409b3ab1684d88ee9caaa916838d6c6786508b6c1d228R42) so we need to explicitly disable it by `--pruning archive`
## Type of change

- Bug fix (non-breaking change which fixes an issue)
