### PR TITLE
Change state version to 0

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -116,7 +116,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 8,
-    state_version: 1,
+    state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.


### PR DESCRIPTION
Turns out 0 is the vaue we've been using 