### PR TITLE
A0-1041: Treasury code cleanup

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ac-primitives",
  "anyhow",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 
 [dependencies]

--- a/aleph-client/src/balances.rs
+++ b/aleph-client/src/balances.rs
@@ -1,0 +1,13 @@
+use crate::AnyConnection;
+use primitives::Balance;
+
+/// Reads from the storage how much balance is currently on chain.
+///
+/// Performs a single storage read.
+pub fn total_issuance<C: AnyConnection>(connection: &C) -> Balance {
+    connection
+        .as_connection()
+        .get_storage_value("Balances", "TotalIssuance", None)
+        .expect("Key `Balances::TotalIssuance` should be present in storage")
+        .unwrap_or(0)
+}

--- a/aleph-client/src/balances.rs
+++ b/aleph-client/src/balances.rs
@@ -9,5 +9,5 @@ pub fn total_issuance<C: AnyConnection>(connection: &C) -> Balance {
         .as_connection()
         .get_storage_value("Balances", "TotalIssuance", None)
         .expect("Key `Balances::TotalIssuance` should be present in storage")
-        .unwrap_or(0)
+        .unwrap()
 }

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -12,6 +12,7 @@ use substrate_api_client::{
 };
 
 pub use account::{get_free_balance, locks};
+pub use balances::total_issuance;
 pub use debug::print_storages;
 pub use fee::{get_next_fee_multiplier, get_tx_fee_info, FeeInfo};
 pub use multisig::{
@@ -35,6 +36,9 @@ pub use system::set_code;
 pub use transfer::{
     batch_transfer as balances_batch_transfer, transfer as balances_transfer, TransferTransaction,
 };
+pub use treasury::{
+    proposals_counter as treasury_proposals_counter, staking_treasury_payout, treasury_account,
+};
 pub use vesting::{
     get_schedules, merge_schedules, vest, vest_other, vested_transfer, VestingError,
     VestingSchedule,
@@ -42,6 +46,7 @@ pub use vesting::{
 pub use waiting::{wait_for_event, wait_for_finalized_block};
 
 mod account;
+mod balances;
 mod debug;
 mod fee;
 mod multisig;
@@ -50,6 +55,7 @@ mod session;
 mod staking;
 mod system;
 mod transfer;
+mod treasury;
 mod vesting;
 mod waiting;
 

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -37,7 +37,9 @@ pub use transfer::{
     batch_transfer as balances_batch_transfer, transfer as balances_transfer, TransferTransaction,
 };
 pub use treasury::{
-    proposals_counter as treasury_proposals_counter, staking_treasury_payout, treasury_account,
+    approve as approve_treasury_proposal, proposals_counter as treasury_proposals_counter,
+    propose as make_treasury_proposal, reject as reject_treasury_proposal, staking_treasury_payout,
+    treasury_account,
 };
 pub use vesting::{
     get_schedules, merge_schedules, vest, vest_other, vested_transfer, VestingError,

--- a/aleph-client/src/treasury.rs
+++ b/aleph-client/src/treasury.rs
@@ -69,12 +69,7 @@ pub fn propose(
         Compact(value),
         GenericAddress::Id(beneficiary.clone())
     );
-    try_send_xt(
-        connection,
-        xt.clone(),
-        Some("treasury spend"),
-        XtStatus::Finalized,
-    )
+    try_send_xt(connection, xt, Some("treasury spend"), XtStatus::Finalized)
 }
 
 #[derive(Debug, Decode, Copy, Clone)]
@@ -104,7 +99,7 @@ fn send_rejection(connection: &RootConnection, proposal_id: u32) -> ApiResult<Op
     );
     try_send_xt(
         connection,
-        xt.clone(),
+        xt,
         Some("treasury rejection"),
         XtStatus::Finalized,
     )
@@ -133,7 +128,7 @@ fn send_approval(connection: &RootConnection, proposal_id: u32) -> ApiResult<Opt
     );
     try_send_xt(
         connection,
-        xt.clone(),
+        xt,
         Some("treasury approval"),
         XtStatus::Finalized,
     )

--- a/aleph-client/src/treasury.rs
+++ b/aleph-client/src/treasury.rs
@@ -133,7 +133,7 @@ fn wait_for_approval<C: AnyConnection>(connection: &C, proposal_id: u32) -> AnyR
             .as_connection()
             .get_storage_value("Treasury", "Approvals", None)
             .expect("Key `Treasury::Approvals` should be present in storage")
-            .unwrap_or_default();
+            .unwrap();
         if approvals.contains(&proposal_id) {
             return Ok(());
         } else {

--- a/aleph-client/src/treasury.rs
+++ b/aleph-client/src/treasury.rs
@@ -1,0 +1,49 @@
+use frame_support::PalletId;
+use log::info;
+use sp_runtime::{traits::AccountIdConversion, AccountId32};
+
+use primitives::Balance;
+
+use crate::AnyConnection;
+
+/// Returns the account of the treasury.
+pub fn treasury_account() -> AccountId32 {
+    PalletId(*b"a0/trsry").into_account_truncating()
+}
+
+/// Returns how many treasury proposals have ever been created.
+///
+/// Requires a single storage read.
+pub fn proposals_counter<C: AnyConnection>(connection: &C) -> u32 {
+    connection
+        .as_connection()
+        .get_storage_value("Treasury", "ProposalCount", None)
+        .expect("Key `Treasury::ProposalCount` should be present in storage")
+        .unwrap_or(0)
+}
+
+/// Calculates how much balance will be paid out to the treasury after each era.
+///
+/// Every call to this method is potentially expensive - it requires three storage reads.
+pub fn staking_treasury_payout<C: AnyConnection>(connection: &C) -> Balance {
+    let sessions_per_era = connection
+        .as_connection()
+        .get_constant::<u32>("Staking", "SessionsPerEra")
+        .expect("Constant `Staking::SessionsPerEra` should be present");
+    let session_period = connection
+        .as_connection()
+        .get_constant::<u32>("Elections", "SessionPeriod")
+        .expect("Constant `Elections::SessionPeriod` should be present");
+    let millisecs_per_block = 2 * connection
+        .as_connection()
+        .get_constant::<u64>("Timestamp", "MinimumPeriod")
+        .expect("Constant `Timestamp::MinimumPeriod` should be present");
+
+    let millisecs_per_era = millisecs_per_block * session_period as u64 * sessions_per_era as u64;
+    let treasury_era_payout_from_staking = primitives::staking::era_payout(millisecs_per_era).1;
+    info!(
+        "[+] Possible treasury gain from staking is {}",
+        treasury_era_payout_from_staking
+    );
+    treasury_era_payout_from_staking
+}

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ac-primitives",
  "anyhow",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ac-primitives",
  "anyhow",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ac-primitives",
  "anyhow",

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ac-primitives",
  "anyhow",


### PR DESCRIPTION
# Description

Moved some functionalities from e2e to aleph-client. Local refactors.

Next steps (another PRs):
 - [unify reading storage/constants in aleph-client](https://cardinal-cryptography.atlassian.net/browse/A0-1096)
 - [extend cliain with treasury commands](https://cardinal-cryptography.atlassian.net/browse/A0-1098)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have made corresponding changes to the existing documentation
- I have created new documentation
- I have bumped aleph-client version if relevant
