### PR TITLE
A0-1099: Conditionally enable treasury proposals

### DIFF
--- a/.github/workflows/build-node-and-runtime.yml
+++ b/.github/workflows/build-node-and-runtime.yml
@@ -57,7 +57,7 @@ jobs:
           retention-days: 7
 
       - name: Build test binary
-        run: cargo build --release -p aleph-node --features "short_session"
+        run: cargo build --release -p aleph-node --features "short_session treasury_proposals"
 
       - name: Upload test binary
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-node-and-runtime.yml
+++ b/.github/workflows/build-node-and-runtime.yml
@@ -57,7 +57,7 @@ jobs:
           retention-days: 7
 
       - name: Build test binary
-        run: cargo build --release -p aleph-node --features "short_session treasury_proposals"
+        run: cargo build --release -p aleph-node --features "short_session enable_treasury_proposals"
 
       - name: Upload test binary
         uses: actions/upload-artifact@v2

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -74,6 +74,6 @@ short_session = [
     "aleph-runtime/short_session",
     "aleph-primitives/short_session"
 ]
-treasury_proposals = [
-    "aleph-runtime/treasury_proposals"
+enable_treasury_proposals = [
+    "aleph-runtime/enable_treasury_proposals"
 ]

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -74,3 +74,6 @@ short_session = [
     "aleph-runtime/short_session",
     "aleph-primitives/short_session"
 ]
+treasury_proposals = [
+    "aleph-runtime/treasury_proposals"
+]

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -109,4 +109,4 @@ std = [
     "pallet-nomination-pools/std",
 ]
 short_session = ["primitives/short_session"]
-treasury_proposals = []
+enable_treasury_proposals = []

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -109,3 +109,4 @@ std = [
     "pallet-nomination-pools/std",
 ]
 short_session = ["primitives/short_session"]
+treasury_proposals = []

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -574,16 +574,23 @@ impl pallet_multisig::Config for Runtime {
     type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
 }
 
+#[cfg(not(feature = "treasury_proposals"))]
+// This value effectively disables treasury.
+pub const TREASURY_PROPOSAL_BOND: Balance = 100_000_000_000 * TOKEN;
+
+#[cfg(feature = "treasury_proposals")]
+pub const TREASURY_PROPOSAL_BOND: Balance = 100 * TOKEN;
+
 parameter_types! {
     // We do not burn any money within treasury.
     pub const Burn: Permill = Permill::from_percent(0);
     // The fraction of the proposal that the proposer should deposit.
     // We agreed on non-progressive deposit.
     pub const ProposalBond: Permill = Permill::from_percent(0);
-    // The minimal deposit for proposal. This value effectively disables treasury.
-    pub const ProposalBondMinimum: Balance = 100_000_000_000 * TOKEN;
+    // The minimal deposit for proposal.
+    pub const ProposalBondMinimum: Balance = TREASURY_PROPOSAL_BOND;
     // The upper bound of the deposit for the proposal.
-    pub const ProposalBondMaximum: Balance = 100_000_000_000 * TOKEN;
+    pub const ProposalBondMaximum: Balance = TREASURY_PROPOSAL_BOND;
     // Maximum number of approvals that can wait in the spending queue.
     pub const MaxApprovals: u32 = 20;
     // Every 4 hours we fund accepted proposals.

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 20,
+    spec_version: 21,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 8,

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -574,11 +574,11 @@ impl pallet_multisig::Config for Runtime {
     type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
 }
 
-#[cfg(not(feature = "treasury_proposals"))]
+#[cfg(not(feature = "enable_treasury_proposals"))]
 // This value effectively disables treasury.
 pub const TREASURY_PROPOSAL_BOND: Balance = 100_000_000_000 * TOKEN;
 
-#[cfg(feature = "treasury_proposals")]
+#[cfg(feature = "enable_treasury_proposals")]
 pub const TREASURY_PROPOSAL_BOND: Balance = 100 * TOKEN;
 
 parameter_types! {

--- a/scripts/run_local_e2e_pipeline.sh
+++ b/scripts/run_local_e2e_pipeline.sh
@@ -3,7 +3,7 @@
 set -e
 
 # build release binary
-cargo build --release -p aleph-node --features "short_session"
+cargo build --release -p aleph-node --features "short_session treasury_proposals"
 # build docker image
 docker build --tag aleph-node:latest -f ./docker/Dockerfile .
 

--- a/scripts/run_local_e2e_pipeline.sh
+++ b/scripts/run_local_e2e_pipeline.sh
@@ -3,7 +3,7 @@
 set -e
 
 # build release binary
-cargo build --release -p aleph-node --features "short_session treasury_proposals"
+cargo build --release -p aleph-node --features "short_session enable_treasury_proposals"
 # build docker image
 docker build --tag aleph-node:latest -f ./docker/Dockerfile .
 

--- a/scripts/run_nodes.sh
+++ b/scripts/run_nodes.sh
@@ -38,7 +38,7 @@ clear
 
 
 if $BUILD_ALEPH_NODE ; then
-  cargo build --release -p aleph-node --features "short_session treasury_proposals"
+  cargo build --release -p aleph-node --features "short_session enable_treasury_proposals"
 fi
 
 declare -a account_ids

--- a/scripts/run_nodes.sh
+++ b/scripts/run_nodes.sh
@@ -38,7 +38,7 @@ clear
 
 
 if $BUILD_ALEPH_NODE ; then
-  cargo build --release -p aleph-node --features "short_session"
+  cargo build --release -p aleph-node --features "short_session treasury_proposals"
 fi
 
 declare -a account_ids


### PR DESCRIPTION
# Description

We introduce new feature flag to `aleph-node` and `aleph-runtime`: `treasury_proposals`:
 - when it is **on** making proposal to the treasury has a constant price of 100 tokens
 - when it is **off** making proposal to the treasury has a constant price of 10<sup>11</sup> tokens (which effectively disables proposals)

By default the feature is **off**. However, for local development and tests we switch it on. Hence, we could restore old e2e test verifying that `sudo` can maintain proposals (reject/approve).

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have added tests
- I have made neccessary updates to the Infrastructure
- I have made corresponding changes to the existing documentation
- I have created new documentation
- I have bumped `spec_version` and `transaction_version`
