### PR TITLE
fix change_validators call

### DIFF
--- a/pallets/elections/src/impls.rs
+++ b/pallets/elections/src/impls.rs
@@ -5,9 +5,9 @@ use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 use crate::{
     traits::{EraInfoProvider, SessionInfoProvider, ValidatorRewardsHandler},
-    CommitteeSize, Config, CurrentEraValidators, EraValidators, NextEraNonReservedValidators,
-    NextEraReservedValidators, Pallet, SessionValidatorBlockCount, ValidatorEraTotalReward,
-    ValidatorTotalRewards,
+    CommitteeSize, Config, CurrentEraValidators, EraValidators, NextEraCommitteeSize,
+    NextEraNonReservedValidators, NextEraReservedValidators, Pallet, SessionValidatorBlockCount,
+    ValidatorEraTotalReward, ValidatorTotalRewards,
 };
 
 const MAX_REWARD: u32 = 1_000_000_000;
@@ -201,10 +201,13 @@ where
         Self::if_era_starts_do(active_era + 1, session, || {
             let reserved_validators = NextEraReservedValidators::<T>::get();
             let non_reserved_validators = NextEraNonReservedValidators::<T>::get();
+            let committee_size = NextEraCommitteeSize::<T>::get();
+
             CurrentEraValidators::<T>::put(EraValidators {
                 reserved: reserved_validators,
                 non_reserved: non_reserved_validators,
             });
+            CommitteeSize::<T>::put(committee_size);
         });
     }
 

--- a/pallets/elections/src/lib.rs
+++ b/pallets/elections/src/lib.rs
@@ -131,6 +131,18 @@ pub mod pallet {
     #[pallet::storage]
     pub type CommitteeSize<T> = StorageValue<_, u32, ValueQuery>;
 
+    #[pallet::type_value]
+    pub fn DefaultNextEraCommitteeSize<T: Config>() -> u32 {
+        CommitteeSize::<T>::get()
+    }
+
+    /// Desirable size of a committee in force from a new era.
+    ///
+    /// can be change via `change_validators` call that require sudo.
+    #[pallet::storage]
+    pub type NextEraCommitteeSize<T> =
+        StorageValue<_, u32, ValueQuery, DefaultNextEraCommitteeSize<T>>;
+
     /// List of reserved validators in force from a new era.
     ///
     /// Can be changed via `change_validators` call that requires sudo.
@@ -173,7 +185,7 @@ pub mod pallet {
             committee_size: Option<u32>,
         ) -> DispatchResult {
             ensure_root(origin)?;
-            let committee_size = committee_size.unwrap_or_else(CommitteeSize::<T>::get);
+            let committee_size = committee_size.unwrap_or(NextEraCommitteeSize::<T>::get());
             let reserved_validators =
                 reserved_validators.unwrap_or_else(NextEraReservedValidators::<T>::get);
             let non_reserved_validators =
@@ -187,7 +199,7 @@ pub mod pallet {
 
             NextEraNonReservedValidators::<T>::put(non_reserved_validators.clone());
             NextEraReservedValidators::<T>::put(reserved_validators.clone());
-            CommitteeSize::<T>::put(committee_size);
+            NextEraCommitteeSize::<T>::put(committee_size);
 
             Self::deposit_event(Event::ChangeValidators(
                 reserved_validators,


### PR DESCRIPTION
# Description
Fix setting the CommitteSize for the next era in the pallet call.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- delete when not applicable to your PR -->
- I have created new documentation
- I have bumped `spec_version` and `transaction_version`
