### PR TITLE
Rotating reserved nodes

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "log",
  "pallet-aleph",
  "pallet-balances",
+ "pallet-elections",
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
@@ -1659,6 +1660,25 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-elections"
+version = "0.3.0"
+dependencies = [
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-session",
+ "pallet-staking",
+ "parity-scale-codec",
+ "primitives",
+ "scale-info",
+ "sp-core",
+ "sp-staking",
  "sp-std",
 ]
 

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -25,6 +25,7 @@ pallet-balances = { git = "https://github.com/Cardinal-Cryptography/substrate.gi
 pallet-vesting = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.23", default-features = false }
 
 pallet-aleph = { path = "../pallets/aleph", default-features = false }
+pallet-elections = { path = "../pallets/elections", default-features = false }
 primitives = { path = "../primitives", default-features = false }
 
 [features]
@@ -39,4 +40,5 @@ std = [
     "pallet-balances/std",
     "pallet-multisig/std",
     "pallet-vesting/std",
+    "pallet-elections/std",
 ]

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -108,7 +108,12 @@ pub trait AnyConnection: Clone + Send {
     ) -> T {
         self.as_connection()
             .get_storage_value(pallet, key, None)
-            .unwrap_or_else(|_| panic!("Key `{}::{}` should be present in storage", pallet, key))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Key `{}::{}` should be present in storage, error {:?}",
+                    pallet, key, e
+                )
+            })
             .unwrap_or_else(fallback)
     }
 

--- a/aleph-client/src/session.rs
+++ b/aleph-client/src/session.rs
@@ -5,6 +5,7 @@ use sp_core::{Pair, H256};
 use substrate_api_client::{
     compose_call, compose_extrinsic, AccountId, ExtrinsicParams, FromHexString, XtStatus,
 };
+use pallet_elections::CommitteeSeats;
 
 use crate::{
     send_xt, waiting::wait_for_event, AnyConnection, BlockNumber, RootConnection, SignedConnection,
@@ -45,17 +46,17 @@ pub fn change_validators(
     sudo_connection: &RootConnection,
     new_reserved_validators: Option<Vec<AccountId>>,
     new_non_reserved_validators: Option<Vec<AccountId>>,
-    validators_per_session: Option<u32>,
+    committee_size: Option<CommitteeSeats>,
     status: XtStatus,
 ) {
-    info!(target: "aleph-client", "New validators: reserved: {:#?}, non_reserved: {:#?}, validators_per_session: {:?}", new_reserved_validators, new_non_reserved_validators, validators_per_session);
+    info!(target: "aleph-client", "New validators: reserved: {:#?}, non_reserved: {:#?}, validators_per_session: {:?}", new_reserved_validators, new_non_reserved_validators, committee_size);
     let call = compose_call!(
         sudo_connection.as_connection().metadata,
         "Elections",
         "change_validators",
         new_reserved_validators,
         new_non_reserved_validators,
-        validators_per_session
+        committee_size
     );
     let xt = compose_extrinsic!(
         sudo_connection.as_connection(),

--- a/aleph-client/src/session.rs
+++ b/aleph-client/src/session.rs
@@ -1,11 +1,11 @@
 use codec::{Decode, Encode};
 use log::info;
+use pallet_elections::CommitteeSeats;
 use primitives::SessionIndex;
 use sp_core::{Pair, H256};
 use substrate_api_client::{
     compose_call, compose_extrinsic, AccountId, ExtrinsicParams, FromHexString, XtStatus,
 };
-use pallet_elections::CommitteeSeats;
 
 use crate::{
     send_xt, waiting::wait_for_event, AnyConnection, BlockNumber, RootConnection, SignedConnection,

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "log",
  "pallet-aleph",
  "pallet-balances",
+ "pallet-elections",
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
@@ -429,6 +430,7 @@ dependencies = [
  "env_logger 0.8.4",
  "ink_metadata",
  "log",
+ "pallet-elections",
  "pallet-staking",
  "parity-scale-codec",
  "primitives",
@@ -2046,6 +2048,25 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime 6.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23)",
+ "sp-std 4.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23)",
+]
+
+[[package]]
+name = "pallet-elections"
+version = "0.3.0"
+dependencies = [
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-session",
+ "pallet-staking",
+ "parity-scale-codec",
+ "primitives",
+ "scale-info",
+ "sp-core 6.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23)",
+ "sp-staking",
  "sp-std 4.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23)",
 ]
 

--- a/bin/cliain/Cargo.toml
+++ b/bin/cliain/Cargo.toml
@@ -15,6 +15,7 @@ env_logger = "0.8"
 ink_metadata = { version = "3.0", features = ["derive"] }
 log = "0.4"
 pallet-staking = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.23" }
+pallet-elections = { path = "../../pallets/elections" }
 primitives = { path = "../../primitives" }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/bin/cliain/src/validators.rs
+++ b/bin/cliain/src/validators.rs
@@ -1,4 +1,5 @@
 use aleph_client::RootConnection;
+use pallet_elections::CommitteeSeats;
 use sp_core::crypto::Ss58Codec;
 use substrate_api_client::{AccountId, XtStatus};
 
@@ -15,7 +16,10 @@ pub fn change_validators(root_connection: RootConnection, validators: Vec<String
         &root_connection,
         Some(validators),
         Some(vec![]),
-        Some(validators_len),
+        Some(CommitteeSeats {
+            reserved_seats: validators_len,
+            non_reserved_seats: 0,
+        }),
         XtStatus::Finalized,
     );
     // TODO we need to check state here whether change members actually succeed

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 23,
+    spec_version: 24,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 8,

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 24,
+    spec_version: 25,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 8,

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "log",
  "pallet-aleph",
  "pallet-balances",
+ "pallet-elections",
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",

--- a/e2e-tests/src/rewards.rs
+++ b/e2e-tests/src/rewards.rs
@@ -6,7 +6,7 @@ use aleph_client::{
     RewardPoint, SessionKeys, SignedConnection,
 };
 use log::info;
-use pallet_elections::LENIENT_THRESHOLD;
+use pallet_elections::{CommitteeSeats, LENIENT_THRESHOLD};
 use pallet_staking::Exposure;
 use primitives::{EraIndex, SessionIndex};
 use sp_core::H256;
@@ -161,7 +161,7 @@ pub fn check_points(
     let before_end_of_session_block_hash = get_block_hash(connection, end_of_session_block - 1);
     info!("End-of-session block hash: {}.", end_of_session_block_hash);
 
-    let members_per_session: u32 = connection
+    let committee_seats: CommitteeSeats = connection
         .as_connection()
         .get_storage_value(
             "Elections",
@@ -170,6 +170,8 @@ pub fn check_points(
         )
         .expect("Failed to decode CommitteeSize extrinsic!")
         .unwrap_or_else(|| panic!("Failed to obtain CommitteeSize for session {}.", session));
+
+    let members_per_session = committee_seats.non_reserved_seats + committee_seats.reserved_seats;
 
     info!("Members per session: {}.", members_per_session);
 

--- a/e2e-tests/src/test/era_validators.rs
+++ b/e2e-tests/src/test/era_validators.rs
@@ -4,6 +4,7 @@ use aleph_client::{
     SignedConnection,
 };
 use codec::Decode;
+use pallet_elections::CommitteeSeats;
 use sp_core::Pair;
 use substrate_api_client::{AccountId, XtStatus};
 
@@ -89,7 +90,10 @@ pub fn era_validators(config: &Config) -> anyhow::Result<()> {
         &root_connection,
         Some(initial_reserved_validators.clone()),
         Some(initial_non_reserved_validators.clone()),
-        Some(4),
+        Some(CommitteeSeats {
+            reserved_seats: 2,
+            non_reserved_seats: 2,
+        }),
         XtStatus::InBlock,
     );
     wait_for_full_era_completion(&connection)?;
@@ -98,7 +102,10 @@ pub fn era_validators(config: &Config) -> anyhow::Result<()> {
         &root_connection,
         Some(new_reserved_validators.clone()),
         Some(new_non_reserved_validators.clone()),
-        Some(4),
+        Some(CommitteeSeats {
+            reserved_seats: 2,
+            non_reserved_seats: 2,
+        }),
         XtStatus::InBlock,
     );
 

--- a/e2e-tests/src/test/rewards.rs
+++ b/e2e-tests/src/test/rewards.rs
@@ -246,7 +246,6 @@ pub fn disable_node(config: &Config) -> anyhow::Result<()> {
 
 pub fn force_new_era(config: &Config) -> anyhow::Result<()> {
     const MAX_DIFFERENCE: f64 = 0.07;
-    const VALIDATORS_PER_SESSION: u32 = 4;
 
     let node = &config.node;
     let accounts = get_validators_keys(config);
@@ -269,7 +268,10 @@ pub fn force_new_era(config: &Config) -> anyhow::Result<()> {
         &root_connection,
         Some(reserved_members.clone()),
         Some(non_reserved_members.clone()),
-        Some(VALIDATORS_PER_SESSION),
+        Some(CommitteeSeats {
+            reserved_seats: 2,
+            non_reserved_seats: 2,
+        }),
         XtStatus::Finalized,
     );
 

--- a/e2e-tests/src/test/rewards.rs
+++ b/e2e-tests/src/test/rewards.rs
@@ -4,6 +4,7 @@ use aleph_client::{
     KeyPair, SignedConnection,
 };
 use log::info;
+use pallet_elections::CommitteeSeats;
 use primitives::{staking::MIN_VALIDATOR_BOND, Balance, SessionIndex, TOKEN};
 use substrate_api_client::{AccountId, XtStatus};
 
@@ -111,7 +112,10 @@ pub fn points_stake_change(config: &Config) -> anyhow::Result<()> {
         &root_connection,
         Some(reserved_members.clone()),
         Some(non_reserved_members.clone()),
-        Some(4),
+        Some(CommitteeSeats {
+            reserved_seats: 2,
+            non_reserved_seats: 2,
+        }),
         XtStatus::Finalized,
     );
 
@@ -166,7 +170,6 @@ pub fn points_stake_change(config: &Config) -> anyhow::Result<()> {
 
 pub fn disable_node(config: &Config) -> anyhow::Result<()> {
     const MAX_DIFFERENCE: f64 = 0.05;
-    const VALIDATORS_PER_SESSION: u32 = 4;
 
     let root_connection = config.create_root_connection();
 
@@ -178,7 +181,10 @@ pub fn disable_node(config: &Config) -> anyhow::Result<()> {
         &root_connection,
         Some(reserved_members.clone()),
         Some(non_reserved_members.clone()),
-        Some(VALIDATORS_PER_SESSION),
+        Some(CommitteeSeats {
+            reserved_seats: 2,
+            non_reserved_seats: 2,
+        }),
         XtStatus::Finalized,
     );
 

--- a/e2e-tests/src/test/rewards.rs
+++ b/e2e-tests/src/test/rewards.rs
@@ -123,7 +123,10 @@ pub fn points_basic(config: &Config) -> anyhow::Result<()> {
         &root_connection,
         Some(reserved_members.clone()),
         Some(non_reserved_members.clone()),
-        Some(4),
+        Some(CommitteeSeats {
+            reserved_seats: 2,
+            non_reserved_seats: 2,
+        }),
         XtStatus::Finalized,
     );
 

--- a/e2e-tests/src/test/staking.rs
+++ b/e2e-tests/src/test/staking.rs
@@ -7,6 +7,7 @@ use aleph_client::{
 };
 use frame_support::BoundedVec;
 use log::info;
+use pallet_elections::CommitteeSeats;
 use primitives::{
     staking::{MIN_NOMINATOR_BOND, MIN_VALIDATOR_BOND},
     TOKEN,
@@ -116,7 +117,10 @@ pub fn staking_new_validator(config: &Config) -> anyhow::Result<()> {
         &root_connection,
         Some(convert_authorities_to_account_id(&validator_accounts)),
         Some(vec![]),
-        Some(4),
+        Some(CommitteeSeats {
+            reserved_seats: 4,
+            non_reserved_seats: 0,
+        }),
         XtStatus::InBlock,
     );
 
@@ -186,7 +190,10 @@ pub fn staking_new_validator(config: &Config) -> anyhow::Result<()> {
         &root_connection,
         Some(convert_authorities_to_account_id(&validator_accounts)),
         Some(vec![]),
-        Some(5),
+        Some(CommitteeSeats {
+            reserved_seats: 5,
+            non_reserved_seats: 0,
+        }),
         XtStatus::InBlock,
     );
     let current_session = get_current_session(&root_connection);

--- a/e2e-tests/src/test/validators_change.rs
+++ b/e2e-tests/src/test/validators_change.rs
@@ -73,7 +73,7 @@ pub fn change_validators(config: &Config) -> anyhow::Result<()> {
         connection.read_storage_value("Elections", "NextEraNonReservedValidators");
 
     let committee_size_after: CommitteeSeats =
-        connection.read_storage_value("Elections", "CommitteeSize");
+        connection.read_storage_value("Elections", "NextEraCommitteeSize");
 
     info!(
         "[+] state before tx: reserved: {:#?}, non_reserved: {:#?}, committee_size: {:#?}",

--- a/e2e-tests/src/test/validators_change.rs
+++ b/e2e-tests/src/test/validators_change.rs
@@ -3,6 +3,7 @@ use aleph_client::{
 };
 use codec::Decode;
 use log::info;
+use pallet_elections::CommitteeSeats;
 use sp_core::Pair;
 use substrate_api_client::{AccountId, XtStatus};
 
@@ -23,7 +24,8 @@ pub fn change_validators(config: &Config) -> anyhow::Result<()> {
     let non_reserved_before: Vec<AccountId> =
         connection.read_storage_value("Elections", "NextEraNonReservedValidators");
 
-    let committee_size_before: u32 = connection.read_storage_value("Elections", "CommitteeSize");
+    let committee_size_before: CommitteeSeats =
+        connection.read_storage_value("Elections", "CommitteeSize");
 
     info!(
         "[+] state before tx: reserved: {:#?}, non_reserved: {:#?}, committee_size: {:#?}",
@@ -35,7 +37,10 @@ pub fn change_validators(config: &Config) -> anyhow::Result<()> {
         &connection,
         Some(new_validators[0..2].to_vec()),
         Some(new_validators[2..].to_vec()),
-        Some(4),
+        Some(CommitteeSeats {
+            reserved_seats: 2,
+            non_reserved_seats: 2,
+        }),
         XtStatus::InBlock,
     );
 
@@ -63,7 +68,8 @@ pub fn change_validators(config: &Config) -> anyhow::Result<()> {
     let non_reserved_after: Vec<AccountId> =
         connection.read_storage_value("Elections", "NextEraNonReservedValidators");
 
-    let committee_size_after: u32 = connection.read_storage_value("Elections", "CommitteeSize");
+    let committee_size_after: CommitteeSeats =
+        connection.read_storage_value("Elections", "CommitteeSize");
 
     info!(
         "[+] state before tx: reserved: {:#?}, non_reserved: {:#?}, committee_size: {:#?}",
@@ -72,7 +78,13 @@ pub fn change_validators(config: &Config) -> anyhow::Result<()> {
 
     assert_eq!(new_validators[..2], reserved_after);
     assert_eq!(new_validators[2..], non_reserved_after);
-    assert_eq!(4, committee_size_after);
+    assert_eq!(
+        CommitteeSeats {
+            reserved_seats: 2,
+            non_reserved_seats: 2
+        },
+        committee_size_after
+    );
 
     let block_number = connection
         .as_connection()

--- a/e2e-tests/src/test/validators_change.rs
+++ b/e2e-tests/src/test/validators_change.rs
@@ -48,7 +48,7 @@ pub fn change_validators(config: &Config) -> anyhow::Result<()> {
     struct NewValidatorsEvent {
         reserved: Vec<AccountId>,
         non_reserved: Vec<AccountId>,
-        committee_size: u32,
+        committee_size: CommitteeSeats,
     }
     wait_for_event(
         &connection,
@@ -58,7 +58,11 @@ pub fn change_validators(config: &Config) -> anyhow::Result<()> {
 
             e.reserved == new_validators[0..2]
                 && e.non_reserved == new_validators[2..]
-                && e.committee_size == 4
+                && e.committee_size
+                    == CommitteeSeats {
+                        reserved_seats: 2,
+                        non_reserved_seats: 2,
+                    }
         },
     )?;
 

--- a/e2e-tests/src/test/validators_rotate.rs
+++ b/e2e-tests/src/test/validators_rotate.rs
@@ -4,6 +4,7 @@ use aleph_client::{
     change_validators, get_current_session, wait_for_finalized_block, wait_for_full_era_completion,
     wait_for_session, AnyConnection, Header, KeyPair, RootConnection, SignedConnection,
 };
+use pallet_elections::CommitteeSeats;
 use sp_core::Pair;
 use substrate_api_client::{AccountId, XtStatus};
 
@@ -86,7 +87,10 @@ pub fn validators_rotate(config: &Config) -> anyhow::Result<()> {
         &root_connection,
         Some(reserved_validators.clone()),
         Some(non_reserved_validators),
-        Some(4),
+        Some(CommitteeSeats {
+            reserved_seats: 2,
+            non_reserved_seats: 2,
+        }),
         XtStatus::InBlock,
     );
     wait_for_full_era_completion(&connection)?;

--- a/pallets/elections/src/impls.rs
+++ b/pallets/elections/src/impls.rs
@@ -5,9 +5,9 @@ use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 use crate::{
     traits::{EraInfoProvider, SessionInfoProvider, ValidatorRewardsHandler},
-    CommitteeSize, Config, CurrentEraValidators, EraValidators, NextEraCommitteeSize,
-    NextEraNonReservedValidators, NextEraReservedValidators, Pallet, SessionValidatorBlockCount,
-    ValidatorEraTotalReward, ValidatorTotalRewards,
+    CommitteeSeats, CommitteeSize, Config, CurrentEraValidators, EraValidators,
+    NextEraCommitteeSize, NextEraNonReservedValidators, NextEraReservedValidators, Pallet,
+    SessionValidatorBlockCount, ValidatorEraTotalReward, ValidatorTotalRewards,
 };
 
 const MAX_REWARD: u32 = 1_000_000_000;
@@ -68,35 +68,44 @@ pub fn compute_validator_scaled_total_rewards<V>(
         .collect()
 }
 
+fn choose_for_session<T: Clone>(l: Vec<T>, count: usize, session: usize) -> Option<Vec<T>> {
+    if l.is_empty() || count == 0 {
+        return None;
+    }
+
+    let l_len = l.len();
+    let first_index = session.saturating_mul(count) % l_len;
+    let mut chosen = Vec::new();
+
+    for i in 0..count {
+        chosen.push(l[first_index.saturating_add(i) % l_len].clone());
+    }
+
+    Some(chosen)
+}
+
 fn rotate<T: Clone + PartialEq>(
     current_session: SessionIndex,
-    n_validators: usize,
+    reserved_seats: usize,
+    non_reserved_seats: usize,
     reserved: Vec<T>,
     non_reserved: Vec<T>,
 ) -> Option<Vec<T>> {
-    if non_reserved.is_empty() {
-        return Some(reserved);
-    }
-
     // The validators for the committee at the session `n` are chosen as follow:
-    // 1. Reserved validators are always chosen.
-    // 2. Given non-reserved list of validators the chosen ones are from the range:
-    // `n * free_seats` to `(n + 1) * free_seats` where free_seats is equal to free number of free
-    // seats in the committee after reserved nodes are added.
-    let free_seats = n_validators.saturating_sub(reserved.len());
+    // 1. `reserved_seats` validators are chosen from the reserved set while `non_reserved_seats` from the non_reserved set.
+    // 2. Given a set of validators the chosen ones are from the range:
+    // `n * seats` to `(n + 1) * seats` where seats is equal to reserved_seats(non_reserved_seats) for reserved(non_reserved) validators.
 
-    let non_reserved_len = non_reserved.len();
-    let first_validator = (current_session as usize).saturating_mul(free_seats) % non_reserved_len;
+    let reserved_committee = choose_for_session(reserved, reserved_seats, current_session as usize);
+    let non_reserved_committee =
+        choose_for_session(non_reserved, non_reserved_seats, current_session as usize);
 
-    let committee = reserved
-        .into_iter()
-        .chain(
-            (first_validator..first_validator + free_seats)
-                .map(|i| non_reserved[i % non_reserved_len].clone()),
-        )
-        .collect();
-
-    Some(committee)
+    match (reserved_committee, non_reserved_committee) {
+        (Some(rc), Some(nrc)) => Some(rc.into_iter().chain(nrc.into_iter()).collect()),
+        (Some(rc), _) => Some(rc),
+        (_, Some(nrc)) => Some(nrc),
+        _ => None,
+    }
 }
 
 impl<T> Pallet<T>
@@ -122,7 +131,7 @@ where
     }
 
     fn blocks_to_produce_per_session() -> u32 {
-        T::SessionPeriod::get() / CommitteeSize::<T>::get()
+        T::SessionPeriod::get().saturating_div(CommitteeSize::<T>::get().size())
     }
 
     fn reward_for_session_non_committee(
@@ -177,9 +186,18 @@ where
             reserved,
             non_reserved,
         } = CurrentEraValidators::<T>::get();
-        let n_validators = CommitteeSize::<T>::get() as usize;
+        let CommitteeSeats {
+            reserved_seats,
+            non_reserved_seats,
+        } = CommitteeSize::<T>::get();
 
-        rotate(current_session, n_validators, reserved, non_reserved)
+        rotate(
+            current_session,
+            reserved_seats as usize,
+            non_reserved_seats as usize,
+            reserved,
+            non_reserved,
+        )
     }
 
     fn if_era_starts_do<F: Fn()>(era: EraIndex, start_index: SessionIndex, on_era_start: F) {
@@ -396,7 +414,7 @@ mod tests {
             compute_validator_scaled_total_rewards(vec![
                 (1, 20 * max),
                 (2, 10 * max),
-                (3, 30 * max)
+                (3, 30 * max),
             ])
         );
     }
@@ -406,23 +424,30 @@ mod tests {
     ) {
         let reserved: Vec<_> = (0..11).collect();
         let non_reserved: Vec<_> = (11..101).collect();
-        let total_validators = 53;
-        let mut rotated_free_seats_validators: VecDeque<_> = (11..101).collect();
+        let reserved_seats = 7;
+        let non_reserved_seats = 13;
+        let mut rotated_non_reserved_validators: VecDeque<_> = (11..101).collect();
+        let mut rotated_reserved_validators: VecDeque<_> = (0..11).collect();
 
         for session_index in 0u32..100u32 {
-            let mut expected_rotated_free_seats = vec![];
-            for _ in 0..total_validators - reserved.len() {
-                let first = rotated_free_seats_validators.pop_front().unwrap();
-                expected_rotated_free_seats.push(first);
-                rotated_free_seats_validators.push_back(first);
+            let mut expected_committee = vec![];
+            for _ in 0..reserved_seats {
+                let first = rotated_reserved_validators.pop_front().unwrap();
+                expected_committee.push(first);
+                rotated_reserved_validators.push_back(first);
             }
-            let mut expected_rotated_committee = reserved.clone();
-            expected_rotated_committee.append(&mut expected_rotated_free_seats);
+            for _ in 0..non_reserved_seats {
+                let first = rotated_non_reserved_validators.pop_front().unwrap();
+                expected_committee.push(first);
+                rotated_non_reserved_validators.push_back(first);
+            }
+
             assert_eq!(
-                expected_rotated_committee,
+                expected_committee,
                 rotate(
                     session_index,
-                    total_validators,
+                    reserved_seats,
+                    non_reserved_seats,
                     reserved.clone(),
                     non_reserved.clone(),
                 )

--- a/pallets/elections/src/impls.rs
+++ b/pallets/elections/src/impls.rs
@@ -68,7 +68,11 @@ pub fn compute_validator_scaled_total_rewards<V>(
         .collect()
 }
 
-fn choose_for_session<T: Clone>(validators: Vec<T>, count: usize, session: usize) -> Option<Vec<T>> {
+fn choose_for_session<T: Clone>(
+    validators: Vec<T>,
+    count: usize,
+    session: usize,
+) -> Option<Vec<T>> {
     if validators.is_empty() || count == 0 {
         return None;
     }

--- a/pallets/elections/src/impls.rs
+++ b/pallets/elections/src/impls.rs
@@ -68,17 +68,17 @@ pub fn compute_validator_scaled_total_rewards<V>(
         .collect()
 }
 
-fn choose_for_session<T: Clone>(l: Vec<T>, count: usize, session: usize) -> Option<Vec<T>> {
-    if l.is_empty() || count == 0 {
+fn choose_for_session<T: Clone>(validators: Vec<T>, count: usize, session: usize) -> Option<Vec<T>> {
+    if validators.is_empty() || count == 0 {
         return None;
     }
 
-    let l_len = l.len();
-    let first_index = session.saturating_mul(count) % l_len;
+    let validators_len = validators.len();
+    let first_index = session.saturating_mul(count) % validators_len;
     let mut chosen = Vec::new();
 
     for i in 0..count {
-        chosen.push(l[first_index.saturating_add(i) % l_len].clone());
+        chosen.push(validators[first_index.saturating_add(i) % validators_len].clone());
     }
 
     Some(chosen)

--- a/pallets/elections/src/impls.rs
+++ b/pallets/elections/src/impls.rs
@@ -125,9 +125,14 @@ where
 
     fn get_committee_and_non_committee() -> (Vec<T::AccountId>, Vec<T::AccountId>) {
         let committee = T::SessionInfoProvider::current_committee();
-        let non_committee = CurrentEraValidators::<T>::get()
-            .non_reserved
+        let EraValidators {
+            reserved,
+            non_reserved,
+        } = CurrentEraValidators::<T>::get();
+
+        let non_committee = non_reserved
             .into_iter()
+            .chain(reserved.into_iter())
             .filter(|a| !committee.contains(a))
             .collect();
 

--- a/pallets/elections/src/lib.rs
+++ b/pallets/elections/src/lib.rs
@@ -151,6 +151,9 @@ pub mod pallet {
                 _ if on_chain == StorageVersion::new(1) => {
                     migrations::v1_to_v2::pre_upgrade::<T, Self>()
                 }
+                _ if on_chain == StorageVersion::new(2) => {
+                    migrations::v2_to_v3::pre_upgrade::<T, Self>()
+                }
                 _ => Err("Bad storage version"),
             }
         }
@@ -158,7 +161,7 @@ pub mod pallet {
         fn post_upgrade() -> Result<(), &'static str> {
             let on_chain = <Pallet<T> as GetStorageVersion>::on_chain_storage_version();
             match on_chain {
-                _ if on_chain == STORAGE_VERSION => migrations::v1_to_v2::post_upgrade::<T, Self>(),
+                _ if on_chain == STORAGE_VERSION => migrations::v2_to_v3::post_upgrade::<T, Self>(),
                 _ => Err("Bad storage version"),
             }
         }

--- a/pallets/elections/src/lib.rs
+++ b/pallets/elections/src/lib.rs
@@ -28,7 +28,7 @@ use sp_std::{
     prelude::*,
 };
 
-const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 pub type BlockCount = u32;
 pub type TotalReward = u32;
@@ -130,9 +130,14 @@ pub mod pallet {
                     _ if on_chain == StorageVersion::new(0) => {
                         migrations::v0_to_v1::migrate::<T, Self>()
                             + migrations::v1_to_v2::migrate::<T, Self>()
+                            + migrations::v2_to_v3::migrate::<T, Self>()
                     }
                     _ if on_chain == StorageVersion::new(1) => {
                         migrations::v1_to_v2::migrate::<T, Self>()
+                            + migrations::v2_to_v3::migrate::<T, Self>()
+                    }
+                    _ if on_chain == StorageVersion::new(2) => {
+                        migrations::v2_to_v3::migrate::<T, Self>()
                     }
                     _ => {
                         log::warn!(

--- a/pallets/elections/src/lib.rs
+++ b/pallets/elections/src/lib.rs
@@ -48,7 +48,7 @@ impl<AccountId> Default for EraValidators<AccountId> {
     }
 }
 
-#[derive(Decode, Encode, TypeInfo, Debug, Clone, Copy, PartialEq)]
+#[derive(Decode, Encode, TypeInfo, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CommitteeSeats {
     pub reserved_seats: u32,
     pub non_reserved_seats: u32,
@@ -57,15 +57,6 @@ pub struct CommitteeSeats {
 impl CommitteeSeats {
     fn size(&self) -> u32 {
         self.reserved_seats.saturating_add(self.non_reserved_seats)
-    }
-}
-
-impl Default for CommitteeSeats {
-    fn default() -> Self {
-        Self {
-            reserved_seats: 0,
-            non_reserved_seats: 0,
-        }
     }
 }
 

--- a/pallets/elections/src/migrations/mod.rs
+++ b/pallets/elections/src/migrations/mod.rs
@@ -1,2 +1,3 @@
 pub mod v0_to_v1;
 pub mod v1_to_v2;
+pub mod v2_to_v3;

--- a/pallets/elections/src/migrations/v1_to_v2.rs
+++ b/pallets/elections/src/migrations/v1_to_v2.rs
@@ -77,6 +77,7 @@ pub fn migrate<T: Config, P: PalletInfoAccess>() -> Weight {
     T::DbWeight::get().reads(reads) + T::DbWeight::get().writes(writes)
 }
 
+#[allow(dead_code)]
 #[cfg(feature = "try-runtime")]
 pub fn pre_upgrade<T: Config, P: PalletInfoAccess>() -> Result<(), &'static str> {
     match MembersPerSession::get() {

--- a/pallets/elections/src/migrations/v1_to_v2.rs
+++ b/pallets/elections/src/migrations/v1_to_v2.rs
@@ -77,7 +77,6 @@ pub fn migrate<T: Config, P: PalletInfoAccess>() -> Weight {
     T::DbWeight::get().reads(reads) + T::DbWeight::get().writes(writes)
 }
 
-#[allow(dead_code)]
 #[cfg(feature = "try-runtime")]
 pub fn pre_upgrade<T: Config, P: PalletInfoAccess>() -> Result<(), &'static str> {
     match MembersPerSession::get() {
@@ -104,6 +103,7 @@ pub fn pre_upgrade<T: Config, P: PalletInfoAccess>() -> Result<(), &'static str>
     }
 }
 
+#[allow(dead_code)]
 #[cfg(feature = "try-runtime")]
 pub fn post_upgrade<T: Config, P: PalletInfoAccess>() -> Result<(), &'static str> {
     match CommitteeSize::get() {

--- a/pallets/elections/src/migrations/v2_to_v3.rs
+++ b/pallets/elections/src/migrations/v2_to_v3.rs
@@ -1,0 +1,83 @@
+use frame_support::{log, storage_alias, traits::{Get, PalletInfoAccess, StorageVersion}, weights::Weight};
+use sp_std::vec::Vec;
+use crate::{CommitteeSeats, EraValidators, Config};
+
+// V2 storages
+#[storage_alias]
+type CurrentEraValidators<T> =
+StorageValue<Elections, EraValidators<<T as frame_system::Config>::AccountId>>;
+#[storage_alias]
+type NextEraReservedValidators<T> = StorageValue<Elections, Vec<<T as frame_system::Config>::AccountId>>;
+
+// V3 storages
+#[storage_alias]
+type CommitteeSize = StorageValue<Elections, CommitteeSeats>;
+#[storage_alias]
+type NextEraCommitteeSize = StorageValue<Elections, CommitteeSeats>;
+
+
+pub fn migrate<T: Config, P: PalletInfoAccess>() -> Weight {
+    log::info!(target: "pallet_elections", "Running migration from STORAGE_VERSION 2 to 3 for pallet elections");
+
+    let mut reads = 2;
+    let mut writes = 1;
+
+    if let Some(EraValidators { reserved, .. }) = CurrentEraValidators::<T>::get() {
+        let reserved_len = reserved.len();
+        reads += 1;
+        match CommitteeSize::translate::<u32, _>(|old: Option<u32>| {
+            Some(match old {
+                Some(cs) =>
+                    CommitteeSeats {
+                        reserved_seats: reserved_len as u32,
+                        non_reserved_seats: cs.saturating_sub(reserved_len as u32),
+                    }
+                ,
+                None => CommitteeSeats {
+                    reserved_seats: reserved_len as u32,
+                    non_reserved_seats: 0,
+                }
+            })
+        }) {
+            Ok(_) => {
+                writes += 1;
+                log::info!(target: "pallet_elections", "Successfully migrated storage for CommitteeSize");
+            }
+            Err(why) => {
+                log::error!(target: "pallet_elections", "Something went wrong during the migration of CommitteeSize storage {:?}", why);
+            }
+        }
+    }
+
+    if let Some(reserved) = NextEraReservedValidators::<T>::get() {
+        let n_era_reserved_len = reserved.len();
+        reads += 1;
+        match NextEraCommitteeSize::translate::<u32, _>(|old| {
+            Some(match old {
+                Some(cs) =>
+                    CommitteeSeats {
+                        reserved_seats: n_era_reserved_len as u32,
+                        non_reserved_seats: cs.saturating_sub(n_era_reserved_len as u32),
+                    }
+                ,
+                None => CommitteeSeats {
+                    reserved_seats: n_era_reserved_len as u32,
+                    non_reserved_seats: 0,
+                }
+            })
+        }) {
+            Ok(_) => {
+                writes += 1;
+                log::info!(target: "pallet_elections", "Successfully migrated storage for NextEraCommitteeSize");
+            }
+            Err(why) => {
+                log::error!(target: "pallet_elections", "Something went wrong during the migration of NextEraCommitteeSize storage {:?}", why);
+            }
+        }
+    }
+
+    StorageVersion::new(3).put::<P>();
+
+
+    T::DbWeight::get().reads(reads) + T::DbWeight::get().writes(writes)
+}


### PR DESCRIPTION
# Description
Added support for rotating reserved nodes.

Migrations tested on local node with latest main and on testnet with try-runtime.

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

<!-- delete when not applicable to your PR -->
- I have bumped `spec_version` and `transaction_version`
