### PR TITLE
Add validator change to force new era e2e test for rewards

### DIFF
--- a/e2e-tests/src/test/rewards.rs
+++ b/e2e-tests/src/test/rewards.rs
@@ -240,6 +240,7 @@ pub fn disable_node(config: &Config) -> anyhow::Result<()> {
 
 pub fn force_new_era(config: &Config) -> anyhow::Result<()> {
     const MAX_DIFFERENCE: f64 = 0.07;
+    const VALIDATORS_PER_SESSION: u32 = 4;
 
     let node = &config.node;
     let accounts = get_validators_keys(config);
@@ -257,6 +258,14 @@ pub fn force_new_era(config: &Config) -> anyhow::Result<()> {
         .iter()
         .map(account_from_keypair)
         .collect();
+
+    change_validators(
+        &root_connection,
+        Some(reserved_members.clone()),
+        Some(non_reserved_members.clone()),
+        Some(VALIDATORS_PER_SESSION),
+        XtStatus::Finalized,
+    );
 
     wait_for_full_era_completion(&connection)?;
 


### PR DESCRIPTION
# Description

Tiny fix adding a `validators_change` call in the `force_new_era` e2e test for rewards.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
