### PR TITLE
A0-823: Slack notifications about workflow status

### DIFF
--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -1,5 +1,5 @@
 name: 'Send Slack notifiction'
-description: 'Action used to Send slack notifications to give workflow status in channel specified in SLACK_WEBHOOK'
+description: 'Action used to send Slack notifications about workflow status in channel specified in SLACK_WEBHOOK'
 
 inputs:
   notify-on:

--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -1,0 +1,46 @@
+name: 'Send Slack notifiction'
+description: 'Action used to Send slack notifications to give workflow status in channel specified in SLACK_WEBHOOK'
+
+inputs:
+  notify-on:
+    description: "Choose when Slack messages should be sent"
+    type: choice
+    options:
+      - always
+      - success
+      - failure
+      - neutral
+      - skipped
+      - cancelled
+      - timed_out
+      - action_required
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Get workflow conclusion
+      uses: technote-space/workflow-conclusion-action@v3
+
+    - name: Export envs
+      shell: bash
+      run: |
+        #!/bin/bash
+        if [[ "$WORKFLOW_CONCLUSION" == "success" ]]; then \
+          echo SLACK_COLOR="#57d115" >> $GITHUB_ENV; else \
+          echo SLACK_COLOR="#ff0000" >> $GITHUB_ENV; fi
+        echo WORKFLOW_NAME="$(echo "$GITHUB_WORKFLOW" | rev | cut -f1 -d"/" | rev)" >> $GITHUB_ENV
+        echo STATUS="$(echo "$WORKFLOW_CONCLUSION")" >> $GITHUB_ENV
+        if [[ "$NOTIFY_ON" == "always" ]]; then \
+          echo WORKFLOW_CONCLUSION="always" >> $GITHUB_ENV; fi
+        echo NOTIFY_ON="$(echo "$NOTIFY_ON")" >> $GITHUB_ENV
+      env:
+        NOTIFY_ON: ${{ inputs.notify-on }}
+
+    - name: Send Slack message
+      uses: rtCamp/action-slack-notify@v2
+      if: env.WORKFLOW_CONCLUSION == env.NOTIFY_ON || env.WORKFLOW_CONCLUSION == 'always'
+      env:
+        SLACK_TITLE: "*Status: ${{ env.STATUS }}* \n || \n Workflow: ${{ env.WORKFLOW_NAME }}"
+        SLACK_USERNAME: GithubActions
+        SLACK_ICON_EMOJI: ":aleph:"

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -93,3 +93,18 @@ jobs:
           branch: mainnet
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}
+
+  slack:
+    name: Slack notification
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Send Slack message
+        uses: ./.github/actions/slack-notification
+        with:
+          notify-on: "always"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -100,3 +100,18 @@ jobs:
           branch: testnet
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}
+
+  slack:
+    name: Slack notification
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Send Slack message
+        uses: ./.github/actions/slack-notification
+        with:
+          notify-on: "failure"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-devnet.yml
+++ b/.github/workflows/deploy-to-devnet.yml
@@ -119,3 +119,18 @@ jobs:
           branch: main
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}
+
+  slack:
+    name: Slack notification
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Send Slack message
+        uses: ./.github/actions/slack-notification
+        with:
+          notify-on: "failure"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/e2e-tests-contracts.yml
+++ b/.github/workflows/e2e-tests-contracts.yml
@@ -95,3 +95,18 @@ jobs:
 
       - name: Cleanup cache
         uses: ./.github/actions/post-cache
+
+  slack:
+    name: Slack notification
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Send Slack message
+        uses: ./.github/actions/slack-notification
+        with:
+          notify-on: "failure"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -666,3 +666,18 @@ jobs:
           name: |
             old-aleph-release-node
             old-aleph-runtime
+
+  slack:
+    name: Slack notification
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Send Slack message
+        uses: ./.github/actions/slack-notification
+        with:
+          notify-on: "failure"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
# Description

1. Added new custom action for sending Slack notifications (`.github/actions/slack-notification`)
2. Triggered action mentioned above in these workflows:

- `.github/workflows/deploy-mainnet.yml` - always
- `.github/workflows/deploy-testnet.yml` - only on failure
- `.github/workflows/deploy-to-devnet.yml` - only on failure
- `.github/workflows/e2e-tests-contracts.yml` - only on failure
- `.github/workflows/e2e-tests-main-devnet.yml` - only on failure

## Type of change
- New feature (non-breaking change which adds functionality)