### PR TITLE
Remove not needed license-files entries

### DIFF
--- a/pallets/aleph/Cargo.toml
+++ b/pallets/aleph/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.4.0"
 authors = ["Cardinal Cryptography"]
 edition = "2021"
 license = "Apache 2.0"
-license-file = "./LICENSE"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }

--- a/pallets/elections/Cargo.toml
+++ b/pallets/elections/Cargo.toml
@@ -3,7 +3,6 @@ name = "pallet-elections"
 version = "0.3.0"
 edition = "2021"
 license = "Apache 2.0"
-license-file = "./LICENSE"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }


### PR DESCRIPTION
# Description

We don't need both `license-file` and `license` in one toml file. 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
