### PR TITLE
[A0-1141] Enforce disabled pruning

### DIFF
--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -16,11 +16,11 @@ fn main() -> sc_cli::Result<()> {
         .import_params
         .pruning_params
         .pruning
+        .replace(String::from("archive"))
         .map_or(false, |x| x != "archive")
     {
         println!("Pruning not supported. Switching to 'archive' mode.");
     }
-    cli.run.import_params.pruning_params.pruning = Some(String::from("archive"));
 
     match &cli.subcommand {
         Some(Subcommand::BootstrapChain(cmd)) => cmd.run(),

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -9,7 +9,20 @@ use sc_network::config::Role;
 use sc_service::PartialComponents;
 
 fn main() -> sc_cli::Result<()> {
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
+
+    match cli.run.import_params.pruning_params.pruning.as_ref() {
+        Some(mode) => {
+            if mode != "archive" {
+                println!("Pruning not supported. Switching to 'archive' mode.");
+                cli.run.import_params.pruning_params.pruning = Some(String::from("archive"));
+            }
+        }
+        None => {
+            cli.run.import_params.pruning_params.pruning = Some(String::from("archive"));
+        }
+    }
+
     match &cli.subcommand {
         Some(Subcommand::BootstrapChain(cmd)) => cmd.run(),
         Some(Subcommand::BootstrapNode(cmd)) => cmd.run(),

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -11,17 +11,16 @@ use sc_service::PartialComponents;
 fn main() -> sc_cli::Result<()> {
     let mut cli = Cli::parse();
 
-    match cli.run.import_params.pruning_params.pruning.as_ref() {
-        Some(mode) => {
-            if mode != "archive" {
-                println!("Pruning not supported. Switching to 'archive' mode.");
-                cli.run.import_params.pruning_params.pruning = Some(String::from("archive"));
-            }
-        }
-        None => {
-            cli.run.import_params.pruning_params.pruning = Some(String::from("archive"));
-        }
+    if cli
+        .run
+        .import_params
+        .pruning_params
+        .pruning
+        .map_or(false, |x| x != "archive")
+    {
+        println!("Pruning not supported. Switching to 'archive' mode.");
     }
+    cli.run.import_params.pruning_params.pruning = Some(String::from("archive"));
 
     match &cli.subcommand {
         Some(Subcommand::BootstrapChain(cmd)) => cmd.run(),


### PR DESCRIPTION
# Description

Quick and a bit dirty fix for the fact that we don't support pruning. The value of the corresponding flag is forcefully set at the beginning of `main()`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
