### PR TITLE
A0-1175: Full genesis init for pallet elections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4242,6 +4242,7 @@ dependencies = [
  "parity-scale-codec",
  "primitives",
  "scale-info",
+ "serde",
  "sp-core",
  "sp-runtime",
  "sp-staking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4242,7 +4242,6 @@ dependencies = [
  "parity-scale-codec",
  "primitives",
  "scale-info",
- "serde",
  "sp-core",
  "sp-runtime",
  "sp-staking",
@@ -4807,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -1677,6 +1677,7 @@ dependencies = [
  "parity-scale-codec",
  "primitives",
  "scale-info",
+ "serde",
  "sp-core",
  "sp-staking",
  "sp-std",

--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "ac-primitives",
  "anyhow",
@@ -102,7 +102,6 @@ dependencies = [
  "log",
  "pallet-aleph",
  "pallet-balances",
- "pallet-elections",
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
@@ -1664,26 +1663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-elections"
-version = "0.3.0"
-dependencies = [
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
- "pallet-authorship",
- "pallet-balances",
- "pallet-session",
- "pallet-staking",
- "parity-scale-codec",
- "primitives",
- "scale-info",
- "serde",
- "sp-core",
- "sp-staking",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
 source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23#bfcc96afecbbf2413ef610e2b549c0fbfbb9a32b"
@@ -1952,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 license = "Apache 2.0"
 
@@ -26,7 +26,6 @@ pallet-balances = { git = "https://github.com/Cardinal-Cryptography/substrate.gi
 pallet-vesting = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.23", default-features = false }
 
 pallet-aleph = { path = "../pallets/aleph", default-features = false }
-pallet-elections = { path = "../pallets/elections", default-features = false }
 primitives = { path = "../primitives", default-features = false }
 
 [features]
@@ -41,5 +40,4 @@ std = [
     "pallet-balances/std",
     "pallet-multisig/std",
     "pallet-vesting/std",
-    "pallet-elections/std",
 ]

--- a/aleph-client/src/session.rs
+++ b/aleph-client/src/session.rs
@@ -1,7 +1,6 @@
 use codec::{Decode, Encode};
 use log::info;
-use pallet_elections::CommitteeSeats;
-use primitives::SessionIndex;
+use primitives::{CommitteeSeats, SessionIndex};
 use sp_core::{Pair, H256};
 use substrate_api_client::{
     compose_call, compose_extrinsic, AccountId, ExtrinsicParams, FromHexString, XtStatus,

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "ac-primitives",
  "anyhow",

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
  "parity-scale-codec",
  "primitives",
  "scale-info",
+ "serde",
  "sp-core",
  "sp-staking",
  "sp-std",

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -102,7 +102,6 @@ dependencies = [
  "log",
  "pallet-aleph",
  "pallet-balances",
- "pallet-elections",
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
@@ -1764,26 +1763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-elections"
-version = "0.3.0"
-dependencies = [
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
- "pallet-authorship",
- "pallet-balances",
- "pallet-session",
- "pallet-staking",
- "parity-scale-codec",
- "primitives",
- "scale-info",
- "serde",
- "sp-core",
- "sp-staking",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
 source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23#bfcc96afecbbf2413ef610e2b549c0fbfbb9a32b"
@@ -2071,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "ac-primitives",
  "anyhow",
@@ -102,7 +102,6 @@ dependencies = [
  "log",
  "pallet-aleph",
  "pallet-balances",
- "pallet-elections",
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
@@ -430,7 +429,6 @@ dependencies = [
  "env_logger 0.8.4",
  "ink_metadata",
  "log",
- "pallet-elections",
  "pallet-staking",
  "parity-scale-codec",
  "primitives",
@@ -2046,26 +2044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-elections"
-version = "0.3.0"
-dependencies = [
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
- "pallet-authorship",
- "pallet-balances",
- "pallet-session",
- "pallet-staking",
- "parity-scale-codec",
- "primitives",
- "scale-info",
- "serde",
- "sp-core 6.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23)",
- "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23)",
-]
-
-[[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
 source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23#bfcc96afecbbf2413ef610e2b549c0fbfbb9a32b"
@@ -2334,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -2059,6 +2059,7 @@ dependencies = [
  "parity-scale-codec",
  "primitives",
  "scale-info",
+ "serde",
  "sp-core 6.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23)",
  "sp-staking",
  "sp-std 4.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23)",

--- a/bin/cliain/Cargo.toml
+++ b/bin/cliain/Cargo.toml
@@ -16,7 +16,6 @@ env_logger = "0.8"
 ink_metadata = { version = "3.0", features = ["derive"] }
 log = "0.4"
 pallet-staking = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.23" }
-pallet-elections = { path = "../../pallets/elections" }
 primitives = { path = "../../primitives" }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/bin/cliain/src/validators.rs
+++ b/bin/cliain/src/validators.rs
@@ -1,5 +1,5 @@
 use aleph_client::RootConnection;
-use pallet_elections::CommitteeSeats;
+use primitives::CommitteeSeats;
 use sp_core::crypto::Ss58Codec;
 use substrate_api_client::{AccountId, XtStatus};
 

--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -389,9 +389,9 @@ fn generate_genesis_config(
             key: Some(sudo_account),
         },
         elections: ElectionsConfig {
-            non_reserved_validators: accounts_config.members.clone(),
+            reserved_validators: accounts_config.members.clone(),
+            non_reserved_validators: vec![],
             committee_seats: Default::default(),
-            reserved_validators: vec![],
         },
         session: SessionConfig {
             keys: accounts_config.keys,

--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, path::PathBuf, str::FromStr};
 
 use aleph_primitives::{
     staking::{MIN_NOMINATOR_BOND, MIN_VALIDATOR_BOND},
-    AuthorityId as AlephId, ADDRESSES_ENCODING, DEFAULT_COMMITTEE_SIZE, TOKEN, TOKEN_DECIMALS,
+    AuthorityId as AlephId, ADDRESSES_ENCODING, TOKEN, TOKEN_DECIMALS,
 };
 use aleph_runtime::{
     AccountId, AuraConfig, BalancesConfig, ElectionsConfig, GenesisConfig, Perbill, SessionConfig,
@@ -388,7 +388,7 @@ fn generate_genesis_config(
         },
         elections: ElectionsConfig {
             non_reserved_validators: accounts_config.members.clone(),
-            committee_size: DEFAULT_COMMITTEE_SIZE,
+            committee_seats: Default::default(),
             reserved_validators: vec![],
         },
         session: SessionConfig {

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 27,
+    spec_version: 28,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 9,

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -1793,6 +1793,7 @@ dependencies = [
  "parity-scale-codec",
  "primitives",
  "scale-info",
+ "serde",
  "sp-core",
  "sp-staking",
  "sp-std",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "ac-primitives",
  "anyhow",
@@ -127,7 +127,6 @@ dependencies = [
  "log",
  "pallet-aleph",
  "pallet-balances",
- "pallet-elections",
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
@@ -1793,7 +1792,6 @@ dependencies = [
  "parity-scale-codec",
  "primitives",
  "scale-info",
- "serde",
  "sp-core",
  "sp-staking",
  "sp-std",
@@ -2068,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/e2e-tests/src/rewards.rs
+++ b/e2e-tests/src/rewards.rs
@@ -6,9 +6,9 @@ use aleph_client::{
     RewardPoint, SessionKeys, SignedConnection,
 };
 use log::info;
-use pallet_elections::{CommitteeSeats, LENIENT_THRESHOLD};
+use pallet_elections::LENIENT_THRESHOLD;
 use pallet_staking::Exposure;
-use primitives::{EraIndex, SessionIndex};
+use primitives::{CommitteeSeats, EraIndex, SessionIndex};
 use sp_core::H256;
 use sp_runtime::Perquintill;
 use substrate_api_client::{AccountId, XtStatus};

--- a/e2e-tests/src/test/electing_validators.rs
+++ b/e2e-tests/src/test/electing_validators.rs
@@ -8,8 +8,7 @@ use aleph_client::{
     SignedConnection,
 };
 use log::info;
-use pallet_elections::CommitteeSeats;
-use primitives::{staking::MIN_VALIDATOR_BOND, EraIndex, TOKEN};
+use primitives::{staking::MIN_VALIDATOR_BOND, CommitteeSeats, EraIndex, TOKEN};
 use sp_core::{storage::StorageKey, Pair};
 use substrate_api_client::{compose_extrinsic, AccountId, XtStatus};
 

--- a/e2e-tests/src/test/era_validators.rs
+++ b/e2e-tests/src/test/era_validators.rs
@@ -4,7 +4,7 @@ use aleph_client::{
     SignedConnection,
 };
 use codec::Decode;
-use pallet_elections::CommitteeSeats;
+use primitives::CommitteeSeats;
 use sp_core::Pair;
 use substrate_api_client::{AccountId, XtStatus};
 

--- a/e2e-tests/src/test/rewards.rs
+++ b/e2e-tests/src/test/rewards.rs
@@ -5,8 +5,9 @@ use aleph_client::{
     RootConnection, SignedConnection,
 };
 use log::info;
-use pallet_elections::CommitteeSeats;
-use primitives::{staking::MIN_VALIDATOR_BOND, Balance, EraIndex, SessionIndex, TOKEN};
+use primitives::{
+    staking::MIN_VALIDATOR_BOND, Balance, CommitteeSeats, EraIndex, SessionIndex, TOKEN,
+};
 use substrate_api_client::{AccountId, XtStatus};
 
 use crate::{

--- a/e2e-tests/src/test/staking.rs
+++ b/e2e-tests/src/test/staking.rs
@@ -7,10 +7,9 @@ use aleph_client::{
 };
 use frame_support::BoundedVec;
 use log::info;
-use pallet_elections::CommitteeSeats;
 use primitives::{
     staking::{MIN_NOMINATOR_BOND, MIN_VALIDATOR_BOND},
-    TOKEN,
+    CommitteeSeats, TOKEN,
 };
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,

--- a/e2e-tests/src/test/validators_change.rs
+++ b/e2e-tests/src/test/validators_change.rs
@@ -3,7 +3,7 @@ use aleph_client::{
 };
 use codec::Decode;
 use log::info;
-use pallet_elections::CommitteeSeats;
+use primitives::CommitteeSeats;
 use sp_core::Pair;
 use substrate_api_client::{AccountId, XtStatus};
 

--- a/e2e-tests/src/test/validators_rotate.rs
+++ b/e2e-tests/src/test/validators_rotate.rs
@@ -4,7 +4,7 @@ use aleph_client::{
     change_validators, get_current_session, wait_for_finalized_block, wait_for_full_era_completion,
     wait_for_session, AnyConnection, Header, KeyPair, RootConnection, SignedConnection,
 };
-use pallet_elections::CommitteeSeats;
+use primitives::CommitteeSeats;
 use sp_core::Pair;
 use substrate_api_client::{AccountId, XtStatus};
 

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "ac-primitives",
  "anyhow",

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -1860,6 +1860,7 @@ dependencies = [
  "parity-scale-codec",
  "primitives",
  "scale-info",
+ "serde",
  "sp-core",
  "sp-staking",
  "sp-std",

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -102,7 +102,6 @@ dependencies = [
  "log",
  "pallet-aleph",
  "pallet-balances",
- "pallet-elections",
  "pallet-multisig",
  "pallet-staking",
  "pallet-treasury",
@@ -1847,26 +1846,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-elections"
-version = "0.3.0"
-dependencies = [
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
- "pallet-authorship",
- "pallet-balances",
- "pallet-session",
- "pallet-staking",
- "parity-scale-codec",
- "primitives",
- "scale-info",
- "serde",
- "sp-core",
- "sp-staking",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
 source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.23#bfcc96afecbbf2413ef610e2b549c0fbfbb9a32b"
@@ -2135,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/pallets/elections/Cargo.toml
+++ b/pallets/elections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-elections"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache 2.0"
 

--- a/pallets/elections/Cargo.toml
+++ b/pallets/elections/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache 2.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", optional = true }
 
 frame-support = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.23" }
 frame-system = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.23" }
@@ -39,5 +40,6 @@ std = [
     "primitives/std",
     "pallet-balances/std",
     "sp-staking/std",
+    "serde",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/elections/Cargo.toml
+++ b/pallets/elections/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache 2.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0", optional = true }
 
 frame-support = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.23" }
 frame-system = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.23" }
@@ -40,6 +39,5 @@ std = [
     "primitives/std",
     "pallet-balances/std",
     "sp-staking/std",
-    "serde",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/elections/src/impls.rs
+++ b/pallets/elections/src/impls.rs
@@ -1,5 +1,6 @@
 use frame_election_provider_support::sp_arithmetic::Perquintill;
 use frame_support::pallet_prelude::Get;
+use primitives::CommitteeSeats;
 use sp_staking::{EraIndex, SessionIndex};
 use sp_std::{
     collections::{btree_map::BTreeMap, btree_set::BTreeSet},
@@ -8,9 +9,9 @@ use sp_std::{
 
 use crate::{
     traits::{EraInfoProvider, SessionInfoProvider, ValidatorRewardsHandler},
-    CommitteeSeats, CommitteeSize, Config, CurrentEraValidators, EraValidators,
-    NextEraCommitteeSize, NextEraNonReservedValidators, NextEraReservedValidators, Pallet,
-    SessionValidatorBlockCount, ValidatorEraTotalReward, ValidatorTotalRewards,
+    CommitteeSize, Config, CurrentEraValidators, EraValidators, NextEraCommitteeSize,
+    NextEraNonReservedValidators, NextEraReservedValidators, Pallet, SessionValidatorBlockCount,
+    ValidatorEraTotalReward, ValidatorTotalRewards,
 };
 
 const MAX_REWARD: u32 = 1_000_000_000;

--- a/pallets/elections/src/lib.rs
+++ b/pallets/elections/src/lib.rs
@@ -280,9 +280,14 @@ pub mod pallet {
     #[pallet::genesis_build]
     impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
         fn build(&self) {
-            <NextEraNonReservedValidators<T>>::put(&self.non_reserved_validators);
             <CommitteeSize<T>>::put(&self.committee_seats);
+            <NextEraCommitteeSize<T>>::put(&self.committee_seats);
+            <NextEraNonReservedValidators<T>>::put(&self.non_reserved_validators);
             <NextEraReservedValidators<T>>::put(&self.reserved_validators);
+            <CurrentEraValidators<T>>::put(&EraValidators {
+                reserved: self.reserved_validators.clone(),
+                non_reserved: self.non_reserved_validators.clone(),
+            });
         }
     }
 

--- a/pallets/elections/src/lib.rs
+++ b/pallets/elections/src/lib.rs
@@ -22,6 +22,7 @@ use codec::{Decode, Encode};
 use frame_support::traits::StorageVersion;
 pub use impls::{compute_validator_scaled_total_rewards, LENIENT_THRESHOLD};
 pub use pallet::*;
+use primitives::DEFAULT_COMMITTEE_SIZE;
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -29,6 +30,7 @@ use sp_std::{
     collections::{btree_map::BTreeMap, btree_set::BTreeSet},
     prelude::*,
 };
+
 const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 pub type BlockCount = u32;
@@ -49,7 +51,7 @@ impl<AccountId> Default for EraValidators<AccountId> {
     }
 }
 
-#[derive(Decode, Encode, TypeInfo, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Decode, Encode, TypeInfo, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct CommitteeSeats {
     pub reserved_seats: u32,
@@ -59,6 +61,15 @@ pub struct CommitteeSeats {
 impl CommitteeSeats {
     fn size(&self) -> u32 {
         self.reserved_seats.saturating_add(self.non_reserved_seats)
+    }
+}
+
+impl Default for CommitteeSeats {
+    fn default() -> Self {
+        CommitteeSeats {
+            reserved_seats: DEFAULT_COMMITTEE_SIZE,
+            non_reserved_seats: 0,
+        }
     }
 }
 
@@ -76,7 +87,6 @@ pub mod pallet {
         pallet_prelude::{BlockNumberFor, OriginFor},
     };
     use pallet_session::SessionManager;
-    use primitives::DEFAULT_COMMITTEE_SIZE;
 
     use super::*;
     use crate::traits::{EraInfoProvider, SessionInfoProvider, ValidatorRewardsHandler};
@@ -269,10 +279,7 @@ pub mod pallet {
             Self {
                 non_reserved_validators: Vec::new(),
                 reserved_validators: Vec::new(),
-                committee_seats: CommitteeSeats {
-                    reserved_seats: DEFAULT_COMMITTEE_SIZE,
-                    non_reserved_seats: 0,
-                },
+                committee_seats: Default::default(),
             }
         }
     }

--- a/pallets/elections/src/lib.rs
+++ b/pallets/elections/src/lib.rs
@@ -22,10 +22,7 @@ use codec::{Decode, Encode};
 use frame_support::traits::StorageVersion;
 pub use impls::{compute_validator_scaled_total_rewards, LENIENT_THRESHOLD};
 pub use pallet::*;
-use primitives::DEFAULT_COMMITTEE_SIZE;
 use scale_info::TypeInfo;
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
 use sp_std::{
     collections::{btree_map::BTreeMap, btree_set::BTreeSet},
     prelude::*,
@@ -51,28 +48,6 @@ impl<AccountId> Default for EraValidators<AccountId> {
     }
 }
 
-#[derive(Decode, Encode, TypeInfo, Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct CommitteeSeats {
-    pub reserved_seats: u32,
-    pub non_reserved_seats: u32,
-}
-
-impl CommitteeSeats {
-    fn size(&self) -> u32 {
-        self.reserved_seats.saturating_add(self.non_reserved_seats)
-    }
-}
-
-impl Default for CommitteeSeats {
-    fn default() -> Self {
-        CommitteeSeats {
-            reserved_seats: DEFAULT_COMMITTEE_SIZE,
-            non_reserved_seats: 0,
-        }
-    }
-}
-
 #[derive(Decode, Encode, TypeInfo)]
 pub struct ValidatorTotalRewards<T>(pub BTreeMap<T, TotalReward>);
 
@@ -87,6 +62,7 @@ pub mod pallet {
         pallet_prelude::{BlockNumberFor, OriginFor},
     };
     use pallet_session::SessionManager;
+    use primitives::CommitteeSeats;
 
     use super::*;
     use crate::traits::{EraInfoProvider, SessionInfoProvider, ValidatorRewardsHandler};

--- a/pallets/elections/src/migrations/v2_to_v3.rs
+++ b/pallets/elections/src/migrations/v2_to_v3.rs
@@ -3,9 +3,10 @@ use frame_support::{
     traits::{Get, PalletInfoAccess, StorageVersion},
     weights::Weight,
 };
+use primitives::CommitteeSeats;
 use sp_std::vec::Vec;
 
-use crate::{CommitteeSeats, Config, EraValidators};
+use crate::{Config, EraValidators};
 
 // V2 storages
 #[storage_alias]

--- a/pallets/elections/src/mock.rs
+++ b/pallets/elections/src/mock.rs
@@ -208,35 +208,59 @@ impl ElectionDataProvider for StakingMock {
     }
 }
 
-pub fn new_test_ext(
+pub struct TestExtBuilder {
     reserved_validators: Vec<AccountId>,
     non_reserved_validators: Vec<AccountId>,
-) -> sp_io::TestExternalities {
-    let mut t = frame_system::GenesisConfig::default()
-        .build_storage::<Test>()
-        .unwrap();
+    committee_seats: CommitteeSeats,
+}
 
-    let validators: Vec<_> = non_reserved_validators
-        .iter()
-        .chain(reserved_validators.iter())
-        .collect();
+impl TestExtBuilder {
+    pub fn new(
+        reserved_validators: Vec<AccountId>,
+        non_reserved_validators: Vec<AccountId>,
+    ) -> Self {
+        Self {
+            committee_seats: CommitteeSeats {
+                reserved_seats: reserved_validators.len() as u32,
+                non_reserved_seats: non_reserved_validators.len() as u32,
+            },
+            reserved_validators,
+            non_reserved_validators,
+        }
+    }
 
-    let balances: Vec<_> = (0..validators.len())
-        .map(|i| (i as u64, 10_000_000))
-        .collect();
+    pub fn with_committee_seats(mut self, committee_seats: CommitteeSeats) -> Self {
+        self.committee_seats = committee_seats;
+        self
+    }
 
-    pallet_balances::GenesisConfig::<Test> { balances }
+    pub fn build(self) -> sp_io::TestExternalities {
+        let mut t = frame_system::GenesisConfig::default()
+            .build_storage::<Test>()
+            .unwrap();
+
+        let validators: Vec<_> = self
+            .non_reserved_validators
+            .iter()
+            .chain(self.reserved_validators.iter())
+            .collect();
+
+        let balances: Vec<_> = (0..validators.len())
+            .map(|i| (i as u64, 10_000_000))
+            .collect();
+
+        pallet_balances::GenesisConfig::<Test> { balances }
+            .assimilate_storage(&mut t)
+            .unwrap();
+
+        crate::GenesisConfig::<Test> {
+            non_reserved_validators: self.non_reserved_validators,
+            reserved_validators: self.reserved_validators,
+            committee_seats: self.committee_seats,
+        }
         .assimilate_storage(&mut t)
         .unwrap();
 
-    let committee_size = validators.len() as u32;
-    crate::GenesisConfig::<Test> {
-        non_reserved_validators,
-        committee_size,
-        reserved_validators,
+        t.into()
     }
-    .assimilate_storage(&mut t)
-    .unwrap();
-
-    t.into()
 }

--- a/pallets/elections/src/mock.rs
+++ b/pallets/elections/src/mock.rs
@@ -7,6 +7,7 @@ use frame_support::{
     weights::RuntimeDbWeight,
     BoundedVec,
 };
+use primitives::CommitteeSeats;
 use sp_core::H256;
 use sp_runtime::{
     testing::{Header, TestXt},

--- a/pallets/elections/src/tests.rs
+++ b/pallets/elections/src/tests.rs
@@ -23,9 +23,9 @@ fn support(total: Balance, voters: Vec<(AccountId, Balance)>) -> Support<Account
 
 #[test]
 fn storage_is_initialized_already_in_genesis() {
-    static RESERVED: [AccountId; 3] = [1, 2, 3];
-    static NON_RESERVED: [AccountId; 2] = [4, 5];
-    static COMMITTEE_SEATS: CommitteeSeats = CommitteeSeats {
+    const RESERVED: [AccountId; 3] = [1, 2, 3];
+    const NON_RESERVED: [AccountId; 2] = [4, 5];
+    const COMMITTEE_SEATS: CommitteeSeats = CommitteeSeats {
         reserved_seats: 3,
         non_reserved_seats: 2,
     };

--- a/pallets/elections/src/tests.rs
+++ b/pallets/elections/src/tests.rs
@@ -4,7 +4,14 @@ use frame_election_provider_support::{ElectionProvider, Support};
 use frame_support::bounded_vec;
 use pallet_session::SessionManager;
 
-use crate::{mock::*, CommitteeSeats, CommitteeSize};
+use crate::{
+    mock::{
+        with_active_era, with_electable_targets, with_elected_validators, with_electing_voters,
+        AccountId, Balance, Elections, SessionsPerEra, Test, TestExtBuilder,
+    },
+    CommitteeSeats, CommitteeSize, CurrentEraValidators, NextEraCommitteeSize,
+    NextEraNonReservedValidators, NextEraReservedValidators,
+};
 
 fn no_support() -> Support<AccountId> {
     Default::default()
@@ -15,53 +22,85 @@ fn support(total: Balance, voters: Vec<(AccountId, Balance)>) -> Support<Account
 }
 
 #[test]
+fn storage_is_initialized_already_in_genesis() {
+    static RESERVED: [AccountId; 3] = [1, 2, 3];
+    static NON_RESERVED: [AccountId; 2] = [4, 5];
+    static COMMITTEE_SEATS: CommitteeSeats = CommitteeSeats {
+        reserved_seats: 3,
+        non_reserved_seats: 2,
+    };
+
+    TestExtBuilder::new(RESERVED.to_vec(), NON_RESERVED.to_vec())
+        .with_committee_seats(COMMITTEE_SEATS)
+        .build()
+        .execute_with(|| {
+            assert_eq!(CommitteeSize::<Test>::get(), COMMITTEE_SEATS);
+            assert_eq!(NextEraCommitteeSize::<Test>::get(), COMMITTEE_SEATS);
+            assert_eq!(NextEraReservedValidators::<Test>::get(), RESERVED);
+            assert_eq!(NextEraNonReservedValidators::<Test>::get(), NON_RESERVED);
+            assert_eq!(CurrentEraValidators::<Test>::get().reserved, RESERVED);
+            assert_eq!(
+                CurrentEraValidators::<Test>::get().non_reserved,
+                NON_RESERVED
+            );
+            // We do not expect SessionValidatorBlockCount and ValidatorEraTotalReward to be
+            // populated from genesis.
+        });
+}
+
+#[test]
 fn validators_are_elected_only_when_staking() {
-    new_test_ext(vec![1, 2, 3, 4], vec![5, 6, 7, 8]).execute_with(|| {
-        // We check all 4 possibilities for both reserved and non reserved validators:
-        // { staking validator, not staking validator } x { any support, no support }.
-        //
-        // Only those considered as staking should be elected.
+    TestExtBuilder::new(vec![1, 2, 3, 4], vec![5, 6, 7, 8])
+        .build()
+        .execute_with(|| {
+            // We check all 4 possibilities for both reserved and non reserved validators:
+            // { staking validator, not staking validator } x { any support, no support }.
+            //
+            // Only those considered as staking should be elected.
 
-        with_electable_targets(vec![1, 2, 5, 6]);
-        with_electing_voters(vec![
-            (1, 10, bounded_vec![1]),
-            (3, 10, bounded_vec![3]),
-            (5, 10, bounded_vec![5]),
-            (7, 10, bounded_vec![7]),
-        ]);
+            with_electable_targets(vec![1, 2, 5, 6]);
+            with_electing_voters(vec![
+                (1, 10, bounded_vec![1]),
+                (3, 10, bounded_vec![3]),
+                (5, 10, bounded_vec![5]),
+                (7, 10, bounded_vec![7]),
+            ]);
 
-        let elected = <Elections as ElectionProvider>::elect().expect("`elect()` should succeed");
+            let elected =
+                <Elections as ElectionProvider>::elect().expect("`elect()` should succeed");
 
-        assert_eq!(
-            elected,
-            &[
-                (1, support(10, vec![(1, 10)])),
-                (2, no_support()),
-                (5, support(10, vec![(5, 10)])),
-                (6, no_support()),
-            ]
-        );
-    });
+            assert_eq!(
+                elected,
+                &[
+                    (1, support(10, vec![(1, 10)])),
+                    (2, no_support()),
+                    (5, support(10, vec![(5, 10)])),
+                    (6, no_support()),
+                ]
+            );
+        });
 }
 
 #[test]
 fn session_authorities_must_have_been_elected() {
-    new_test_ext(vec![1, 2], vec![5, 6]).execute_with(|| {
-        let next_era = 41;
-
-        CommitteeSize::<Test>::put(CommitteeSeats {
+    TestExtBuilder::new(vec![1, 2], vec![5, 6])
+        .with_committee_seats(CommitteeSeats {
             reserved_seats: 2,
             non_reserved_seats: 2,
+        })
+        .build()
+        .execute_with(|| {
+            let next_era = 41;
+
+            with_active_era(next_era - 1);
+            with_elected_validators(next_era, vec![1, 5]);
+
+            let mut authorities = <Elections as SessionManager<AccountId>>::new_session(
+                next_era * SessionsPerEra::get(),
+            )
+            .unwrap_or_default();
+
+            authorities.sort();
+            assert_eq!(authorities, &[1, 5]);
         });
-
-        with_active_era(next_era - 1);
-        with_elected_validators(next_era, vec![1, 5]);
-
-        let mut authorities =
-            <Elections as SessionManager<AccountId>>::new_session(next_era * SessionsPerEra::get())
-                .unwrap_or_default();
-
-        authorities.sort();
-        assert_eq!(authorities, &[1, 5]);
-    });
 }

--- a/pallets/elections/src/tests.rs
+++ b/pallets/elections/src/tests.rs
@@ -3,14 +3,15 @@
 use frame_election_provider_support::{ElectionProvider, Support};
 use frame_support::bounded_vec;
 use pallet_session::SessionManager;
+use primitives::CommitteeSeats;
 
 use crate::{
     mock::{
         with_active_era, with_electable_targets, with_elected_validators, with_electing_voters,
         AccountId, Balance, Elections, SessionsPerEra, Test, TestExtBuilder,
     },
-    CommitteeSeats, CommitteeSize, CurrentEraValidators, NextEraCommitteeSize,
-    NextEraNonReservedValidators, NextEraReservedValidators,
+    CommitteeSize, CurrentEraValidators, NextEraCommitteeSize, NextEraNonReservedValidators,
+    NextEraReservedValidators,
 };
 
 fn no_support() -> Support<AccountId> {

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitives"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Cardinal Cryptography"]
 edition = "2021"
 license = "Apache 2.0"

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::too_many_arguments, clippy::unnecessary_mut_passed)]
 #![cfg_attr(not(feature = "std"), no_std)]
 use codec::{Decode, Encode};
+use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 use sp_core::crypto::KeyTypeId;
 use sp_runtime::ConsensusEngineId;
 pub use sp_staking::{EraIndex, SessionIndex};
@@ -43,10 +46,32 @@ pub const DEFAULT_SESSIONS_PER_ERA: SessionIndex = 96;
 pub const TOKEN_DECIMALS: u32 = 12;
 pub const TOKEN: u128 = 10u128.pow(TOKEN_DECIMALS);
 
-pub const DEFAULT_COMMITTEE_SIZE: u32 = 4;
-
 pub const ADDRESSES_ENCODING: u8 = 42;
 pub const DEFAULT_UNIT_CREATION_DELAY: u64 = 300;
+
+pub const DEFAULT_COMMITTEE_SIZE: u32 = 4;
+
+#[derive(Decode, Encode, TypeInfo, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct CommitteeSeats {
+    pub reserved_seats: u32,
+    pub non_reserved_seats: u32,
+}
+
+impl CommitteeSeats {
+    pub fn size(&self) -> u32 {
+        self.reserved_seats.saturating_add(self.non_reserved_seats)
+    }
+}
+
+impl Default for CommitteeSeats {
+    fn default() -> Self {
+        CommitteeSeats {
+            reserved_seats: DEFAULT_COMMITTEE_SIZE,
+            non_reserved_seats: 0,
+        }
+    }
+}
 
 #[derive(Encode, Decode, PartialEq, Eq, Debug)]
 pub enum ApiError {


### PR DESCRIPTION
# Description

This PR introduces two changes:
 - we enable setting non-reserved seats for genesis build as well
 - we initialize all the (reasonable) storage items in genesis build 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have added tests
- I have bumped `spec_version`
