### PR TITLE
A0-1211: Add --version flag to aleph-node

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[derive(Debug, Parser)]
-#[clap(subcommand_negates_reqs(true))]
+#[clap(subcommand_negates_reqs(true), version(env!("SUBSTRATE_CLI_IMPL_VERSION")))]
 pub struct Cli {
     #[clap(subcommand)]
     pub subcommand: Option<Subcommand>,


### PR DESCRIPTION
Makes this:
```
$ target/release/aleph-node --version
aleph-node 0.7.0-fe1e38535e3
```
possible.