### PR TITLE
Change consensus engine ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-node"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aleph-runtime",
  "clap",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-node"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Cardinal Cryptography"]
 description = "Aleph node binary"
 edition = "2021"

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -15,10 +15,7 @@ use sp_std::vec::Vec;
 
 pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"alp0");
 
-// Same as GRANDPA_ENGINE_ID because as of right now substrate sends only
-// grandpa justifications over the network.
-// TODO: change this once https://github.com/paritytech/substrate/issues/8172 will be resolved.
-pub const ALEPH_ENGINE_ID: ConsensusEngineId = *b"FRNK";
+pub const ALEPH_ENGINE_ID: ConsensusEngineId = *b"ALPH";
 
 mod app {
     use sp_application_crypto::{app_crypto, ed25519};


### PR DESCRIPTION
# Description

Since https://github.com/paritytech/substrate/pull/8266 resolved the blocker, we can get rid of the default consensus engine ID, which previously was `FRNK`.

If you are curious what `FRNK` means, let these screenshots from https://github.com/paritytech/substrate/pull/2802 confuse you:
![image](https://user-images.githubusercontent.com/27450471/184134130-641d9095-1a32-4fa5-ba54-18fcb043782d.png)
![image](https://user-images.githubusercontent.com/27450471/184134206-bc7ffe18-b223-43b2-89e3-34cbf682226b.png)


## Type of change

Changes in UI:
![image](https://user-images.githubusercontent.com/27450471/184134724-e384af92-e35d-4f76-8bb9-0942d1c4e61b.png)


Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- delete when not applicable to your PR -->
