### PR TITLE
A0-1285: Implement common traits in aleph-client

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "ac-primitives",
  "anyhow",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 license = "Apache 2.0"
 

--- a/aleph-client/src/fee.rs
+++ b/aleph-client/src/fee.rs
@@ -3,7 +3,7 @@ use substrate_api_client::Balance;
 
 use crate::{AnyConnectionExt, Extrinsic};
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct FeeInfo {
     pub fee_without_weight: Balance,
     pub unadjusted_weight: Balance,

--- a/aleph-client/src/fee.rs
+++ b/aleph-client/src/fee.rs
@@ -10,6 +10,12 @@ pub struct FeeInfo {
     pub adjusted_weight: Balance,
 }
 
+impl Default for FeeInfo {
+    fn default() -> Self {
+        FeeInfo { fee_without_weight: 0, unadjusted_weight: 0, adjusted_weight: 0 }
+    }
+}
+
 pub fn get_tx_fee_info<C: AnyConnectionExt, Call: Encode>(
     connection: &C,
     tx: &Extrinsic<Call>,

--- a/aleph-client/src/fee.rs
+++ b/aleph-client/src/fee.rs
@@ -3,21 +3,11 @@ use substrate_api_client::Balance;
 
 use crate::{AnyConnectionExt, Extrinsic};
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct FeeInfo {
     pub fee_without_weight: Balance,
     pub unadjusted_weight: Balance,
     pub adjusted_weight: Balance,
-}
-
-impl Default for FeeInfo {
-    fn default() -> Self {
-        FeeInfo {
-            fee_without_weight: 0,
-            unadjusted_weight: 0,
-            adjusted_weight: 0,
-        }
-    }
 }
 
 pub fn get_tx_fee_info<C: AnyConnectionExt, Call: Encode>(

--- a/aleph-client/src/fee.rs
+++ b/aleph-client/src/fee.rs
@@ -12,7 +12,11 @@ pub struct FeeInfo {
 
 impl Default for FeeInfo {
     fn default() -> Self {
-        FeeInfo { fee_without_weight: 0, unadjusted_weight: 0, adjusted_weight: 0 }
+        FeeInfo {
+            fee_without_weight: 0,
+            unadjusted_weight: 0,
+            adjusted_weight: 0,
+        }
     }
 }
 

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -315,6 +315,7 @@ pub fn create_connection(address: &str) -> Connection {
     create_custom_connection(address).expect("Connection should be created")
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 enum Protocol {
     Ws,
     Wss,

--- a/aleph-client/src/multisig.rs
+++ b/aleph-client/src/multisig.rs
@@ -1,4 +1,7 @@
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    fmt::{Debug, Formatter},
+};
 
 use anyhow::{ensure, Result};
 use codec::{Decode, Encode};
@@ -25,7 +28,7 @@ use crate::{
 const MAX_WEIGHT: u64 = 500_000_000;
 
 /// Gathers all possible errors from this module.
-#[derive(Debug, Error)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Error)]
 pub enum MultisigError {
     #[error("👪❌ Threshold should be between 2 and {0}.")]
     IncorrectThreshold(usize),
@@ -91,7 +94,7 @@ struct Multisig {
 
 /// This represents the ongoing procedure of aggregating approvals among members
 /// of multisignature party.
-#[derive(Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct SignatureAggregation {
     /// The point in 'time' when the aggregation was initiated on the chain.
     /// Internally it is a pair: number of the block containing initial call and the position
@@ -122,6 +125,7 @@ impl SignatureAggregation {
 
 /// `MultisigParty` is representing a multiparty entity constructed from
 /// a group of accounts (`members`) and a threshold (`threshold`).
+#[derive(Clone)]
 pub struct MultisigParty {
     /// Derived multiparty account (public key).
     account: AccountId,
@@ -129,6 +133,16 @@ pub struct MultisigParty {
     members: Vec<KeyPair>,
     /// Minimum required approvals.
     threshold: u16,
+}
+
+impl Debug for MultisigParty {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MultisigParty")
+            .field("account", &self.account)
+            .field("threshold", &self.threshold)
+            .field("member count", &self.members.len())
+            .finish()
+    }
 }
 
 impl MultisigParty {

--- a/aleph-client/src/multisig.rs
+++ b/aleph-client/src/multisig.rs
@@ -94,7 +94,7 @@ struct Multisig {
 
 /// This represents the ongoing procedure of aggregating approvals among members
 /// of multisignature party.
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct SignatureAggregation {
     /// The point in 'time' when the aggregation was initiated on the chain.
     /// Internally it is a pair: number of the block containing initial call and the position

--- a/aleph-client/src/session.rs
+++ b/aleph-client/src/session.rs
@@ -15,7 +15,7 @@ const PALLET: &str = "Session";
 
 // Using custom struct and rely on default Encode trait from Parity's codec
 // it works since byte arrays are encoded in a straight forward way, it as-is
-#[derive(Debug, Encode, Clone)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Decode, Encode)]
 pub struct Keys {
     pub aura: [u8; 32],
     pub aleph: [u8; 32],

--- a/aleph-client/src/staking.rs
+++ b/aleph-client/src/staking.rs
@@ -301,7 +301,7 @@ pub fn bonded<C: AnyConnection>(connection: &C, stash: &KeyPair) -> Option<Accou
 /// `T: pallet_staking::Config` (somehow breaking consistency with similar structures in other
 /// pallets) we have no easy way of retrieving ledgers from storage. Thus, we chose cloning
 /// (relevant part of) this struct instead of implementing `Config` trait.
-#[derive(PartialEq, Eq, Clone, Debug, Encode, Decode)]
+#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
 pub struct StakingLedger {
     pub stash: AccountId,
     #[codec(compact)]

--- a/aleph-client/src/staking.rs
+++ b/aleph-client/src/staking.rs
@@ -301,7 +301,7 @@ pub fn bonded<C: AnyConnection>(connection: &C, stash: &KeyPair) -> Option<Accou
 /// `T: pallet_staking::Config` (somehow breaking consistency with similar structures in other
 /// pallets) we have no easy way of retrieving ledgers from storage. Thus, we chose cloning
 /// (relevant part of) this struct instead of implementing `Config` trait.
-#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode)]
 pub struct StakingLedger {
     pub stash: AccountId,
     #[codec(compact)]

--- a/aleph-client/src/vesting.rs
+++ b/aleph-client/src/vesting.rs
@@ -15,7 +15,7 @@ use crate::{
 const PALLET: &str = "Vesting";
 
 /// Gathers errors from this module.
-#[derive(Debug, Error)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Error)]
 pub enum VestingError {
     #[error("🦺❌ The connection should be signed.")]
     UnsignedConnection,


### PR DESCRIPTION
# Description

Applies [the trait ADR](https://www.notion.so/cardinalcryptography/Basic-traits-derivation-and-field-access-for-public-structs-0aa22c4887024547b613db5754e0664a) to public types in aleph-client.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have bumped aleph-client version if relevant
