### PR TITLE
Improve script for updating substrate branch. Update Cargo.locks

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -1619,12 +1619,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-aleph"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
  "pallet-session",
+ "pallets-support",
  "parity-scale-codec",
  "primitives",
  "scale-info",

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "ac-primitives",
  "anyhow",
@@ -1719,12 +1719,13 @@ checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "pallet-aleph"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
  "pallet-session",
+ "pallets-support",
  "parity-scale-codec",
  "primitives",
  "scale-info",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "ac-primitives",
  "anyhow",
@@ -2000,12 +2000,13 @@ checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "pallet-aleph"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
  "pallet-session",
+ "pallets-support",
  "parity-scale-codec",
  "primitives",
  "scale-info",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "ac-primitives",
  "anyhow",
@@ -1735,12 +1735,13 @@ checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "pallet-aleph"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
  "pallet-session",
+ "pallets-support",
  "parity-scale-codec",
  "primitives",
  "scale-info",

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "ac-primitives",
  "anyhow",
@@ -1802,12 +1802,13 @@ checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "pallet-aleph"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
  "pallet-session",
+ "pallets-support",
  "parity-scale-codec",
  "primitives",
  "scale-info",

--- a/scripts/update_substrate_git_branch.sh
+++ b/scripts/update_substrate_git_branch.sh
@@ -28,7 +28,7 @@ for path in ${paths[@]}; do
     # 2. Find and capture whatever is after closing `"` and before `,` or `}`. It will be available as `\2`.
     # 3. Substitute new branch and concatenate it with `\1` and `\2`.
 
-    sed -e '/Cardinal-Cryptography\/substrate.git/s/\(branch\s*=\s*"\)[^"]*"\([^,}]*\)/\1'"${BRANCH}"'"\2/' < $path > x
+    sed -e '/Cardinal-Cryptography\/substrate.git/s/\(branch\s*=\s*"\)[^"]*"\([^,}]*\)/\1'"${BRANCH//\//\\/}"'"\2/' < $path > x
     mv x "${path}"
 done
 

--- a/scripts/update_substrate_git_branch.sh
+++ b/scripts/update_substrate_git_branch.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 function usage(){
   cat << EOF
-Substitutes the branch name of the repository Cardinal-Cryptography/substrate.git in all Cargo.toml files.
+Substitutes the branch name of the repository `https://github.com/Cardinal-Cryptography/substrate` in all Cargo.toml files.
 
 Usage:
   $0 <new_branch_name>
@@ -28,7 +28,7 @@ for path in ${paths[@]}; do
     # 2. Find and capture whatever is after closing `"` and before `,` or `}`. It will be available as `\2`.
     # 3. Substitute new branch and concatenate it with `\1` and `\2`.
 
-    sed -e '/Cardinal-Cryptography\/substrate.git/s/\(branch\s*=\s*"\)[^"]*"\([^,}]*\)/\1'"${BRANCH//\//\\/}"'"\2/' < $path > x
+    sed -e '/https:\/\/github.com\/Cardinal-Cryptography\/substrate/s/\(branch\s*=\s*"\)[^"]*"\([^,}]*\)/\1'"${BRANCH//\//\\/}"'"\2/' < $path > x
     mv x "${path}"
 done
 

--- a/scripts/update_substrate_git_branch.sh
+++ b/scripts/update_substrate_git_branch.sh
@@ -28,7 +28,7 @@ for path in ${paths[@]}; do
     # 2. Find and capture whatever is after closing `"` and before `,` or `}`. It will be available as `\2`.
     # 3. Substitute new branch and concatenate it with `\1` and `\2`.
 
-    sed -e '/https:\/\/github.com\/Cardinal-Cryptography\/substrate/s/\(branch\s*=\s*"\)[^"]*"\([^,}]*\)/\1'"${BRANCH//\//\\/}"'"\2/' < $path > x
+    sed -e '/https:\/\/github.com\/Cardinal-Cryptography\/substrate\(.git\)\{0,1\}"/s/\(branch\s*=\s*"\)[^"]*"\([^,}]*\)/\1'"${BRANCH//\//\\/}"'"\2/' < $path > x
     mv x "${path}"
 done
 

--- a/scripts/update_substrate_git_branch.sh
+++ b/scripts/update_substrate_git_branch.sh
@@ -23,11 +23,8 @@ paths=$(find . -mindepth 2 -type f -name "Cargo.toml" -not -path "*/target/*") |
 
 for path in ${paths[@]}; do
     echo "Upgrading ${path}"
-    # 1. Find and capture `Cardinal-Cryptography/substrate.git", branch = "` substring. It will be available as `\1`. In place
-    #    of spaces there can be sequence of `\s` characters.
-    # 2. Find and capture whatever is after closing `"` and before `,` or `}`. It will be available as `\2`.
-    # 3. Substitute new branch and concatenate it with `\1` and `\2`.
-
+    # 1. Filter out lines not containing `https://github.com/Cardinal-Cryptography/substrate[.git]"`.
+    # 2. Substitute `###` in `branch = "###"` with $BRANCH.
     sed -e '/https:\/\/github.com\/Cardinal-Cryptography\/substrate\(.git\)\{0,1\}"/s/\(branch\s*=\s*"\)[^"]*"\([^,}]*\)/\1'"${BRANCH//\//\\/}"'"\2/' < $path > x
     mv x "${path}"
 done

--- a/scripts/update_substrate_git_branch.sh
+++ b/scripts/update_substrate_git_branch.sh
@@ -1,20 +1,35 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-branch="$1"
+function usage(){
+  cat << EOF
+Substitutes the branch name of the repository Cardinal-Cryptography/substrate.git in all Cargo.toml files.
+
+Usage:
+  $0 <new_branch_name>
+EOF
+  exit 0
+}
+
+BRANCH="${1:-}"
+if [[ -z "${BRANCH}" ]]; then
+       usage
+       exit 2
+fi
 
 # Find all `Cargo.toml` files outside any `target` directory.
-paths=$(find . -mindepth 2 -type f -name "Cargo.toml" -not -path "*/target/*")
+paths=$(find . -mindepth 2 -type f -name "Cargo.toml" -not -path "*/target/*") || echo "Problems with finding Cargo.toml files"
 
 for path in ${paths[@]}; do
-    echo upgrade $path
+    echo "Upgrading ${path}"
     # 1. Find and capture `Cardinal-Cryptography/substrate.git", branch = "` substring. It will be available as `\1`. In place
     #    of spaces there can be sequence of `\s` characters.
     # 2. Find and capture whatever is after closing `"` and before `,` or `}`. It will be available as `\2`.
     # 3. Substitute new branch and concatenate it with `\1` and `\2`.
-    sed -e 's/\(Cardinal-Cryptography\/substrate.git"\s*,\s*branch\s*=\s*"\)[^"]*"\([^,}]*\)/\1'$branch'"\2/' < $path > x
-    mv x $path
+
+    sed -e '/Cardinal-Cryptography\/substrate.git/s/\(branch\s*=\s*"\)[^"]*"\([^,}]*\)/\1'"${BRANCH}"'"\2/' < $path > x
+    mv x "${path}"
 done
 
-cargo update
+exit 0

--- a/scripts/update_substrate_git_branch.sh
+++ b/scripts/update_substrate_git_branch.sh
@@ -29,4 +29,6 @@ for path in ${paths[@]}; do
     mv x "${path}"
 done
 
+cargo update
+
 exit 0


### PR DESCRIPTION
# Description

This PR improves a bit `scripts/update_substrate_git_branch.sh` so that:
 - it adheres to the recent bash ADR
 - supports branches containing slash
 - works for dependency defined as both `https://github.com/Cardinal-Cryptography/substrate` and `https://github.com/Cardinal-Cryptography/substrate.git` (recently we added 4 dependencies without `.git` suffix)

Additionally, some recent PRs didn't update some Cargo.locks, so I'm attaching new versions as well.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- I have created new documentation