### PR TITLE
Reduce restore cache timeout

### DIFF
--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -47,6 +47,8 @@ runs:
   steps:
     - name: Restore cargo cache
       uses: actions/cache@v3
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MIN: "10"
       with:
         path: |
           ~/.cargo


### PR DESCRIPTION
# Description

Changes the timeout for restore cache from the default of 1 hour to 10 minutes. It seems the action sometimes hangs during download and the way they solved it is with this timeout. 1 hour seems like much too much for the size of caches we generate (the biggest one is 1-2GB).

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- Only changes github action config.
