### PR TITLE
A0-1216: Modify workflows to additional push image to Docker Hub

### DIFF
--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -52,6 +52,26 @@ jobs:
             exit 1
           fi
 
+      - name: Login to Docker Hub
+        id: login-docker-hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Tag and push image of Mainnet to DockerHub
+        env:
+          MAINNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
+          DOCKERHUB_MAINNET_IMAGE: cardinalcryptography/aleph-zero:mainnet-${{ steps.vars.outputs.branch }}
+          DOCKERHUB_MAINNET_LATEST_IMAGE: cardinalcryptography/aleph-zero:mainnet-latest
+        run: |
+          echo "FROM ${{ env.MAINNET_IMAGE }}" > Dockerfile.dockerhub
+          echo 'ENTRYPOINT ["/usr/local/bin/aleph-node"]' >> Dockerfile.dockerhub
+          docker build -t ${{ env.DOCKERHUB_MAINNET_IMAGE }} -f Dockerfile.dockerhub .
+          docker tag ${{ env.DOCKERHUB_MAINNET_IMAGE }} ${{ env.DOCKERHUB_MAINNET_LATEST_IMAGE }}
+          docker push ${{ env.DOCKERHUB_MAINNET_IMAGE }}
+          docker push ${{ env.DOCKERHUB_MAINNET_LATEST_IMAGE }}
+
       - name: GIT | Checkout aleph-apps repo
         uses: actions/checkout@master
         with:

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -59,6 +59,26 @@ jobs:
             docker push ${{ env.TESTNET_IMAGE }}
           fi
 
+      - name: Login to Docker Hub
+        id: login-docker-hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Tag and push image of Testnet to DockerHub
+        env:
+          TESTNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
+          DOCKERHUB_TESTNET_IMAGE: cardinalcryptography/aleph-zero:testnet-${{ steps.vars.outputs.branch }}
+          DOCKERHUB_TESTNET_LATEST_IMAGE: cardinalcryptography/aleph-zero:testnet-latest
+        run: |
+          echo "FROM ${{ env.DOCKERHUB_TESTNET_IMAGE }}" > Dockerfile.dockerhub
+          echo 'ENTRYPOINT ["/usr/local/bin/aleph-node"]' >> Dockerfile.dockerhub
+          docker build -t ${{ env.DOCKERHUB_TESTNET_IMAGE }} -f Dockerfile.dockerhub .
+          docker tag ${{ env.DOCKERHUB_TESTNET_IMAGE }} ${{ env.DOCKERHUB_TESTNET_LATEST_IMAGE }}
+          docker push ${{ env.DOCKERHUB_TESTNET_IMAGE }}
+          docker push ${{ env.DOCKERHUB_TESTNET_LATEST_IMAGE }}
+
       - name: GIT | Checkout aleph-apps repo
         uses: actions/checkout@master
         with:


### PR DESCRIPTION
Modifies GitHub workflows to push aleph-node image with ENTRYPOINT changed to aleph-node binary, to Docker Hub