### PR TITLE
A0-1216: Modify GitHub workflows to push image to DockerHub

### DIFF
--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -51,7 +51,27 @@ jobs:
             echo "::error title=Wrong docker image tag::Docker image ${{ env.IMAGE }} doesn't exist"
             exit 1
           fi
-          
+
+      - name: Login to Docker Hub
+        id: login-docker-hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Tag and push image of Mainnet to DockerHub
+        env:
+          MAINNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
+          DOCKERHUB_MAINNET_IMAGE: cardinalcryptography/aleph-zero:mainnet-${{ steps.vars.outputs.branch }}
+          DOCKERHUB_MAINNET_LATEST_IMAGE: cardinalcryptography/aleph-zero:mainnet-latest
+        run: |
+          echo "FROM ${{ env.MAINNET_IMAGE }}" > Dockerfile.dockerhub
+          echo 'ENTRYPOINT ["/usr/local/bin/aleph-node"]' >> Dockerfile.dockerhub
+          docker build -t ${{ env.DOCKERHUB_MAINNET_IMAGE }} -f Dockerfile.dockerhub .
+          docker tag ${{ env.DOCKERHUB_MAINNET_IMAGE }} ${{ env.DOCKERHUB_MAINNET_LATEST_IMAGE }}
+          docker push ${{ env.DOCKERHUB_MAINNET_IMAGE }}
+          docker push ${{ env.DOCKERHUB_MAINNET_LATEST_IMAGE }}
+
       - name: GIT | Checkout aleph-apps repo
         uses: actions/checkout@master
         with:

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -58,7 +58,27 @@ jobs:
             docker tag ${{ env.DEVNET_IMAGE }} ${{ env.TESTNET_IMAGE }}
             docker push ${{ env.TESTNET_IMAGE }}
           fi
-          
+
+      - name: Login to Docker Hub
+        id: login-docker-hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Tag and push image of Testnet to DockerHub
+        env:
+          TESTNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
+          DOCKERHUB_TESTNET_IMAGE: cardinalcryptography/aleph-zero:testnet-${{ steps.vars.outputs.branch }}
+          DOCKERHUB_TESTNET_LATEST_IMAGE: cardinalcryptography/aleph-zero:testnet-latest
+        run: |
+          echo "FROM ${{ env.DOCKERHUB_TESTNET_IMAGE }}" > Dockerfile.dockerhub
+          echo 'ENTRYPOINT ["/usr/local/bin/aleph-node"]' >> Dockerfile.dockerhub
+          docker build -t ${{ env.DOCKERHUB_TESTNET_IMAGE }} -f Dockerfile.dockerhub .
+          docker tag ${{ env.DOCKERHUB_TESTNET_IMAGE }} ${{ env.DOCKERHUB_TESTNET_LATEST_IMAGE }}
+          docker push ${{ env.DOCKERHUB_TESTNET_IMAGE }}
+          docker push ${{ env.DOCKERHUB_TESTNET_LATEST_IMAGE }}
+
       - name: GIT | Checkout aleph-apps repo
         uses: actions/checkout@master
         with:


### PR DESCRIPTION
Modifies GitHub workflows to push aleph-node image to Docker Hub, with ENTRYPOINT changed from docker-entrypoint.sh to aleph-node binary.

The solution for building docker container has been already tested and the images for existing testnet and mainnet versions have been already pushed to Docker Hub manually. You can check them at: https://hub.docker.com/r/cardinalcryptography/aleph-zero/tags

Same change have been recently applied to the `release-7` branch