### PR TITLE
A0-1382: Replace ubuntu-latest with ubuntu-20.04 in all the workflows

### DIFF
--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -66,7 +66,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-target-${{ inputs.target-key }}-${{ inputs.cache-version }}
 
-    - name: Install sccache for ubuntu-latest
+    - name: Install sccache for ubuntu-20.04
       shell: bash
       run: |
         LINK=https://github.com/mozilla/sccache/releases/download

--- a/.github/workflows/build-node-and-runtime.yml
+++ b/.github/workflows/build-node-and-runtime.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     name: Build binary artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       RUST_BACKTRACE: full
     steps:

--- a/.github/workflows/build-send-postsync-hook-runtime-image.yml
+++ b/.github/workflows/build-send-postsync-hook-runtime-image.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: Save cliain binary as an artifact
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/check-excluded-packages.yml
+++ b/.github/workflows/check-excluded-packages.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     name: Check excluded packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/deploy-feature-envs.yaml
+++ b/.github/workflows/deploy-feature-envs.yaml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ (github.event.label.name == '[AZERO] DEPLOY-FEATURE-ENV') || (github.event.label.name == '[AZERO] DEPLOY-HOT-FEATURE-ENV') }}
     needs: [build_aleph_node_binary]
     name: Build, prepare and push aleph-node image from PR to ECR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout repo
         uses: actions/checkout@v2.3.4
@@ -58,7 +58,7 @@ jobs:
   deploy_feature_env:
     if: ${{ (github.event.label.name == '[AZERO] DEPLOY-FEATURE-ENV') || (github.event.label.name == '[AZERO] DEPLOY-HOT-FEATURE-ENV') }}
     name: Deploy feature environment based on the PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
@@ -264,7 +264,7 @@ jobs:
     if: ${{ (github.event.label.name == '[AZERO] DEPLOY-FEATURE-ENV') || (github.event.label.name == '[AZERO] DEPLOY-HOT-FEATURE-ENV') }}
     needs: [push_pr_image,deploy_feature_env]
     name: Update feature environment to the latest PR aleph-node image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout repo
         uses: actions/checkout@v2.3.4
@@ -375,7 +375,7 @@ jobs:
   destroy_feature_env:
     if: ${{ github.event.label.name == '[AZERO] DELETE-FEATURE-ENV' }}
     name: Destroy feature env
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
@@ -426,7 +426,7 @@ jobs:
   destroy_feature_env_on_close:
     if: (github.event.action == 'closed' && !contains( github.event.pull_request.labels.*.name, 'DESTROYED') && contains( github.event.pull_request.labels.*.name, 'DEPLOYED'))
     name: Destroy feature env when PR closed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   deploy-mainnet:
     name: Deploy new aleph-node image to Mainnet EKS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: 'mainnet'
     env:
       AWS_REGION: us-east-1 # this region is used by all public ECR repos
@@ -116,7 +116,7 @@ jobs:
 
   slack:
     name: Slack notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [deploy-mainnet]
     if: always()
     steps:

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   deploy-testnet:
     name: Deploy new aleph-node image to Testnet EKS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: 
       name: testnet
     env:
@@ -123,7 +123,7 @@ jobs:
 
   slack:
     name: Slack notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [deploy-testnet]
     if: always()
     steps:

--- a/.github/workflows/deploy-to-devnet.yml
+++ b/.github/workflows/deploy-to-devnet.yml
@@ -11,7 +11,7 @@ jobs:
     name: Deploy new aleph-node image to EKS
     environment:
       name: devnet
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       AWS_REGION: eu-central-1
     steps:
@@ -116,7 +116,7 @@ jobs:
 
   slack:
     name: Slack notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [deploy-devnet]
     if: always()
     steps:

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -27,7 +27,7 @@ jobs:
   build-test-docker:
     needs: [build-new-node]
     name: Build docker image with the test node artifact
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Source code
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
   check-determinism:
     needs: [build-new-node]
     name: Verify runtime build determinism
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       RUST_BACKTRACE: full
     steps:
@@ -90,7 +90,7 @@ jobs:
 
   build-test-client:
     name: Build e2e test client suite
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       RUST_BACKTRACE: full
     steps:
@@ -130,7 +130,7 @@ jobs:
   run-e2e-finalization-test:
     needs: [build-test-docker, build-test-client]
     name: Run e2e finalization test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -145,7 +145,7 @@ jobs:
   run-e2e-rewards-disable-node-test:
     needs: [build-test-docker, build-test-client]
     name: Run e2e reward points - disable node test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -161,7 +161,7 @@ jobs:
   run-e2e-token-transfer-test:
     needs: [build-test-docker, build-test-client]
     name: Run e2e token transfer test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -176,7 +176,7 @@ jobs:
   run-e2e-channeling-fee-test:
     needs: [build-test-docker, build-test-client]
     name: Run e2e channeling fee test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -190,7 +190,7 @@ jobs:
   run-e2e-treasury-access-test:
     needs: [build-test-docker, build-test-client]
     name: Run e2e treasury access test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -205,7 +205,7 @@ jobs:
   run-e2e-batch-transactions-test:
     needs: [build-test-docker, build-test-client]
     name: Run e2e batch transactions test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -220,7 +220,7 @@ jobs:
   run-e2e-staking-era-payouts-test:
     needs: [build-test-docker, build-test-client]
     name: Run e2e staking era payouts test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -236,7 +236,7 @@ jobs:
   run-e2e-staking-new-validator-test:
     needs: [build-test-docker, build-test-client]
     name: Run e2e staking new validator test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -252,7 +252,7 @@ jobs:
   run-e2e-change-validators-test:
     needs: [build-test-docker, build-test-client]
     name: Run e2e change validators test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -268,7 +268,7 @@ jobs:
   run-e2e-fee-calculation:
     needs: [build-test-docker, build-test-client]
     name: Run e2e fee calculation test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -282,7 +282,7 @@ jobs:
   run-e2e-validators-rotate:
     needs: [build-test-docker, build-test-client]
     name: Run validators rotation test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -297,7 +297,7 @@ jobs:
   run-e2e-era-payout:
     needs: [build-test-docker, build-test-client]
     name: Run era payout test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -312,7 +312,7 @@ jobs:
   run-e2e-era-validators:
     needs: [build-test-docker, build-test-client]
     name: Run era validators test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -327,7 +327,7 @@ jobs:
   run-e2e-rewards-force-new-era:
     needs: [build-test-docker, build-test-client]
     name: Run force new era test to check rewards
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -342,7 +342,7 @@ jobs:
   run-e2e-rewards-stake-change:
     needs: [build-test-docker, build-test-client]
     name: Run reward points with stake changed test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -357,7 +357,7 @@ jobs:
   run-e2e-rewards-change-stake-force-new-era:
     needs: [build-test-docker, build-test-client]
     name: Run reward points with stake changed and new era forced test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -372,7 +372,7 @@ jobs:
   run-e2e-rewards-points-basic:
     needs: [build-test-docker, build-test-client]
     name: Run basic reward points calculation test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -387,7 +387,7 @@ jobs:
   run-e2e-authorities-are-staking:
     needs: [build-test-docker, build-test-client]
     name: Run authorities are staking test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -424,7 +424,7 @@ jobs:
       run-e2e-authorities-are-staking,
     ]
     name: Check e2e test suite completion
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
      - name: All e2e tests completed
        run: echo "All e2e tests completed."
@@ -434,7 +434,7 @@ jobs:
     needs: [check-e2e-test-suite-completion]
     name: Push node image to the ECR
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: GIT | Checkout Source code
         uses: actions/checkout@v2
@@ -488,7 +488,7 @@ jobs:
 
   test-catch-up:
     name: Test catching up
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-new-node
     steps:
       - name: Checkout source code
@@ -513,7 +513,7 @@ jobs:
 
   test-multiple-restarts:
     name: Test multiple restarts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-new-node
     steps:
       - name: Checkout source code
@@ -538,7 +538,7 @@ jobs:
 
   check-runtime-change:
     name: Inspect whether runtime version has been changed (compared with main)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       runtime-updated: ${{ steps.inspect.outputs.diff }}
     steps:
@@ -561,7 +561,7 @@ jobs:
     name: Build new runtime and try_runtime tool
     needs: [ check-runtime-change ]
     if: ${{ needs.check-runtime-change.outputs.runtime-updated != 0 }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
@@ -604,7 +604,7 @@ jobs:
 
   test-runtime-update:
     name: Test runtime update with try-runtime tool
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [ build-new-runtime-and-try_runtime ]
     steps:
       - name: Checkout source code
@@ -637,7 +637,7 @@ jobs:
 
   slack:
     name: Slack notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [push-image]
     if: always()
     steps:

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -16,7 +16,7 @@ jobs:
   build-test-docker:
     needs: [build-new-node]
     name: Build docker image with the test node artifact
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
   check-determinism:
     needs: [build-new-node]
     name: Verify runtime build determinism
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       RUST_BACKTRACE: full
     steps:
@@ -77,7 +77,7 @@ jobs:
 
   build-test-client:
     name: Build e2e test client suite
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       RUST_BACKTRACE: full
     steps:
@@ -116,7 +116,7 @@ jobs:
   run-e2e-authorities-are-staking:
     needs: [build-test-docker, build-test-client]
     name: Run authorities are staking test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -133,14 +133,14 @@ jobs:
       run-e2e-authorities-are-staking,
     ]
     name: Check e2e test suite completion
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: All e2e tests completed
         run: echo "All e2e tests completed."
 
   slack:
     name: Slack notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [check-e2e-test-suite-completion, check-determinism]
     if: always()
     steps:

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'Cardinal-Cryptography/aleph-node'}}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   check-test-and-lint:
     name: Run check, test and lints
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CARGO_INCREMENTAL: 0
     steps:


### PR DESCRIPTION
In GitHub workflows, `ubuntu-latest` means `ubuntu-20.04` which is a bit confusing. That's for starters. 

In the future, GH might decide to change `ubuntu-latest` to `22.04`. Hence, it's safer to replace the `runs-on` value to `ubuntu-20.04` everywhere for visibility.

Documentation on the workers: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources 