### PR TITLE
A0-1449: Add workflow for building and pushing cliain docker image

### DIFF
--- a/.github/workflows/build-and-push-cliain.yaml
+++ b/.github/workflows/build-and-push-cliain.yaml
@@ -1,0 +1,49 @@
+name: Build and push cliain docker image
+
+on:
+  push:
+    paths:
+      - 'bin/cliain/**'
+  workflow_dispatch:
+
+jobs:
+  build-image:
+    name: Build binary
+    runs-on: ubuntu-20.04
+    steps:
+      - name: GIT | Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+
+      - name: Cargo | Build release binary
+        run: |
+          cd ./bin/cliain && cargo build --release
+
+      - name: GIT | Get branch name and commit SHA
+        id: get_branch
+        uses: ./.github/actions/get-branch
+      
+      - name: Login to ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
+      
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+      
+      - name: Build and push latest docker image
+        id: build-image
+        env:
+          RELEASE_IMAGE: public.ecr.aws/p6e8q1z1/cliain:${{ steps.get_branch.outputs.branch_name == 'main' && 'latest' || steps.get_branch.outputs.branch_name }}
+        uses: docker/build-push-action@v2
+        with:
+          context: ./bin/cliain
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./bin/cliain/Dockerfile
+          push: true
+          tags: ${{ env.RELEASE_IMAGE }}

--- a/bin/cliain/Dockerfile
+++ b/bin/cliain/Dockerfile
@@ -1,5 +1,13 @@
 FROM ubuntu:jammy-20220531
 
+RUN apt update && \
+    apt install wget -y && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+
 COPY target/release/cliain /usr/local/bin
 RUN chmod +x /usr/local/bin/cliain
 


### PR DESCRIPTION
Adds a github workflow that builds the cliain docker image and pushes it to ECR registry. 
In addition to that, few lines have been added to the Dockerfile from `benjamin` branch that add libssl 1.1.