### PR TITLE
A0-1408: Network protocols

### DIFF
--- a/finality-aleph/src/validator_network/handshake.rs
+++ b/finality-aleph/src/validator_network/handshake.rs
@@ -1,0 +1,100 @@
+use std::fmt::{Display, Error as FmtError, Formatter};
+
+use aleph_primitives::AuthorityId;
+use tokio::time::{timeout, Duration};
+
+use crate::{
+    crypto::AuthorityPen,
+    validator_network::{
+        io::{receive_data, send_data, ReceiveError, SendError},
+        Splittable,
+    },
+};
+
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Handshake error.
+#[derive(Debug)]
+pub enum HandshakeError {
+    /// Send error.
+    SendError(SendError),
+    /// Receive error.
+    ReceiveError(ReceiveError),
+    /// Timeout.
+    TimedOut,
+}
+
+impl Display for HandshakeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        use HandshakeError::*;
+        match self {
+            SendError(e) => write!(f, "send error: {}", e),
+            ReceiveError(e) => write!(f, "receive error: {}", e),
+            TimedOut => write!(f, "timed out"),
+        }
+    }
+}
+
+impl From<SendError> for HandshakeError {
+    fn from(e: SendError) -> Self {
+        HandshakeError::SendError(e)
+    }
+}
+
+impl From<ReceiveError> for HandshakeError {
+    fn from(e: ReceiveError) -> Self {
+        HandshakeError::ReceiveError(e)
+    }
+}
+
+/// Performs the handshake. The goal is to obtain ID of the peer,
+/// and split the communication stream into two halves.
+/// Current version makes an unrealistic assumption that the peer is not malicious.
+/// To be rewritten.
+pub async fn execute_v0_handshake<S: Splittable>(
+    stream: S,
+    authority_pen: AuthorityPen,
+) -> Result<(S::Sender, S::Receiver, AuthorityId), HandshakeError> {
+    let authority_id = authority_pen.authority_id();
+    let (stream, peer_id) = receive_data(send_data(stream, authority_id).await?).await?;
+    let (sender, receiver) = stream.split();
+    Ok((sender, receiver, peer_id))
+}
+
+/// Wrapper that adds timeout to the function performing handshake.
+pub async fn v0_handshake<S: Splittable>(
+    stream: S,
+    authority_pen: AuthorityPen,
+) -> Result<(S::Sender, S::Receiver, AuthorityId), HandshakeError> {
+    timeout(
+        HANDSHAKE_TIMEOUT,
+        execute_v0_handshake(stream, authority_pen),
+    )
+    .await
+    .map_err(|_| HandshakeError::TimedOut)?
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::try_join;
+
+    use super::execute_v0_handshake;
+    use crate::validator_network::mock::{keys, MockSplittable};
+
+    // Only one basic test for now, as the handshake will be rewritten.
+
+    #[tokio::test]
+    async fn dual_handshake() {
+        let (stream_a, stream_b) = MockSplittable::new(4096);
+        let (id_a, pen_a) = keys().await;
+        let (id_b, pen_b) = keys().await;
+        assert_ne!(id_a, id_b);
+        let ((_, _, received_id_b), (_, _, received_id_a)) = try_join!(
+            execute_v0_handshake(stream_a, pen_a),
+            execute_v0_handshake(stream_b, pen_b),
+        )
+        .expect("handshake should work");
+        assert_eq!(id_a, received_id_a);
+        assert_eq!(id_b, received_id_b);
+    }
+}

--- a/finality-aleph/src/validator_network/heartbeat.rs
+++ b/finality-aleph/src/validator_network/heartbeat.rs
@@ -1,0 +1,75 @@
+use codec::{Decode, Encode};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    time::{sleep, timeout, Duration},
+};
+
+use crate::validator_network::io::{receive_data, send_data};
+
+const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_MISSED_HEARTBEATS: u32 = 4;
+
+/// Represents the heartbeat message. Holds a single integer,
+/// which should be interpreted as a message counter.
+#[derive(Debug, Clone, Encode, Decode)]
+struct Heartbeat(u32);
+
+/// Sends heartbeat messages at regular intervals, indefinitely.
+/// Fails if the communication channel is closed.
+pub async fn heartbeat_sender<S: AsyncWrite + Unpin + Send>(mut stream: S) {
+    let mut counter: u32 = 0;
+    loop {
+        stream = match send_data(stream, Heartbeat(counter)).await {
+            Ok(stream) => stream,
+            // If anything at all went wrong, the heartbeat is dead.
+            Err(_) => return,
+        };
+        counter += 1;
+        sleep(HEARTBEAT_TIMEOUT).await;
+    }
+}
+
+/// Receives heartbeat messages indefinitely.
+/// Fails if the communication channel is closed, or if no message is received
+/// for too long.
+pub async fn heartbeat_receiver<S: AsyncRead + Unpin + Send>(mut stream: S) {
+    loop {
+        stream = match timeout(
+            HEARTBEAT_TIMEOUT * MAX_MISSED_HEARTBEATS,
+            receive_data::<S, Heartbeat>(stream),
+        )
+        .await
+        {
+            Ok(Ok((stream, _))) => stream,
+            // If anything at all went wrong the heartbeat is dead.
+            _ => return,
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::{
+        self,
+        time::{timeout, Duration},
+    };
+
+    use super::{heartbeat_receiver, heartbeat_sender};
+    use crate::validator_network::mock::MockSplittable;
+
+    #[tokio::test]
+    async fn sender_closed_on_broken_connection() {
+        let (stream, _) = MockSplittable::new(4096);
+        timeout(Duration::from_secs(10), heartbeat_sender(stream))
+            .await
+            .expect("should end immediately");
+    }
+
+    #[tokio::test]
+    async fn receiver_closed_on_broken_connection() {
+        let (stream, _) = MockSplittable::new(4096);
+        timeout(Duration::from_secs(10), heartbeat_receiver(stream))
+            .await
+            .expect("should end immediately");
+    }
+}

--- a/finality-aleph/src/validator_network/heartbeat.rs
+++ b/finality-aleph/src/validator_network/heartbeat.rs
@@ -17,14 +17,13 @@ struct Heartbeat(u32);
 /// Sends heartbeat messages at regular intervals, indefinitely.
 /// Fails if the communication channel is closed.
 pub async fn heartbeat_sender<S: AsyncWrite + Unpin + Send>(mut stream: S) {
-    let mut counter: u32 = 0;
     loop {
-        stream = match send_data(stream, Heartbeat(counter)).await {
+        // Random number so the message contains something.
+        stream = match send_data(stream, Heartbeat(43)).await {
             Ok(stream) => stream,
             // If anything at all went wrong, the heartbeat is dead.
             Err(_) => return,
         };
-        counter += 1;
         sleep(HEARTBEAT_TIMEOUT).await;
     }
 }

--- a/finality-aleph/src/validator_network/mod.rs
+++ b/finality-aleph/src/validator_network/mod.rs
@@ -5,9 +5,12 @@ use aleph_primitives::AuthorityId;
 use codec::Codec;
 use tokio::io::{AsyncRead, AsyncWrite};
 
+mod handshake;
+mod heartbeat;
 mod io;
 #[cfg(test)]
 mod mock;
+mod protocols;
 
 /// What the data sent using the network has to satisfy.
 pub trait Data: Clone + Codec + Send + Sync + 'static {}

--- a/finality-aleph/src/validator_network/protocols.rs
+++ b/finality-aleph/src/validator_network/protocols.rs
@@ -1,0 +1,519 @@
+use std::fmt::{Display, Error as FmtError, Formatter};
+
+use aleph_primitives::AuthorityId;
+use futures::{
+    channel::{mpsc, oneshot},
+    StreamExt,
+};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::{
+    crypto::AuthorityPen,
+    validator_network::{
+        handshake::{v0_handshake, HandshakeError},
+        heartbeat::{heartbeat_receiver, heartbeat_sender},
+        io::{receive_data, send_data, ReceiveError, SendError},
+        Data, Splittable,
+    },
+};
+
+/// Defines the protocol for communication.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Protocol {
+    /// The current version of the protocol.
+    V0,
+}
+
+/// Protocol error.
+#[derive(Debug)]
+pub enum ProtocolError {
+    /// Error during performing a handshake.
+    HandshakeError(HandshakeError),
+    /// Connected to a peer with unexpected ID.
+    WrongPeer(AuthorityId),
+    /// Sending failed.
+    SendError(SendError),
+    /// Receiving failed.
+    ReceiveError(ReceiveError),
+    /// Heartbeat stopped.
+    CardiacArrest,
+    /// Channel to the parent service closed.
+    NoParentConnection,
+    /// Data channel closed.
+    NoUserConnection,
+}
+
+impl Display for ProtocolError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        use ProtocolError::*;
+        match self {
+            HandshakeError(e) => write!(f, "handshake error: {}", e),
+            WrongPeer(peer_id) => write!(f, "connected to unexpected peer {}", peer_id),
+            SendError(e) => write!(f, "send error: {}", e),
+            ReceiveError(e) => write!(f, "receive error: {}", e),
+            CardiacArrest => write!(f, "heartbeat stopped"),
+            NoParentConnection => write!(f, "cannot send result to service"),
+            NoUserConnection => write!(f, "cannot send data to user"),
+        }
+    }
+}
+
+impl From<HandshakeError> for ProtocolError {
+    fn from(e: HandshakeError) -> Self {
+        ProtocolError::HandshakeError(e)
+    }
+}
+
+impl From<SendError> for ProtocolError {
+    fn from(e: SendError) -> Self {
+        ProtocolError::SendError(e)
+    }
+}
+
+impl From<ReceiveError> for ProtocolError {
+    fn from(e: ReceiveError) -> Self {
+        ProtocolError::ReceiveError(e)
+    }
+}
+
+/// Receives data from the parent service and sends it over the network.
+/// Exits when the parent channel is closed, or if the network connection is broken.
+async fn sending<D: Data, S: AsyncWrite + Unpin + Send>(
+    mut sender: S,
+    mut data_from_user: mpsc::UnboundedReceiver<D>,
+) -> Result<(), ProtocolError> {
+    loop {
+        sender = match data_from_user.next().await {
+            Some(data) => send_data(sender, data).await?,
+            // We have been closed by the parent service, all good.
+            None => return Ok(()),
+        };
+    }
+}
+
+/// Performs the handshake, and then keeps sending data received from the parent service.
+/// Exits on parent request, or in case of broken or dead network connection.
+async fn v0_outgoing<D: Data, S: Splittable>(
+    stream: S,
+    authority_pen: AuthorityPen,
+    peer_id: AuthorityId,
+    data_from_user: mpsc::UnboundedReceiver<D>,
+) -> Result<(), ProtocolError> {
+    let (sender, receiver, other_peer_id) = v0_handshake(stream, authority_pen).await?;
+    if peer_id != other_peer_id {
+        return Err(ProtocolError::WrongPeer(other_peer_id));
+    }
+
+    let sending = sending(sender, data_from_user);
+    let heartbeat = heartbeat_receiver(receiver);
+
+    loop {
+        tokio::select! {
+            _ = heartbeat => return Err(ProtocolError::CardiacArrest),
+            result = sending => return result,
+        }
+    }
+}
+
+/// Receives data from the network and sends it to the parent service.
+/// Exits when the parent channel is closed, or if the network connection is broken.
+async fn receiving<D: Data, S: AsyncRead + Unpin + Send>(
+    mut stream: S,
+    data_for_user: mpsc::UnboundedSender<D>,
+) -> Result<(), ProtocolError> {
+    loop {
+        let (old_stream, data) = receive_data(stream).await?;
+        stream = old_stream;
+        data_for_user
+            .unbounded_send(data)
+            .map_err(|_| ProtocolError::NoUserConnection)?;
+    }
+}
+
+/// Performs the handshake, and then keeps sending data received from the network to the parent service.
+/// Exits on parent request, or in case of broken or dead network connection.
+async fn v0_incoming<D: Data, S: Splittable>(
+    stream: S,
+    authority_pen: AuthorityPen,
+    result_for_parent: mpsc::UnboundedSender<(AuthorityId, oneshot::Sender<()>)>,
+    data_for_user: mpsc::UnboundedSender<D>,
+) -> Result<(), ProtocolError> {
+    let (sender, receiver, peer_id) = v0_handshake(stream, authority_pen).await?;
+
+    let (tx_exit, exit) = oneshot::channel();
+    result_for_parent
+        .unbounded_send((peer_id, tx_exit))
+        .map_err(|_| ProtocolError::NoParentConnection)?;
+
+    let receiving = receiving(receiver, data_for_user);
+    let heartbeat = heartbeat_sender(sender);
+
+    loop {
+        tokio::select! {
+            _ = heartbeat => return Err(ProtocolError::CardiacArrest),
+            result = receiving => return result,
+            _ = exit => return Ok(()),
+        }
+    }
+}
+
+impl Protocol {
+    /// Launches the proper variant of the protocol (receiver half).
+    pub async fn manage_incoming<D: Data, S: Splittable>(
+        &self,
+        stream: S,
+        authority_pen: AuthorityPen,
+        result_for_service: mpsc::UnboundedSender<(AuthorityId, oneshot::Sender<()>)>,
+        data_for_user: mpsc::UnboundedSender<D>,
+    ) -> Result<(), ProtocolError> {
+        use Protocol::*;
+        match self {
+            V0 => v0_incoming(stream, authority_pen, result_for_service, data_for_user).await,
+        }
+    }
+
+    /// Launches the proper variant of the protocol (sender half).
+    pub async fn manage_outgoing<D: Data, S: Splittable>(
+        &self,
+        stream: S,
+        authority_pen: AuthorityPen,
+        peer_id: AuthorityId,
+        data_from_user: mpsc::UnboundedReceiver<D>,
+    ) -> Result<(), ProtocolError> {
+        use Protocol::*;
+        match self {
+            V0 => v0_outgoing(stream, authority_pen, peer_id, data_from_user).await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aleph_primitives::AuthorityId;
+    use futures::{
+        channel::{
+            mpsc,
+            mpsc::{UnboundedReceiver, UnboundedSender},
+            oneshot,
+        },
+        pin_mut, FutureExt, StreamExt,
+    };
+
+    use super::{Protocol, ProtocolError};
+    use crate::{
+        crypto::AuthorityPen,
+        validator_network::{
+            mock::{keys, MockSplittable},
+            Data,
+        },
+    };
+
+    async fn prepare<D: Data>() -> (
+        AuthorityId,
+        AuthorityPen,
+        AuthorityId,
+        AuthorityPen,
+        impl futures::Future<Output = Result<(), ProtocolError>>,
+        impl futures::Future<Output = Result<(), ProtocolError>>,
+        UnboundedReceiver<D>,
+        UnboundedSender<D>,
+        UnboundedReceiver<(AuthorityId, oneshot::Sender<()>)>,
+    ) {
+        let (stream_incoming, stream_outgoing) = MockSplittable::new(4096);
+        let (id_incoming, pen_incoming) = keys().await;
+        let (id_outgoing, pen_outgoing) = keys().await;
+        assert_ne!(id_incoming, id_outgoing);
+        let (result_for_service, result_from_incoming) =
+            mpsc::unbounded::<(AuthorityId, oneshot::Sender<()>)>();
+        let (data_for_user, data_from_incoming) = mpsc::unbounded::<D>();
+        let (data_for_outgoing, data_from_user) = mpsc::unbounded::<D>();
+        let incoming_handle = Protocol::V0.manage_incoming(
+            stream_incoming,
+            pen_incoming.clone(),
+            result_for_service,
+            data_for_user,
+        );
+        let outgoing_handle = Protocol::V0.manage_outgoing(
+            stream_outgoing,
+            pen_outgoing.clone(),
+            id_incoming.clone(),
+            data_from_user,
+        );
+        (
+            id_incoming,
+            pen_incoming,
+            id_outgoing,
+            pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            data_from_incoming,
+            data_for_outgoing,
+            result_from_incoming,
+        )
+    }
+
+    #[tokio::test]
+    async fn send_data() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            mut data_from_incoming,
+            data_for_outgoing,
+            _result_from_incoming,
+        ) = prepare::<Vec<i32>>().await;
+        data_for_outgoing
+            .unbounded_send(vec![4, 3, 43])
+            .expect("should send");
+        data_for_outgoing
+            .unbounded_send(vec![2, 1, 3, 7])
+            .expect("should send");
+        let incoming_handle = incoming_handle.fuse();
+        let outgoing_handle = outgoing_handle.fuse();
+        pin_mut!(incoming_handle);
+        pin_mut!(outgoing_handle);
+        tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            v = data_from_incoming.next() => {
+                assert_eq!(v, Some(vec![4, 3, 43]));
+            },
+        };
+        tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            v = data_from_incoming.next() => {
+                assert_eq!(v, Some(vec![2, 1, 3, 7]));
+            },
+        };
+    }
+
+    #[tokio::test]
+    async fn closed_by_parent_service() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_for_outgoing,
+            mut result_from_incoming,
+        ) = prepare::<Vec<i32>>().await;
+        let incoming_handle = incoming_handle.fuse();
+        let outgoing_handle = outgoing_handle.fuse();
+        pin_mut!(incoming_handle);
+        pin_mut!(outgoing_handle);
+        tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            received = result_from_incoming.next() => {
+                // we drop the exit oneshot channel, thus finishing incoming_handle
+                let (received_id, _) = received.expect("should receive");
+                assert_eq!(received_id, id_outgoing);
+            },
+        };
+        incoming_handle
+            .await
+            .expect("closed manually, should finish with no error");
+    }
+
+    #[tokio::test]
+    async fn parent_service_dead() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_for_outgoing,
+            result_from_incoming,
+        ) = prepare::<Vec<i32>>().await;
+        std::mem::drop(result_from_incoming);
+        let incoming_handle = incoming_handle.fuse();
+        let outgoing_handle = outgoing_handle.fuse();
+        pin_mut!(incoming_handle);
+        pin_mut!(outgoing_handle);
+        tokio::select! {
+            e = &mut incoming_handle => match e {
+                Err(ProtocolError::NoParentConnection) => (),
+                Err(e) => panic!("unexpected error: {}", e),
+                Ok(_) => panic!("successfully finished when parent dead"),
+            },
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+        };
+    }
+
+    #[tokio::test]
+    async fn parent_user_dead() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            data_from_incoming,
+            data_for_outgoing,
+            _result_from_incoming,
+        ) = prepare::<Vec<i32>>().await;
+        std::mem::drop(data_from_incoming);
+        data_for_outgoing
+            .unbounded_send(vec![2, 1, 3, 7])
+            .expect("should send");
+        let incoming_handle = incoming_handle.fuse();
+        let outgoing_handle = outgoing_handle.fuse();
+        pin_mut!(incoming_handle);
+        pin_mut!(outgoing_handle);
+        tokio::select! {
+            e = &mut incoming_handle => match e {
+                Err(ProtocolError::NoUserConnection) => (),
+                Err(e) => panic!("unexpected error: {}", e),
+                Ok(_) => panic!("successfully finished when user dead"),
+            },
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+        };
+    }
+
+    #[tokio::test]
+    async fn sender_dead_before_handshake() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_for_outgoing,
+            _result_from_incoming,
+        ) = prepare::<Vec<i32>>().await;
+        std::mem::drop(outgoing_handle);
+        match incoming_handle.await {
+            Err(ProtocolError::HandshakeError(_)) => (),
+            Err(e) => panic!("unexpected error: {}", e),
+            Ok(_) => panic!("successfully finished when connection dead"),
+        };
+    }
+
+    #[tokio::test]
+    async fn sender_dead_after_handshake() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_for_outgoing,
+            mut result_from_incoming,
+        ) = prepare::<Vec<i32>>().await;
+        let incoming_handle = incoming_handle.fuse();
+        pin_mut!(incoming_handle);
+        let (_, _exit) = tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            out = result_from_incoming.next() => out.expect("should receive"),
+        };
+        // outgoing_handle got consumed by tokio::select!, the sender is dead
+        match incoming_handle.await {
+            Err(ProtocolError::ReceiveError(_)) => (),
+            Err(e) => panic!("unexpected error: {}", e),
+            Ok(_) => panic!("successfully finished when connection dead"),
+        };
+    }
+
+    #[tokio::test]
+    async fn receiver_dead_before_handshake() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_for_outgoing,
+            _result_from_incoming,
+        ) = prepare::<Vec<i32>>().await;
+        std::mem::drop(incoming_handle);
+        match outgoing_handle.await {
+            Err(ProtocolError::HandshakeError(_)) => (),
+            Err(e) => panic!("unexpected error: {}", e),
+            Ok(_) => panic!("successfully finished when connection dead"),
+        };
+    }
+
+    #[tokio::test]
+    async fn receiver_dead_after_handshake() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_for_outgoing,
+            mut result_from_incoming,
+        ) = prepare::<Vec<i32>>().await;
+        let outgoing_handle = outgoing_handle.fuse();
+        pin_mut!(outgoing_handle);
+        let (_, _exit) = tokio::select! {
+            _ = incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            out = result_from_incoming.next() => out.expect("should receive"),
+        };
+        // incoming_handle got consumed by tokio::select!, the receiver is dead
+        match outgoing_handle.await {
+            // We never get the SendError variant here, because we did not send anything
+            // through data_for_outgoing.
+            Err(ProtocolError::CardiacArrest) => (),
+            Err(e) => panic!("unexpected error: {}", e),
+            Ok(_) => panic!("successfully finished when connection dead"),
+        };
+    }
+
+    #[tokio::test]
+    async fn receiver_dead_after_handshake_try_send_error() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            data_for_outgoing,
+            mut result_from_incoming,
+        ) = prepare::<Vec<i32>>().await;
+        let outgoing_handle = outgoing_handle.fuse();
+        pin_mut!(outgoing_handle);
+        let (_, _exit) = tokio::select! {
+            _ = incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            out = result_from_incoming.next() => out.expect("should receive"),
+        };
+        // incoming_handle got consumed by tokio::select!, the receiver is dead
+        data_for_outgoing
+            .unbounded_send(vec![2, 1, 3, 7])
+            .expect("should send");
+        // The kind of error we get depends on which branch of tokio::select! in
+        // the main loop of v0_outgoing is chosen, and since it happens randomly,
+        // we cannot exclude the CardiacArrest variant. Therefore, we accept both
+        // possible results. These tests will be improved in the future.
+        match outgoing_handle.await {
+            Err(ProtocolError::SendError(_)) => (),
+            Err(ProtocolError::CardiacArrest) => (),
+            Err(e) => panic!("unexpected error: {}", e),
+            Ok(_) => panic!("successfully finished when connection dead"),
+        };
+    }
+}


### PR DESCRIPTION
Note that the handshake is essentially a mock, there is a separate task for implementing it.

# Description

Add protocols for communication within the validator network, including a rudimentary handshake and a way to check the network stays alive.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have added tests
- I have made corresponding changes to the existing documentation
- I have created new documentation
