### PR TITLE
A0-1408: Protocol negotiation and connection handling

### DIFF
--- a/finality-aleph/src/validator_network/incoming.rs
+++ b/finality-aleph/src/validator_network/incoming.rs
@@ -1,0 +1,71 @@
+use std::fmt::{Display, Error as FmtError, Formatter};
+
+use aleph_primitives::AuthorityId;
+use futures::channel::{mpsc, oneshot};
+use log::{debug, info};
+
+use crate::{
+    crypto::AuthorityPen,
+    validator_network::{
+        protocol_negotiation::{protocol, ProtocolNegotiationError},
+        protocols::ProtocolError,
+        Data, Splittable,
+    },
+};
+
+enum IncomingError {
+    ProtocolNegotiationError(ProtocolNegotiationError),
+    ProtocolError(ProtocolError),
+}
+
+impl Display for IncomingError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        use IncomingError::*;
+        match self {
+            ProtocolNegotiationError(e) => write!(f, "protocol negotiation error: {}", e),
+            ProtocolError(e) => write!(f, "protocol error: {}", e),
+        }
+    }
+}
+
+impl From<ProtocolNegotiationError> for IncomingError {
+    fn from(e: ProtocolNegotiationError) -> Self {
+        IncomingError::ProtocolNegotiationError(e)
+    }
+}
+
+impl From<ProtocolError> for IncomingError {
+    fn from(e: ProtocolError) -> Self {
+        IncomingError::ProtocolError(e)
+    }
+}
+
+async fn manage_incoming<D: Data, S: Splittable>(
+    authority_pen: AuthorityPen,
+    stream: S,
+    result_for_parent: mpsc::UnboundedSender<(AuthorityId, oneshot::Sender<()>)>,
+    data_for_user: mpsc::UnboundedSender<D>,
+) -> Result<(), IncomingError> {
+    debug!(target: "validator-network", "Performing incoming protocol negotiation.");
+    let (stream, protocol) = protocol(stream).await?;
+    debug!(target: "validator-network", "Negotiated protocol, running.");
+    Ok(protocol
+        .manage_incoming(stream, authority_pen, result_for_parent, data_for_user)
+        .await?)
+}
+
+/// Manage an incoming connection. After the handshake it will send the recognized AuthorityId to
+/// the parent, together with an exit channel for this process. When this channel is dropped the
+/// process ends. Whenever data arrives on this connection it will be passed to the user. Any
+/// failures in receiving data result in the process stopping, we assume the other side will
+/// reestablish it if necessary.
+pub async fn incoming<D: Data, S: Splittable>(
+    authority_pen: AuthorityPen,
+    stream: S,
+    result_for_parent: mpsc::UnboundedSender<(AuthorityId, oneshot::Sender<()>)>,
+    data_for_user: mpsc::UnboundedSender<D>,
+) {
+    if let Err(e) = manage_incoming(authority_pen, stream, result_for_parent, data_for_user).await {
+        info!(target: "validator-network", "Incoming connection failed: {}", e);
+    }
+}

--- a/finality-aleph/src/validator_network/mod.rs
+++ b/finality-aleph/src/validator_network/mod.rs
@@ -7,9 +7,12 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 mod handshake;
 mod heartbeat;
+mod incoming;
 mod io;
 #[cfg(test)]
 mod mock;
+mod outgoing;
+mod protocol_negotiation;
 mod protocols;
 
 /// What the data sent using the network has to satisfy.

--- a/finality-aleph/src/validator_network/outgoing.rs
+++ b/finality-aleph/src/validator_network/outgoing.rs
@@ -1,0 +1,90 @@
+use std::fmt::{Display, Error as FmtError, Formatter};
+
+use aleph_primitives::AuthorityId;
+use futures::channel::mpsc;
+use log::{debug, info};
+
+use crate::{
+    crypto::AuthorityPen,
+    validator_network::{
+        protocol_negotiation::{protocol, ProtocolNegotiationError},
+        protocols::ProtocolError,
+        Data, Dialer,
+    },
+};
+
+enum OutgoingError<A: Data, ND: Dialer<A>> {
+    Dial(ND::Error),
+    ProtocolNegotiation(ProtocolNegotiationError),
+    Protocol(ProtocolError),
+}
+
+impl<A: Data, ND: Dialer<A>> Display for OutgoingError<A, ND> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        use OutgoingError::*;
+        match self {
+            Dial(e) => write!(f, "dial error: {}", e),
+            ProtocolNegotiation(e) => write!(f, "protocol negotiation error: {}", e),
+            Protocol(e) => write!(f, "protocol error: {}", e),
+        }
+    }
+}
+
+impl<A: Data, ND: Dialer<A>> From<ProtocolNegotiationError> for OutgoingError<A, ND> {
+    fn from(e: ProtocolNegotiationError) -> Self {
+        OutgoingError::ProtocolNegotiation(e)
+    }
+}
+
+impl<A: Data, ND: Dialer<A>> From<ProtocolError> for OutgoingError<A, ND> {
+    fn from(e: ProtocolError) -> Self {
+        OutgoingError::Protocol(e)
+    }
+}
+
+async fn manage_outgoing<D: Data, A: Data, ND: Dialer<A>>(
+    authority_pen: AuthorityPen,
+    peer_id: AuthorityId,
+    mut dialer: ND,
+    addresses: Vec<A>,
+    data_from_user: mpsc::UnboundedReceiver<D>,
+) -> Result<(), OutgoingError<A, ND>> {
+    debug!(target: "validator-network", "Trying to connect to {}.", peer_id);
+    let stream = dialer
+        .connect(addresses)
+        .await
+        .map_err(OutgoingError::Dial)?;
+    debug!(target: "validator-network", "Performing outgoing protocol negotiation.");
+    let (stream, protocol) = protocol(stream).await?;
+    debug!(target: "validator-network", "Negotiated protocol, running.");
+    Ok(protocol
+        .manage_outgoing(stream, authority_pen, peer_id, data_from_user)
+        .await?)
+}
+
+/// Establish an outgoing connection to the provided peer using the dialer and then manage it.
+/// While this works it will send any data from the user to the peer. Any failures will be reported
+/// to the parent, so that connections can be reestablished if necessary.
+pub async fn outgoing<D: Data, A: Data, ND: Dialer<A>>(
+    authority_pen: AuthorityPen,
+    peer_id: AuthorityId,
+    dialer: ND,
+    addresses: Vec<A>,
+    data_from_user: mpsc::UnboundedReceiver<D>,
+    failure_for_parent: mpsc::UnboundedSender<AuthorityId>,
+) {
+    if let Err(e) = manage_outgoing(
+        authority_pen,
+        peer_id.clone(),
+        dialer,
+        addresses,
+        data_from_user,
+    )
+    .await
+    {
+        info!(target: "validator-network", "Outgoing connection to {} failed: {}.", peer_id, e);
+    }
+    if failure_for_parent.unbounded_send(peer_id).is_err() {
+        debug!(target: "validator-network", "Could not send the closing message, we've probably been terminated by the parent service.");
+    }
+}

--- a/finality-aleph/src/validator_network/protocol_negotiation.rs
+++ b/finality-aleph/src/validator_network/protocol_negotiation.rs
@@ -1,0 +1,267 @@
+use std::{
+    cmp::{max, min},
+    fmt::{Display, Error as FmtError, Formatter},
+};
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    time::{timeout, Duration},
+};
+
+use crate::validator_network::protocols::Protocol;
+
+pub type ProtocolVersion = u32;
+
+const MIN_SUPPORTED_PROTOCOL: ProtocolVersion = 0;
+const MAX_SUPPORTED_PROTOCOL: ProtocolVersion = 0;
+const PROTOCOL_NEGOTIATION_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A range of supported protocols, will fail to decode if the range is empty.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProtocolsRange(ProtocolVersion, ProtocolVersion);
+
+impl Display for ProtocolsRange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        write!(f, "[{},{}]", self.0, self.1)
+    }
+}
+
+const fn supported_protocol_range() -> ProtocolsRange {
+    ProtocolsRange(MIN_SUPPORTED_PROTOCOL, MAX_SUPPORTED_PROTOCOL)
+}
+
+/// What went wrong when negotiating a protocol.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ProtocolNegotiationError {
+    ConnectionClosed,
+    InvalidRange(ProtocolsRange),
+    ProtocolMismatch(ProtocolsRange, ProtocolsRange),
+    BadChoice(ProtocolVersion),
+    TimedOut,
+}
+
+impl Display for ProtocolNegotiationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        use ProtocolNegotiationError::*;
+        match self {
+            ConnectionClosed => write!(f, "connection closed"),
+            InvalidRange(range) => write!(f, "invalid range: {}", range),
+            ProtocolMismatch(our_range, their_range) => write!(
+                f,
+                "failed negotiation with range {}, their {}",
+                our_range, their_range
+            ),
+            BadChoice(version) => write!(
+                f,
+                "negotiated protocol version {}, which we don't know, this is a severe bug",
+                version
+            ),
+            TimedOut => write!(f, "timed out"),
+        }
+    }
+}
+
+impl ProtocolsRange {
+    fn valid(&self) -> bool {
+        self.0 <= self.1
+    }
+
+    fn encode(&self) -> [u8; 8] {
+        let mut result = self.0.to_le_bytes().to_vec();
+        result.append(&mut self.1.to_le_bytes().to_vec());
+        result.try_into().expect("this is literally 8 bytes")
+    }
+
+    fn decode(encoded: &[u8; 8]) -> Result<Self, ProtocolNegotiationError> {
+        let result = ProtocolsRange(
+            ProtocolVersion::from_le_bytes(
+                encoded[0..4].try_into().expect("this is literally 4 bytes"),
+            ),
+            ProtocolVersion::from_le_bytes(
+                encoded[4..8].try_into().expect("this is literally 4 bytes"),
+            ),
+        );
+        match result.valid() {
+            true => Ok(result),
+            false => Err(ProtocolNegotiationError::InvalidRange(result)),
+        }
+    }
+}
+
+fn intersection(
+    range1: ProtocolsRange,
+    range2: ProtocolsRange,
+) -> Result<ProtocolsRange, ProtocolNegotiationError> {
+    let intersection = ProtocolsRange(max(range1.0, range2.0), min(range1.1, range2.1));
+    match intersection.valid() {
+        true => Ok(intersection),
+        false => Err(ProtocolNegotiationError::ProtocolMismatch(range1, range2)),
+    }
+}
+
+fn maximum_of_intersection(
+    range1: ProtocolsRange,
+    range2: ProtocolsRange,
+) -> Result<Protocol, ProtocolNegotiationError> {
+    intersection(range1, range2).map(|intersection| match intersection.1 {
+        0 => Ok(Protocol::V0),
+        unknown_version => Err(ProtocolNegotiationError::BadChoice(unknown_version)),
+    })?
+}
+
+async fn negotiate_protocol_version<S: AsyncReadExt + AsyncWriteExt + Unpin>(
+    mut stream: S,
+    our_protocol_range: ProtocolsRange,
+) -> Result<(S, Protocol), ProtocolNegotiationError> {
+    stream
+        .write_all(&our_protocol_range.encode())
+        .await
+        .map_err(|_| ProtocolNegotiationError::ConnectionClosed)?;
+    let mut buf = [0; 8];
+    stream
+        .read_exact(&mut buf)
+        .await
+        .map_err(|_| ProtocolNegotiationError::ConnectionClosed)?;
+    let their_protocol_range = ProtocolsRange::decode(&buf)?;
+    Ok((
+        stream,
+        maximum_of_intersection(our_protocol_range, their_protocol_range)?,
+    ))
+}
+
+/// Negotiate a protocol version to use.
+pub async fn protocol<S: AsyncReadExt + AsyncWriteExt + Unpin>(
+    stream: S,
+) -> Result<(S, Protocol), ProtocolNegotiationError> {
+    timeout(
+        PROTOCOL_NEGOTIATION_TIMEOUT,
+        negotiate_protocol_version(stream, supported_protocol_range()),
+    )
+    .await
+    .map_err(|_| ProtocolNegotiationError::TimedOut)?
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::{pin_mut, FutureExt};
+    use tokio::io::duplex;
+
+    use super::{negotiate_protocol_version, supported_protocol_range, ProtocolNegotiationError};
+    use crate::validator_network::protocols::Protocol;
+
+    fn correct_negotiation<S>(result: Result<(S, Protocol), ProtocolNegotiationError>) {
+        match result {
+            Ok((_stream, protocol)) => assert_eq!(Protocol::V0, protocol),
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
+    }
+
+    fn incorrect_negotiation<S>(
+        result: Result<(S, Protocol), ProtocolNegotiationError>,
+        expected_error: ProtocolNegotiationError,
+    ) {
+        match result {
+            Ok((_stream, protocol)) => {
+                panic!("Unexpectedly managed to negotiate protocol {:?}", protocol)
+            }
+            Err(e) => assert_eq!(expected_error, e),
+        }
+    }
+
+    #[tokio::test]
+    async fn negotiates_when_both_agree_exactly() {
+        let (stream1, stream2) = duplex(4096);
+        let negotiation1 = negotiate_protocol_version(stream1, supported_protocol_range()).fuse();
+        pin_mut!(negotiation1);
+        let negotiation2 = negotiate_protocol_version(stream2, supported_protocol_range()).fuse();
+        pin_mut!(negotiation2);
+        for _ in 0..2 {
+            tokio::select! {
+                result = &mut negotiation1 => correct_negotiation(result),
+                result = &mut negotiation2 => correct_negotiation(result),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn negotiates_when_one_broader() {
+        let (stream1, stream2) = duplex(4096);
+        let mut broader_protocol_range = supported_protocol_range();
+        broader_protocol_range.1 += 1;
+        let negotiation1 = negotiate_protocol_version(stream1, supported_protocol_range()).fuse();
+        pin_mut!(negotiation1);
+        let negotiation2 = negotiate_protocol_version(stream2, broader_protocol_range).fuse();
+        pin_mut!(negotiation2);
+        for _ in 0..2 {
+            tokio::select! {
+                result = &mut negotiation1 => correct_negotiation(result),
+                result = &mut negotiation2 => correct_negotiation(result),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn fails_when_no_intersection() {
+        let (stream1, stream2) = duplex(4096);
+        let mut too_high_protocol_range = supported_protocol_range();
+        too_high_protocol_range.0 = too_high_protocol_range.1 + 1;
+        too_high_protocol_range.1 = too_high_protocol_range.0 + 1;
+        let negotiation1 = negotiate_protocol_version(stream1, supported_protocol_range()).fuse();
+        pin_mut!(negotiation1);
+        let negotiation2 =
+            negotiate_protocol_version(stream2, too_high_protocol_range.clone()).fuse();
+        pin_mut!(negotiation2);
+        for _ in 0..2 {
+            tokio::select! {
+                result = &mut negotiation1 => incorrect_negotiation(result, ProtocolNegotiationError::ProtocolMismatch(supported_protocol_range(), too_high_protocol_range.clone())),
+                result = &mut negotiation2 => incorrect_negotiation(result, ProtocolNegotiationError::ProtocolMismatch(too_high_protocol_range.clone(), supported_protocol_range())),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn fails_when_bad_negotiation() {
+        let (stream1, stream2) = duplex(4096);
+        let mut too_high_protocol_range = supported_protocol_range();
+        too_high_protocol_range.0 = too_high_protocol_range.1 + 1;
+        too_high_protocol_range.1 = too_high_protocol_range.0 + 1;
+        let negotiation1 =
+            negotiate_protocol_version(stream1, too_high_protocol_range.clone()).fuse();
+        pin_mut!(negotiation1);
+        let negotiation2 =
+            negotiate_protocol_version(stream2, too_high_protocol_range.clone()).fuse();
+        pin_mut!(negotiation2);
+        for _ in 0..2 {
+            tokio::select! {
+                result = &mut negotiation1 => incorrect_negotiation(result, ProtocolNegotiationError::BadChoice(too_high_protocol_range.1)),
+                result = &mut negotiation2 => incorrect_negotiation(result, ProtocolNegotiationError::BadChoice(too_high_protocol_range.1)),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn fails_when_invalid_range() {
+        let (stream1, stream2) = duplex(4096);
+        let mut invalid_range = supported_protocol_range();
+        invalid_range.0 = invalid_range.1 + 1;
+        let negotiation1 = negotiate_protocol_version(stream1, invalid_range.clone()).fuse();
+        pin_mut!(negotiation1);
+        let negotiation2 = negotiate_protocol_version(stream2, invalid_range.clone()).fuse();
+        pin_mut!(negotiation2);
+        for _ in 0..2 {
+            tokio::select! {
+                result = &mut negotiation1 => incorrect_negotiation(result, ProtocolNegotiationError::InvalidRange(invalid_range.clone())),
+                result = &mut negotiation2 => incorrect_negotiation(result, ProtocolNegotiationError::InvalidRange(invalid_range.clone())),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn fails_when_connection_droped() {
+        let (stream, _) = duplex(4096);
+        incorrect_negotiation(
+            negotiate_protocol_version(stream, supported_protocol_range()).await,
+            ProtocolNegotiationError::ConnectionClosed,
+        );
+    }
+}


### PR DESCRIPTION
# Description

PR 3/5 for the new validator network. This one adds protocol negotiation and full connection handling once the connections have been established as streams.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have added tests
- I have made corresponding changes to the existing documentation
- I have created new documentation
