### PR TITLE
PeerId is no longer Copy

### DIFF
--- a/finality-aleph/src/network/manager/connections.rs
+++ b/finality-aleph/src/network/manager/connections.rs
@@ -21,7 +21,7 @@ impl<PID: PeerId> Connections<PID> {
     pub fn add_peers(&mut self, session_id: SessionId, peers: impl IntoIterator<Item = PID>) {
         for peer in peers {
             self.associated_sessions
-                .entry(peer)
+                .entry(peer.clone())
                 .or_default()
                 .insert(session_id);
             self.peers_by_session

--- a/finality-aleph/src/network/manager/service.rs
+++ b/finality-aleph/src/network/manager/service.rs
@@ -225,7 +225,7 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
         debug!(target: "aleph-network", "Got addresses:\n{:?}\n and peer_id:{:?}", addresses, peer_id);
         addresses
             .into_iter()
-            .filter_map(|address| address.add_matching_peer_id(peer_id))
+            .filter_map(|address| address.add_matching_peer_id(peer_id.clone()))
             .collect()
     }
 

--- a/finality-aleph/src/network/manager/session.rs
+++ b/finality-aleph/src/network/manager/session.rs
@@ -214,14 +214,15 @@ impl<M: Multiaddress> Handler<M> {
             }
             return false;
         }
-        self.peers_by_node.insert(auth_data.node_id, peer_id);
+        self.peers_by_node
+            .insert(auth_data.node_id, peer_id.clone());
         self.authentications.insert(peer_id, (authentication, None));
         true
     }
 
     /// Returns the PeerId of the node with the given NodeIndex, if known.
     pub fn peer_id(&self, node_id: &NodeIndex) -> Option<M::PeerId> {
-        self.peers_by_node.get(node_id).copied()
+        self.peers_by_node.get(node_id).cloned()
     }
 
     /// Returns maping from NodeIndex to PeerId

--- a/finality-aleph/src/network/mod.rs
+++ b/finality-aleph/src/network/mod.rs
@@ -38,7 +38,7 @@ pub mod testing {
 }
 
 /// Represents the id of an arbitrary node.
-pub trait PeerId: PartialEq + Eq + Copy + Clone + Debug + Display + Hash + Codec + Send {}
+pub trait PeerId: PartialEq + Eq + Clone + Debug + Display + Hash + Codec + Send {}
 
 /// Represents the address of an arbitrary node.
 pub trait Multiaddress: Debug + Hash + Codec + Clone + Eq {

--- a/finality-aleph/src/network/service.rs
+++ b/finality-aleph/src/network/service.rs
@@ -113,7 +113,7 @@ impl<N: Network, D: Data> Service<N, D> {
                     let sender = if let Some(sender) = senders.get(&protocol) {
                         sender
                     } else {
-                        match network.sender(peer_id, protocol) {
+                        match network.sender(peer_id.clone(), protocol) {
                             Ok(sender) => senders.entry(protocol).or_insert(sender),
                             Err(e) => {
                                 debug!(target: "aleph-network", "Failed creating sender. Dropping message: {}", e);
@@ -161,7 +161,7 @@ impl<N: Network, D: Data> Service<N, D> {
         for peer in self.generic_connected_peers.clone() {
             // We only broadcast authentication information in this sense, so we use the generic
             // Protocol.
-            if let Err(e) = self.send_to_peer(data.clone(), peer, Protocol::Generic) {
+            if let Err(e) = self.send_to_peer(data.clone(), peer.clone(), Protocol::Generic) {
                 trace!(target: "aleph-network", "Failed to send broadcast to peer{:?}, {:?}", peer, e);
             }
         }
@@ -188,14 +188,14 @@ impl<N: Network, D: Data> Service<N, D> {
                 let rx = match &protocol {
                     Protocol::Generic => {
                         let (tx, rx) = tracing_unbounded("mpsc_notification_stream_generic");
-                        self.generic_connected_peers.insert(peer);
-                        self.generic_peer_senders.insert(peer, tx);
+                        self.generic_connected_peers.insert(peer.clone());
+                        self.generic_peer_senders.insert(peer.clone(), tx);
                         rx
                     }
                     Protocol::Validator => {
                         let (tx, rx) = tracing_unbounded("mpsc_notification_stream_validator");
-                        self.validator_connected_peers.insert(peer);
-                        self.validator_peer_senders.insert(peer, tx);
+                        self.validator_connected_peers.insert(peer.clone());
+                        self.validator_peer_senders.insert(peer.clone(), tx);
                         rx
                     }
                 };
@@ -245,7 +245,7 @@ impl<N: Network, D: Data> Service<N, D> {
         match command {
             Broadcast => self.broadcast(data),
             SendTo(peer, protocol) => {
-                if let Err(e) = self.send_to_peer(data, peer, protocol) {
+                if let Err(e) = self.send_to_peer(data, peer.clone(), protocol) {
                     trace!(target: "aleph-network", "Failed to send data to peer{:?} via protocol {:?}, {:?}", peer, protocol, e);
                 }
             }


### PR DESCRIPTION
# Description

Remove the requirement that `PeerId` is `Copy`. It's not strictly needed and we will soon be using ones that are not.

## Type of change

????

# Checklist:

?!?
