### PR TITLE
A0-1410: add mock implementation of validator network

### DIFF
--- a/finality-aleph/src/network/mock.rs
+++ b/finality-aleph/src/network/mock.rs
@@ -107,12 +107,12 @@ pub struct Channel<T>(
 );
 
 impl<T> Channel<T> {
-    fn new() -> Self {
+    pub fn new() -> Self {
         let (tx, rx) = mpsc::unbounded();
         Channel(tx, Arc::new(tokio::sync::Mutex::new(rx)))
     }
 
-    fn send(&self, msg: T) {
+    pub fn send(&self, msg: T) {
         self.0.unbounded_send(msg).unwrap();
     }
 
@@ -124,7 +124,7 @@ impl<T> Channel<T> {
         self.1.lock().await.try_next().unwrap_or(None)
     }
 
-    async fn close(self) -> Option<T> {
+    pub async fn close(self) -> Option<T> {
         self.0.close_channel();
         self.try_next().await
     }

--- a/finality-aleph/src/testing/mocks/mod.rs
+++ b/finality-aleph/src/testing/mocks/mod.rs
@@ -21,3 +21,4 @@ mod justification_handler_config;
 mod proposal;
 mod session_info;
 mod single_action_mock;
+mod validator_network;

--- a/finality-aleph/src/testing/mocks/validator_network.rs
+++ b/finality-aleph/src/testing/mocks/validator_network.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use std::sync::Arc;
 
 use aleph_primitives::{AuthorityId, KEY_TYPE};
@@ -68,7 +67,7 @@ impl<D: Data> NetworkIdentity for MockNetwork<D> {
 }
 
 impl<D: Data> MockNetwork<D> {
-    pub async fn new(address: &str) -> Self {
+    pub async fn _new(address: &str) -> Self {
         let key_store = Arc::new(KeyStore::new());
         let id: AuthorityId = key_store
             .ed25519_generate_new(KEY_TYPE, None)
@@ -87,7 +86,7 @@ impl<D: Data> MockNetwork<D> {
     }
 
     // Consumes the network asserting there are no unreceived messages in the channels.
-    pub async fn close_channels(self) {
+    pub async fn _close_channels(self) {
         assert!(self.add_connection.close().await.is_none());
         assert!(self.remove_connection.close().await.is_none());
         assert!(self.send.close().await.is_none());

--- a/finality-aleph/src/testing/mocks/validator_network.rs
+++ b/finality-aleph/src/testing/mocks/validator_network.rs
@@ -8,9 +8,7 @@ use crate::{
     validator_network::Network,
 };
 
-type MockPeerId = AuthorityId;
-
-impl PeerId for MockPeerId {}
+impl PeerId for AuthorityId {}
 
 type MockMultiaddress = (AuthorityId, String);
 
@@ -30,25 +28,25 @@ impl Multiaddress for MockMultiaddress {
 }
 
 pub struct MockNetwork<D: Data> {
-    pub add_connection: Channel<(MockPeerId, Vec<MockMultiaddress>)>,
-    pub remove_connection: Channel<MockPeerId>,
-    pub send: Channel<(D, MockPeerId)>,
+    pub add_connection: Channel<(AuthorityId, Vec<MockMultiaddress>)>,
+    pub remove_connection: Channel<AuthorityId>,
+    pub send: Channel<(D, AuthorityId)>,
     pub next: Channel<D>,
-    id: MockPeerId,
+    id: AuthorityId,
     addresses: Vec<MockMultiaddress>,
 }
 
 #[async_trait::async_trait]
 impl<D: Data> Network<MockMultiaddress, D> for MockNetwork<D> {
-    fn add_connection(&mut self, peer: MockPeerId, addresses: Vec<MockMultiaddress>) {
+    fn add_connection(&mut self, peer: AuthorityId, addresses: Vec<MockMultiaddress>) {
         self.add_connection.send((peer, addresses));
     }
 
-    fn remove_connection(&mut self, peer: MockPeerId) {
+    fn remove_connection(&mut self, peer: AuthorityId) {
         self.remove_connection.send(peer);
     }
 
-    fn send(&self, data: D, recipient: MockPeerId) {
+    fn send(&self, data: D, recipient: AuthorityId) {
         self.send.send((data, recipient));
     }
 
@@ -58,7 +56,7 @@ impl<D: Data> Network<MockMultiaddress, D> for MockNetwork<D> {
 }
 
 impl<D: Data> NetworkIdentity for MockNetwork<D> {
-    type PeerId = MockPeerId;
+    type PeerId = AuthorityId;
     type Multiaddress = MockMultiaddress;
 
     fn identity(&self) -> (Vec<Self::Multiaddress>, Self::PeerId) {

--- a/finality-aleph/src/testing/mocks/validator_network.rs
+++ b/finality-aleph/src/testing/mocks/validator_network.rs
@@ -1,0 +1,96 @@
+#![allow(dead_code)]
+use std::sync::Arc;
+
+use aleph_primitives::{AuthorityId, KEY_TYPE};
+use sp_keystore::{testing::KeyStore, CryptoStore};
+
+use crate::{
+    network::{mock::Channel, Data, Multiaddress, NetworkIdentity, PeerId},
+    validator_network::Network,
+};
+
+type MockPeerId = AuthorityId;
+
+impl PeerId for MockPeerId {}
+
+type MockMultiaddress = (AuthorityId, String);
+
+impl Multiaddress for MockMultiaddress {
+    type PeerId = AuthorityId;
+
+    fn get_peer_id(&self) -> Option<Self::PeerId> {
+        Some(self.0.clone())
+    }
+
+    fn add_matching_peer_id(self, peer_id: Self::PeerId) -> Option<Self> {
+        match self.0 == peer_id {
+            true => Some(self),
+            false => None,
+        }
+    }
+}
+
+pub struct MockNetwork<D: Data> {
+    pub add_connection: Channel<(MockPeerId, Vec<MockMultiaddress>)>,
+    pub remove_connection: Channel<MockPeerId>,
+    pub send: Channel<(D, MockPeerId)>,
+    pub next: Channel<D>,
+    id: MockPeerId,
+    addresses: Vec<MockMultiaddress>,
+}
+
+#[async_trait::async_trait]
+impl<D: Data> Network<MockMultiaddress, D> for MockNetwork<D> {
+    fn add_connection(&mut self, peer: MockPeerId, addresses: Vec<MockMultiaddress>) {
+        self.add_connection.send((peer, addresses));
+    }
+
+    fn remove_connection(&mut self, peer: MockPeerId) {
+        self.remove_connection.send(peer);
+    }
+
+    fn send(&self, data: D, recipient: MockPeerId) {
+        self.send.send((data, recipient));
+    }
+
+    async fn next(&mut self) -> Option<D> {
+        self.next.next().await
+    }
+}
+
+impl<D: Data> NetworkIdentity for MockNetwork<D> {
+    type PeerId = MockPeerId;
+    type Multiaddress = MockMultiaddress;
+
+    fn identity(&self) -> (Vec<Self::Multiaddress>, Self::PeerId) {
+        (self.addresses.clone(), self.id.clone())
+    }
+}
+
+impl<D: Data> MockNetwork<D> {
+    pub async fn new(address: &str) -> Self {
+        let key_store = Arc::new(KeyStore::new());
+        let id: AuthorityId = key_store
+            .ed25519_generate_new(KEY_TYPE, None)
+            .await
+            .unwrap()
+            .into();
+        let addresses = vec![(id.clone(), String::from(address))];
+        MockNetwork {
+            add_connection: Channel::new(),
+            remove_connection: Channel::new(),
+            send: Channel::new(),
+            next: Channel::new(),
+            addresses,
+            id,
+        }
+    }
+
+    // Consumes the network asserting there are no unreceived messages in the channels.
+    pub async fn close_channels(self) {
+        assert!(self.add_connection.close().await.is_none());
+        assert!(self.remove_connection.close().await.is_none());
+        assert!(self.send.close().await.is_none());
+        assert!(self.next.close().await.is_none());
+    }
+}


### PR DESCRIPTION
# Description
This PR introduces mock implementation of validator network. This is the first PR in series of integrating validator network with aleph node.

## Type of change

- Mock implementation