### PR TITLE
A0 1410 integrate validator network pretty

### DIFF
--- a/finality-aleph/src/network/io.rs
+++ b/finality-aleph/src/network/io.rs
@@ -1,0 +1,34 @@
+use futures::channel::mpsc;
+
+use crate::network::{ConnectionManagerIO, Data, Multiaddress, NetworkServiceIO, SessionManagerIO};
+
+pub fn setup<D: Data, M: Multiaddress>() -> (
+    ConnectionManagerIO<D, M>,
+    NetworkServiceIO<D, M>,
+    SessionManagerIO<D>,
+) {
+    // Prepare and start the network
+    let (commands_for_network, commands_from_io) = mpsc::unbounded();
+    let (messages_for_network, messages_from_user) = mpsc::unbounded();
+    let (commands_for_service, commands_from_user) = mpsc::unbounded();
+    let (messages_for_service, commands_from_manager) = mpsc::unbounded();
+    let (messages_for_user, messages_from_network) = mpsc::unbounded();
+
+    let connection_io = ConnectionManagerIO::new(
+        commands_for_network,
+        messages_for_network,
+        commands_from_user,
+        commands_from_manager,
+        messages_from_network,
+    );
+    let channels_for_network =
+        NetworkServiceIO::new(messages_from_user, messages_for_user, commands_from_io);
+    let channels_for_session_manager =
+        SessionManagerIO::new(commands_for_service, messages_for_service);
+
+    (
+        connection_io,
+        channels_for_network,
+        channels_for_session_manager,
+    )
+}

--- a/finality-aleph/src/network/manager/compatibility.rs
+++ b/finality-aleph/src/network/manager/compatibility.rs
@@ -1,0 +1,136 @@
+use std::{
+    fmt::{Display, Error as FmtError, Formatter},
+    mem::size_of,
+};
+
+use codec::{Decode, DecodeAll, Encode, Error as CodecError, Input as CodecInput};
+
+use crate::network::{
+    manager::{DiscoveryMessage, NetworkData},
+    Data, Multiaddress,
+};
+
+type Version = u16;
+type ByteCount = u32;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VersionedNetworkData<D: Data, M: Multiaddress, LM: Multiaddress> {
+    // Most likely from the future.
+    Other(Version, Vec<u8>),
+    Legacy(NetworkData<D, LM>),
+    V1(DiscoveryMessage<M>),
+}
+
+fn encode_with_version(version: Version, mut payload: Vec<u8>) -> Vec<u8> {
+    let mut result = version.encode();
+    // This will produce rubbish if we ever try encodings that have more than u32::MAX bytes.
+    let num_bytes = payload.len() as ByteCount;
+    result.append(&mut num_bytes.encode());
+    result.append(&mut payload);
+    result
+}
+
+impl<D: Data, M: Multiaddress, LM: Multiaddress> Encode for VersionedNetworkData<D, M, LM> {
+    fn size_hint(&self) -> usize {
+        use VersionedNetworkData::*;
+        let version_size = size_of::<Version>();
+        let byte_count_size = size_of::<ByteCount>();
+        version_size
+            + byte_count_size
+            + match self {
+                Other(_, payload) => payload.len(),
+                Legacy(data) => data.size_hint(),
+                V1(data) => data.size_hint(),
+            }
+    }
+
+    fn encode(&self) -> Vec<u8> {
+        use VersionedNetworkData::*;
+        match self {
+            Other(version, payload) => encode_with_version(*version, payload.clone()),
+            Legacy(data) => data.encode(),
+            V1(data) => encode_with_version(1, data.encode()),
+        }
+    }
+}
+
+impl<D: Data, M: Multiaddress, LM: Multiaddress> Decode for VersionedNetworkData<D, M, LM> {
+    fn decode<I: CodecInput>(input: &mut I) -> Result<Self, CodecError> {
+        use VersionedNetworkData::*;
+        let version = Version::decode(input)?;
+        let num_bytes = ByteCount::decode(input)?;
+        match version {
+            1 => Ok(V1(DiscoveryMessage::decode(input)?)),
+            _ => {
+                let mut payload = vec![
+                    0;
+                    num_bytes
+                        .try_into()
+                        .map_err(|_| "input too big to decode")?
+                ];
+                input.read(payload.as_mut_slice())?;
+                Ok(Other(version, payload))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Error {
+    BadFormat,
+    UnknownVersion(Version),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        use Error::*;
+        match self {
+            BadFormat => write!(f, "malformed encoding"),
+            UnknownVersion(version) => {
+                write!(f, "network data encoded with unknown version {}", version)
+            }
+        }
+    }
+}
+
+fn decode_pre_compatibility_network_data<D: Data, M: Multiaddress, LM: Multiaddress>(
+    data_raw: Vec<u8>,
+) -> Result<VersionedNetworkData<D, M, LM>, Error> {
+    use Error::*;
+
+    // We still have to be able to decode the pre-compatibility network data, so that
+    // we can complete a rolling update. When it becomes obsolete we can remove it.
+    let data_cloned = data_raw.clone();
+    match NetworkData::decode_all(&mut data_cloned.as_slice()) {
+        Ok(data) => Ok(VersionedNetworkData::Legacy(data.into())),
+        Err(_) => Err(BadFormat),
+    }
+}
+
+/// Decodes Network Data, even if it was produced by ancient code which does not conform to our
+/// backwards compatibility style.
+/// This should be removed, after rolling update with new network is completed
+pub fn backwards_compatible_decode<D: Data, M: Multiaddress, LM: Multiaddress>(
+    data_raw: Vec<u8>,
+) -> Result<VersionedNetworkData<D, M, LM>, Error> {
+    use Error::*;
+    let data_cloned = data_raw.clone();
+    match VersionedNetworkData::<D, M, LM>::decode_all(&mut data_cloned.as_slice()) {
+        Ok(data) => {
+            use VersionedNetworkData::*;
+            match data {
+                Legacy(data) => Ok(Legacy(data)),
+                V1(data) => Ok(V1(data)),
+                Other(version, _) => {
+                    // it is a coincidence that sometimes pre-compatibility legacy network data second word,
+                    // which is in VersionedNetworkData byte_count_size, can be small enough
+                    // so that network data is false positively recognized  as from the future
+                    // therefore we should try to decode formats
+                    decode_pre_compatibility_network_data(data_raw)
+                        .map_err(|_| UnknownVersion(version))
+                }
+            }
+        }
+        Err(_) => decode_pre_compatibility_network_data(data_raw),
+    }
+}

--- a/finality-aleph/src/network/manager/mod.rs
+++ b/finality-aleph/src/network/manager/mod.rs
@@ -6,11 +6,13 @@ use crate::{
     NodeIndex, SessionId,
 };
 
+mod compatibility;
 mod connections;
 mod discovery;
 mod service;
 mod session;
 
+pub use compatibility::{backwards_compatible_decode, VersionedNetworkData};
 use connections::Connections;
 pub use discovery::{Discovery, DiscoveryMessage};
 pub use service::{
@@ -18,7 +20,6 @@ pub use service::{
     IO as ConnectionIO,
 };
 pub use session::{Handler as SessionHandler, HandlerError as SessionHandlerError};
-
 /// Data validators use to authenticate themselves for a single session
 /// and disseminate their addresses.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
@@ -44,6 +45,15 @@ impl<M: Multiaddress> AuthData<M> {
 
 /// A full authentication, consisting of a signed AuthData.
 pub type Authentication<M> = (AuthData<M>, Signature);
+
+/// Data inside session, sent to validator network.
+pub type DataInSession<D> = (D, SessionId);
+
+impl<D: Data, M: Multiaddress> From<DataInSession<D>> for NetworkData<D, M> {
+    fn from(data: DataInSession<D>) -> Self {
+        NetworkData::Data(data.0, data.1)
+    }
+}
 
 /// The data that should be sent to the network service.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]

--- a/finality-aleph/src/network/mod.rs
+++ b/finality-aleph/src/network/mod.rs
@@ -13,6 +13,7 @@ use sp_runtime::traits::Block;
 
 mod aleph;
 mod component;
+mod io;
 mod manager;
 #[cfg(test)]
 pub mod mock;
@@ -26,22 +27,27 @@ pub use component::{
     NetworkMap as ComponentNetworkMap, Receiver as ReceiverComponent, Sender as SenderComponent,
     SimpleNetwork,
 };
+pub use io::setup as setup_io;
 use manager::SessionCommand;
-pub use manager::{ConnectionIO, ConnectionManager, ConnectionManagerConfig};
-pub use service::{Service, IO};
-pub use session::{Manager as SessionManager, ManagerError};
+pub use manager::{
+    ConnectionIO as ConnectionManagerIO, ConnectionManager, ConnectionManagerConfig,
+};
+pub use service::{Service, IO as NetworkServiceIO};
+pub use session::{Manager as SessionManager, ManagerError, IO as SessionManagerIO};
 pub use split::{split, Split};
-
 #[cfg(test)]
 pub mod testing {
-    pub use super::manager::{Authentication, DiscoveryMessage, NetworkData, SessionHandler};
+    pub use super::manager::{
+        Authentication, DataInSession, DiscoveryMessage, NetworkData, SessionHandler,
+        VersionedNetworkData,
+    };
 }
 
 /// Represents the id of an arbitrary node.
 pub trait PeerId: PartialEq + Eq + Clone + Debug + Display + Hash + Codec + Send {}
 
 /// Represents the address of an arbitrary node.
-pub trait Multiaddress: Debug + Hash + Codec + Clone + Eq {
+pub trait Multiaddress: Debug + Hash + Codec + Clone + Eq + Send + Sync {
     type PeerId: PeerId;
 
     /// Returns the peer id associated with this multiaddress if it exists and is unique.

--- a/finality-aleph/src/network/service.rs
+++ b/finality-aleph/src/network/service.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use aleph_primitives::AuthorityId;
-use codec::Encode;
 use futures::{channel::mpsc, StreamExt};
 use log::{debug, error, info, trace, warn};
 use sc_service::SpawnTaskHandle;
@@ -159,7 +158,9 @@ impl<
                             }
                         }
                     };
-                    if let Err(e) = s.send(data.encode()).await {
+                    // Right now we need to use backward compatible encode here.
+                    // In the future we can change it back to normal encode.
+                    if let Err(e) = s.send(data.backwards_compatible_encode()).await {
                         debug!(target: "aleph-network", "Failed sending data to peer. Dropping sender and message: {}", e);
                         sender = None;
                     }

--- a/finality-aleph/src/network/session.rs
+++ b/finality-aleph/src/network/session.rs
@@ -4,7 +4,9 @@ use futures::channel::{mpsc, oneshot};
 use super::SimpleNetwork;
 use crate::{
     crypto::{AuthorityPen, AuthorityVerifier},
-    network::{ComponentNetworkExt, Data, SendError, SenderComponent, SessionCommand},
+    network::{
+        ComponentNetworkExt, Data, ReceiverComponent, SendError, SenderComponent, SessionCommand,
+    },
     NodeIndex, SessionId,
 };
 
@@ -13,23 +15,44 @@ use crate::{
 pub struct Sender<D: Data> {
     session_id: SessionId,
     messages_for_network: mpsc::UnboundedSender<(D, SessionId, Recipient)>,
+    legacy_messages_for_network: mpsc::UnboundedSender<(D, SessionId, Recipient)>,
 }
 
 impl<D: Data> SenderComponent<D> for Sender<D> {
     fn send(&self, data: D, recipient: Recipient) -> Result<(), SendError> {
         self.messages_for_network
+            .unbounded_send((data.clone(), self.session_id, recipient.clone()))
+            .map_err(|_| SendError::SendFailed)?;
+        self.legacy_messages_for_network
             .unbounded_send((data, self.session_id, recipient))
             .map_err(|_| SendError::SendFailed)
     }
 }
 
+pub struct Receiver<D: Data> {
+    data_from_network: mpsc::UnboundedReceiver<D>,
+    legacy_data_from_network: mpsc::UnboundedReceiver<D>,
+}
+
+#[async_trait::async_trait]
+impl<D: Data> ReceiverComponent<D> for Receiver<D> {
+    async fn next(&mut self) -> Option<D> {
+        tokio::select! {
+            maybe_next = self.data_from_network.next() => maybe_next,
+            maybe_next = self.legacy_data_from_network.next() => maybe_next,
+        }
+    }
+}
+
 /// Sends and receives data within a single session.
-type Network<D> = SimpleNetwork<D, mpsc::UnboundedReceiver<D>, Sender<D>>;
+type Network<D> = SimpleNetwork<D, Receiver<D>, Sender<D>>;
 
 /// Manages sessions for which the network should be active.
 pub struct Manager<D: Data> {
     commands_for_service: mpsc::UnboundedSender<SessionCommand<D>>,
     messages_for_service: mpsc::UnboundedSender<(D, SessionId, Recipient)>,
+    legacy_commands_for_service: mpsc::UnboundedSender<SessionCommand<D>>,
+    legacy_messages_for_service: mpsc::UnboundedSender<(D, SessionId, Recipient)>,
 }
 
 /// What went wrong during a session management operation.
@@ -39,15 +62,31 @@ pub enum ManagerError {
     NetworkReceiveFailed,
 }
 
-impl<D: Data> Manager<D> {
-    /// Create a new manager with the given channels to the service.
+pub struct IO<D: Data> {
+    pub commands_for_service: mpsc::UnboundedSender<SessionCommand<D>>,
+    pub messages_for_service: mpsc::UnboundedSender<(D, SessionId, Recipient)>,
+}
+
+impl<D: Data> IO<D> {
     pub fn new(
         commands_for_service: mpsc::UnboundedSender<SessionCommand<D>>,
         messages_for_service: mpsc::UnboundedSender<(D, SessionId, Recipient)>,
     ) -> Self {
-        Manager {
+        IO {
             commands_for_service,
             messages_for_service,
+        }
+    }
+}
+
+impl<D: Data> Manager<D> {
+    /// Create a new manager with the given channels to the service.
+    pub fn new(io: IO<D>, legacy_io: IO<D>) -> Self {
+        Manager {
+            commands_for_service: io.commands_for_service,
+            messages_for_service: io.messages_for_service,
+            legacy_commands_for_service: legacy_io.commands_for_service,
+            legacy_messages_for_service: legacy_io.messages_for_service,
         }
     }
 
@@ -59,6 +98,12 @@ impl<D: Data> Manager<D> {
         verifier: AuthorityVerifier,
     ) -> Result<(), ManagerError> {
         self.commands_for_service
+            .unbounded_send(SessionCommand::StartNonvalidator(
+                session_id,
+                verifier.clone(),
+            ))
+            .map_err(|_| ManagerError::CommandSendFailed)?;
+        self.legacy_commands_for_service
             .unbounded_send(SessionCommand::StartNonvalidator(session_id, verifier))
             .map_err(|_| ManagerError::CommandSendFailed)
     }
@@ -77,21 +122,43 @@ impl<D: Data> Manager<D> {
         self.commands_for_service
             .unbounded_send(SessionCommand::StartValidator(
                 session_id,
-                verifier,
+                verifier.clone(),
                 node_id,
-                pen,
+                pen.clone(),
                 Some(result_for_us),
             ))
             .map_err(|_| ManagerError::CommandSendFailed)?;
+
+        let (legacy_result_for_us, legacy_result_from_service) = oneshot::channel();
+        self.legacy_commands_for_service
+            .unbounded_send(SessionCommand::StartValidator(
+                session_id,
+                verifier,
+                node_id,
+                pen,
+                Some(legacy_result_for_us),
+            ))
+            .map_err(|_| ManagerError::CommandSendFailed)?;
+
         let data_from_network = result_from_service
             .await
             .map_err(|_| ManagerError::NetworkReceiveFailed)?;
         let messages_for_network = self.messages_for_service.clone();
+
+        let legacy_data_from_network = legacy_result_from_service
+            .await
+            .map_err(|_| ManagerError::NetworkReceiveFailed)?;
+        let legacy_messages_for_network = self.legacy_messages_for_service.clone();
+
         Ok(Network::new(
-            data_from_network,
+            Receiver {
+                data_from_network,
+                legacy_data_from_network,
+            },
             Sender {
                 session_id,
                 messages_for_network,
+                legacy_messages_for_network,
             },
         ))
     }
@@ -108,6 +175,15 @@ impl<D: Data> Manager<D> {
     ) -> Result<(), ManagerError> {
         self.commands_for_service
             .unbounded_send(SessionCommand::StartValidator(
+                session_id,
+                verifier.clone(),
+                node_id,
+                pen.clone(),
+                None,
+            ))
+            .map_err(|_| ManagerError::CommandSendFailed)?;
+        self.legacy_commands_for_service
+            .unbounded_send(SessionCommand::StartValidator(
                 session_id, verifier, node_id, pen, None,
             ))
             .map_err(|_| ManagerError::CommandSendFailed)
@@ -116,6 +192,9 @@ impl<D: Data> Manager<D> {
     /// Stop participating in the given session.
     pub fn stop_session(&self, session_id: SessionId) -> Result<(), ManagerError> {
         self.commands_for_service
+            .unbounded_send(SessionCommand::Stop(session_id))
+            .map_err(|_| ManagerError::CommandSendFailed)?;
+        self.legacy_commands_for_service
             .unbounded_send(SessionCommand::Stop(session_id))
             .map_err(|_| ManagerError::CommandSendFailed)
     }

--- a/finality-aleph/src/tcp_network.rs
+++ b/finality-aleph/src/tcp_network.rs
@@ -1,16 +1,18 @@
-use std::{io::Result as IoResult, net::ToSocketAddrs as _};
+use std::{io::Result as IoResult, marker::PhantomData, net::ToSocketAddrs as _, sync::Arc};
 
-use aleph_primitives::AuthorityId;
+use aleph_primitives::{AuthorityId, KEY_TYPE};
 use codec::{Decode, Encode};
+use futures::future::pending;
 use log::info;
+use sp_keystore::{testing::KeyStore, CryptoStore};
 use tokio::net::{
     tcp::{OwnedReadHalf, OwnedWriteHalf},
     TcpListener, TcpStream, ToSocketAddrs,
 };
 
 use crate::{
-    network::{Multiaddress, NetworkIdentity, PeerId},
-    validator_network::{Dialer, Listener, Splittable},
+    network::{Data, Multiaddress, NetworkIdentity, PeerId},
+    validator_network::{Dialer, Listener, Network, Splittable},
 };
 
 impl Splittable for TcpStream {
@@ -124,4 +126,44 @@ pub async fn new_tcp_network<A: ToSocketAddrs>(
         peer_id,
     };
     Ok((TcpDialer {}, listener, identity))
+}
+
+/// This struct is for integration only. Will be removed after A0-1411.
+struct NoopNetwork<D: Data> {
+    _phantom: PhantomData<D>,
+}
+
+#[async_trait::async_trait]
+impl<D: Data> Network<TcpMultiaddress, D> for NoopNetwork<D> {
+    fn add_connection(&mut self, _peer: AuthorityId, _addresses: Vec<TcpMultiaddress>) {}
+
+    fn remove_connection(&mut self, _peer: AuthorityId) {}
+
+    fn send(&self, _data: D, _recipient: AuthorityId) {}
+
+    async fn next(&mut self) -> Option<D> {
+        Some(pending::<D>().await)
+    }
+}
+
+pub async fn new_noop<D: Data>() -> (
+    impl Network<TcpMultiaddress, D>,
+    impl NetworkIdentity<Multiaddress = TcpMultiaddress, PeerId = AuthorityId>,
+) {
+    let key_store = Arc::new(KeyStore::new());
+    let peer_id: AuthorityId = key_store
+        .ed25519_generate_new(KEY_TYPE, None)
+        .await
+        .unwrap()
+        .into();
+    let addresses = vec![TcpMultiaddress {
+        peer_id: peer_id.clone(),
+        address: String::from(""),
+    }];
+    (
+        NoopNetwork {
+            _phantom: PhantomData,
+        },
+        TcpNetworkIdentity { peer_id, addresses },
+    )
 }

--- a/finality-aleph/src/testing/mocks/mod.rs
+++ b/finality-aleph/src/testing/mocks/mod.rs
@@ -21,4 +21,4 @@ mod justification_handler_config;
 mod proposal;
 mod session_info;
 mod single_action_mock;
-mod validator_network;
+pub mod validator_network;

--- a/finality-aleph/src/testing/mocks/validator_network.rs
+++ b/finality-aleph/src/testing/mocks/validator_network.rs
@@ -8,7 +8,7 @@ use crate::{
     validator_network::Network,
 };
 
-type MockMultiaddress = (AuthorityId, String);
+pub type MockMultiaddress = (AuthorityId, String);
 
 impl Multiaddress for MockMultiaddress {
     type PeerId = AuthorityId;
@@ -25,6 +25,7 @@ impl Multiaddress for MockMultiaddress {
     }
 }
 
+#[derive(Clone)]
 pub struct MockNetwork<D: Data> {
     pub add_connection: Channel<(AuthorityId, Vec<MockMultiaddress>)>,
     pub remove_connection: Channel<AuthorityId>,
@@ -63,7 +64,7 @@ impl<D: Data> NetworkIdentity for MockNetwork<D> {
 }
 
 impl<D: Data> MockNetwork<D> {
-    pub async fn _new(address: &str) -> Self {
+    pub async fn new(address: &str) -> Self {
         let key_store = Arc::new(KeyStore::new());
         let id: AuthorityId = key_store
             .ed25519_generate_new(KEY_TYPE, None)

--- a/finality-aleph/src/testing/mod.rs
+++ b/finality-aleph/src/testing/mod.rs
@@ -1,5 +1,5 @@
 pub mod client_chain_builder;
 mod data_store;
 mod justification;
-pub(crate) mod mocks;
+pub mod mocks;
 mod network;

--- a/finality-aleph/src/validator_network/mod.rs
+++ b/finality-aleph/src/validator_network/mod.rs
@@ -30,7 +30,7 @@ impl<D: Clone + Codec + Send + Sync + 'static> Data for D {}
 /// implementation might fail to deliver any specific message, so messages have to be resent while
 /// they still should be delivered.
 #[async_trait::async_trait]
-pub trait Network<A: Data, D: Data>: Send {
+pub trait Network<A: Data, D: Data>: Send + 'static {
     /// Add the peer to the set of connected peers.
     fn add_connection(&mut self, peer: AuthorityId, addresses: Vec<A>);
 


### PR DESCRIPTION
# Description

This PR integrates new validator network with network service. For now it only uses dummy implementation of network that satisfies the trait but does nothing. After this PR, network service uses two connection managers and they are both connected to two different networks.

1. Legacy Network - uses Substrate network for authentication broadcast and sending AlephBFT data
2. New Network - uses Substrate network (the same one) for authentication broadcast and validator network for sending AlephBFT data

This code is still compatible with older nodes due to NetworkData compatibility implemented in this PR. They can communicate through legacy network. Legacy network and its handling should be removed after we update mainnet to use new validator network and we make sure validator network works correctly.

## Type of change

- New feature (non-breaking change which adds functionality)

# Tests:
- Integration tests were updated, so that they still test legacy network.
- New tests should be added in separate for testing new network.
- I have tested this change running together with older nodes. In result they still communicate with them and finalizing blocks.
- I have tested by hand that the nodes do use authentication for new network and the add other nodes to validator network.
