### PR TITLE
A0-1478: Cleanup compatibility code

### DIFF
--- a/finality-aleph/src/justification/compatibility.rs
+++ b/finality-aleph/src/justification/compatibility.rs
@@ -57,12 +57,17 @@ enum VersionedAlephJustification {
 }
 
 fn encode_with_version(version: Version, mut payload: Vec<u8>) -> Vec<u8> {
-    let mut result = version.encode();
+    let mut result =
+        Vec::with_capacity(size_of::<Version>() + size_of::<ByteCount>() + payload.len());
+    version.encode_to(&mut result);
     // This will produce rubbish if we ever try encodings that have more than u16::MAX bytes. We
     // expect this won't happen, since we will switch to proper multisignatures before proofs get
     // that big.
-    let num_bytes = payload.len() as ByteCount;
-    result.append(&mut num_bytes.encode());
+    payload
+        .len()
+        .try_into()
+        .unwrap_or(u16::MAX)
+        .encode_to(&mut result);
     result.append(&mut payload);
     result
 }

--- a/finality-aleph/src/justification/compatibility.rs
+++ b/finality-aleph/src/justification/compatibility.rs
@@ -66,9 +66,10 @@ fn encode_with_version(version: Version, payload: &[u8]) -> Vec<u8> {
     let size = payload.len().try_into().unwrap_or_else(|_| {
         if payload.len() > ByteCount::MAX.into() {
             warn!(
-                "Versioned Justification too big during Encode. Size is approximately {:?} KiB. Should be {:?} KiB at max.",
-                payload.len() / 1024,
-                ByteCount::MAX / 1024
+                "Versioned Justification v{:?} too big during Encode. Size is {:?}. Should be {:?} at max.",
+                version,
+                payload.len(),
+                ByteCount::MAX
             );
         }
         ByteCount::MAX

--- a/finality-aleph/src/network/manager/compatibility.rs
+++ b/finality-aleph/src/network/manager/compatibility.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use codec::{Decode, Encode, Error as CodecError, Input as CodecInput};
+use log::warn;
 
 use crate::network::{
     manager::{DiscoveryMessage, NetworkData},
@@ -53,6 +54,13 @@ fn encode_with_version(version: Version, payload: &[u8]) -> Vec<u8> {
         .len()
         .try_into()
         .unwrap_or(MAX_AUTHENTICATION_SIZE + 1);
+    if size > MAX_AUTHENTICATION_SIZE {
+        warn!(
+            "Versioned Authentication too big during Encode. Size is approximately {:?} KiB. Should be {:?} KiB at max.",
+            payload.len() / 1024,
+            MAX_AUTHENTICATION_SIZE / 1024
+        );
+    }
 
     let mut result = Vec::with_capacity(version.size_hint() + size.size_hint() + payload.len());
 

--- a/finality-aleph/src/network/manager/compatibility.rs
+++ b/finality-aleph/src/network/manager/compatibility.rs
@@ -55,7 +55,7 @@ fn encode_with_version(version: Version, payload: &[u8]) -> Vec<u8> {
         .try_into()
         .unwrap_or(MAX_AUTHENTICATION_SIZE + 1);
     if size > MAX_AUTHENTICATION_SIZE {
-        println!(
+        warn!(
             "Versioned Authentication v{:?} too big during Encode. Size is {:?}. Should be {:?} at max.",
             version,
             payload.len(),

--- a/finality-aleph/src/network/manager/compatibility.rs
+++ b/finality-aleph/src/network/manager/compatibility.rs
@@ -55,10 +55,11 @@ fn encode_with_version(version: Version, payload: &[u8]) -> Vec<u8> {
         .try_into()
         .unwrap_or(MAX_AUTHENTICATION_SIZE + 1);
     if size > MAX_AUTHENTICATION_SIZE {
-        warn!(
-            "Versioned Authentication too big during Encode. Size is approximately {:?} KiB. Should be {:?} KiB at max.",
-            payload.len() / 1024,
-            MAX_AUTHENTICATION_SIZE / 1024
+        println!(
+            "Versioned Authentication v{:?} too big during Encode. Size is {:?}. Should be {:?} at max.",
+            version,
+            payload.len(),
+            MAX_AUTHENTICATION_SIZE
         );
     }
 


### PR DESCRIPTION
# Description

This removes `as` casting from compatibility code in `VersionedJustification` and `VersionedAuthentication`.

## Type of change

- Bug fix

# Checklist:

- I have made corresponding changes to the existing documentation
