### PR TITLE
A0-1477: extend validator network status report

### DIFF
--- a/finality-aleph/src/network/manager/service.rs
+++ b/finality-aleph/src/network/manager/service.rs
@@ -19,7 +19,7 @@ use crate::{
             Connections, Discovery, DiscoveryMessage, NetworkData, SessionHandler,
             SessionHandlerError,
         },
-        ConnectionCommand, Data, DataCommand, Multiaddress, NetworkIdentity, Protocol,
+        ConnectionCommand, Data, DataCommand, Multiaddress, NetworkIdentity, Protocol, ShortId,
     },
     MillisecsPerBlock, NodeIndex, SessionId, SessionPeriod, STATUS_REPORT_INTERVAL,
 };
@@ -570,7 +570,9 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
                 .map(|(session_id, node_count, peers)| {
                     let peer_ids = peers
                         .iter()
-                        .map(|(node_id, peer_id)| format!("{:?}: {}", node_id, peer_id,))
+                        .map(|(node_id, peer_id)| {
+                            format!("{:?}: {}", node_id, peer_id.to_short_id())
+                        })
                         .collect::<Vec<_>>()
                         .join(", ");
 

--- a/finality-aleph/src/network/mod.rs
+++ b/finality-aleph/src/network/mod.rs
@@ -43,6 +43,21 @@ pub mod testing {
     };
 }
 
+/// This trait is needed for logging. It implements a shorter version of PeerId for ids implementing display.
+pub trait ShortId: Display {
+    fn to_short_id(&self) -> String {
+        let id = format!("{}", self);
+
+        let prefix: String = id.chars().take(4).collect();
+
+        let suffix: String = id.chars().skip(id.len().saturating_sub(8)).collect();
+
+        format!("{}…{}", &prefix, &suffix)
+    }
+}
+
+impl<P: PeerId> ShortId for P {}
+
 /// Represents the id of an arbitrary node.
 pub trait PeerId: PartialEq + Eq + Clone + Debug + Display + Hash + Codec + Send {}
 

--- a/finality-aleph/src/network/service.rs
+++ b/finality-aleph/src/network/service.rs
@@ -17,7 +17,7 @@ use crate::{
     network::{
         manager::{NetworkData, VersionedAuthentication},
         ConnectionCommand, Data, DataCommand, Event, EventStream, Multiaddress, Network,
-        NetworkSender, Protocol,
+        NetworkSender, Protocol, ShortId,
     },
     validator_network::Network as ValidatorNetwork,
     STATUS_REPORT_INTERVAL,
@@ -417,7 +417,7 @@ impl<
         let peer_ids = self
             .legacy_validator_connected_peers
             .iter()
-            .map(|peer_id| format!("{}", peer_id))
+            .map(|peer_id| peer_id.to_short_id())
             .collect::<Vec<_>>()
             .join(", ");
         status.push_str(&format!(

--- a/finality-aleph/src/substrate_network.rs
+++ b/finality-aleph/src/substrate_network.rs
@@ -71,16 +71,7 @@ impl Decode for PeerId {
 
 impl fmt::Display for PeerId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let peer_id: String = self.0.to_string();
-
-        let prefix: String = peer_id.chars().take(4).collect();
-
-        let suffix: String = peer_id
-            .chars()
-            .skip(peer_id.len().saturating_sub(8))
-            .collect();
-
-        write!(f, "{}…{}", &prefix, &suffix)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/finality-aleph/src/validator_network/service.rs
+++ b/finality-aleph/src/validator_network/service.rs
@@ -206,7 +206,7 @@ impl<D: Data, A: Data, ND: Dialer<A>, NL: Listener> Service<D, A, ND, NL> {
                 },
                 // periodically reporting what we are trying to do
                 _ = status_ticker.tick() => {
-                    info!(target: "validator-network", "Manager status report: {}.", self.manager.status_report())
+                    info!(target: "validator-network", "{}", self.manager.status_report())
                 }
                 // received exit signal, stop the network
                 // all workers will be killed automatically after the manager gets dropped


### PR DESCRIPTION
# Description
Extend validator network status report to contain info about what peers we have connected and in which way. Examples are:

## Examples of logs
If we do not maintain any connections:
```
Validator Network Manager status report: not maintaining any 
```

If 3 nodes are fully connected:
```
Validator Network Manager status report: target - 3 connections; both ways: 3, [5ExN…G5GBK9tk, 5FCY…mukzBY9p, 5D6W…tjuhjhjP];  
```
If 3 nodes are not fully connected:
```
 Validator Network Manager status report: target - 3 connections; both ways: 1, [5ExN…G5GBK9tk]; incoming connections: 1, [5FCY…mukzBY9p]; outgoing connections: 1, [5D6W…tjuhjhjP];   
```
If noone is connecting to us:
```
Validator Network Manager status report: WARNING! No incoming peers even though we expected tham, maybe connecting to us is impossible; target - 3 connections; both ways: 0, []; outgoing connections: 3, [5D6W…tjuhjhjP, 5ExN…G5GBK9tk, 5GiZ…1UzWnDHn];
```