### PR TITLE
Add certificats to cliain docker image

### DIFF
--- a/bin/cliain/Dockerfile
+++ b/bin/cliain/Dockerfile
@@ -2,8 +2,14 @@ FROM ubuntu:jammy-20220531
 
 RUN apt update && \
     apt install wget -y && \
+    apt clean
+
+RUN apt update && \
+    apt install ca-certificates -y && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN update-ca-certificates
 
 RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
 RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
@@ -12,3 +18,4 @@ COPY target/release/cliain /usr/local/bin
 RUN chmod +x /usr/local/bin/cliain
 
 ENTRYPOINT ["/usr/local/bin/cliain"]
+


### PR DESCRIPTION
# Description

Adding certificates to cliain docker image. This enables connecting with wss endpoints.

## Type of change

- Bug fix (?) (non-breaking change which fixes an issue)
