### PR TITLE
simple e2e-test for message_compatibility and version upgrade

### DIFF
--- a/.github/actions/run-e2e-test/action.yml
+++ b/.github/actions/run-e2e-test/action.yml
@@ -26,6 +26,15 @@ inputs:
   follow-up-finalization-check:
     description: 'Whether to run a follow-up finalization check.'
     required: false
+  upgrade_version:
+    description: 'Version which will be used during the VersionUpgrade test.'
+    required: false
+  upgrade_session:
+    description: 'Session for which an upgrade should be scheduled.'
+    required: false
+  upgrade_finalization_wait_sessions:
+    description: 'Number of sessions we should wait after performing an upgrade.'
+    required: false
 
 runs:
   using: 'composite'
@@ -64,21 +73,33 @@ runs:
           -r "${{ inputs.randomized }}"
           -m "${{ inputs.min-validator-count }}"
         )
-        
+
         RESERVED_SEATS="${{ inputs.reserved-seats }}"
         NON_RESERVED_SEATS="${{ inputs.non-reserved-seats }}"
-        
+
+        UPGRADE_VERSION=${{ inputs.upgrade_version }}
+        UPGRADE_SESSION=${{ inputs.upgrade_session }}
+        UPGRADE_FINALIZATION_WAIT_SESSIONS=${{ inputs.upgrade_finalization_wait_sessions }}
+
         if [[ -n "${RANDOMIZED}" ]]; then
           ARGS+=(-r "${RANDOMIZED}")
         fi
-        
+
         if [[ -n "${RESERVED_SEATS}" && -n "${NON_RESERVED_SEATS}" ]]; then
           ARGS+=(
             -f "${RESERVED_SEATS}"
             -n "${NON_RESERVED_SEATS}"
           )
         fi
-        
+
+        if [[ -n "${UPGRADE_VERSION}"  && -n "${UPGRADE_SESSION}" && -n "${UPGRADE_FINALIZATION_WAIT_SESSIONS}" ]]; then
+          ARGS+=(
+            -v "${UPGRADE_VERSION}"
+            -s "${UPGRADE_SESSION}"
+            -w "${UPGRADE_FINALIZATION_WAIT_SESSIONS}"
+          )
+        fi
+
         ./.github/scripts/run_e2e_test.sh "${ARGS[@]}"
 
     - name: Run finalization e2e test

--- a/.github/actions/run-e2e-test/action.yml
+++ b/.github/actions/run-e2e-test/action.yml
@@ -26,15 +26,6 @@ inputs:
   follow-up-finalization-check:
     description: 'Whether to run a follow-up finalization check.'
     required: false
-  upgrade_version:
-    description: 'Version which will be used during the VersionUpgrade test.'
-    required: false
-  upgrade_session:
-    description: 'Session for which an upgrade should be scheduled.'
-    required: false
-  upgrade_finalization_wait_sessions:
-    description: 'Number of sessions we should wait after performing an upgrade.'
-    required: false
 
 runs:
   using: 'composite'
@@ -77,10 +68,6 @@ runs:
         RESERVED_SEATS="${{ inputs.reserved-seats }}"
         NON_RESERVED_SEATS="${{ inputs.non-reserved-seats }}"
 
-        UPGRADE_VERSION=${{ inputs.upgrade_version }}
-        UPGRADE_SESSION=${{ inputs.upgrade_session }}
-        UPGRADE_FINALIZATION_WAIT_SESSIONS=${{ inputs.upgrade_finalization_wait_sessions }}
-
         if [[ -n "${RANDOMIZED}" ]]; then
           ARGS+=(-r "${RANDOMIZED}")
         fi
@@ -89,14 +76,6 @@ runs:
           ARGS+=(
             -f "${RESERVED_SEATS}"
             -n "${NON_RESERVED_SEATS}"
-          )
-        fi
-
-        if [[ -n "${UPGRADE_VERSION}"  && -n "${UPGRADE_SESSION}" && -n "${UPGRADE_FINALIZATION_WAIT_SESSIONS}" ]]; then
-          ARGS+=(
-            -v "${UPGRADE_VERSION}"
-            -s "${UPGRADE_SESSION}"
-            -w "${UPGRADE_FINALIZATION_WAIT_SESSIONS}"
           )
         fi
 

--- a/.github/scripts/run_e2e_test.sh
+++ b/.github/scripts/run_e2e_test.sh
@@ -71,6 +71,10 @@ RANDOMIZED="${RANDOMIZED:-"false"}"
 RESERVED_SEATS="${RESERVED_SEATS:-}"
 NON_RESERVED_SEATS="${NON_RESERVED_SEATS:-}"
 
+UPGRADE_VERSION="${UPGRADE_VERSION:-}"
+UPGRADE_SESSION="${UPGRADE_SESSION:-}"
+UPGRADE_FINALIZATION_WAIT_SESSIONS="${UPGRADE_FINALIZATION_WAIT_SESSIONS:-}"
+
 # Do not accept randomization together with test case parameters.
 if [[ "${RANDOMIZED}" == "true" && ( -n "${RESERVED_SEATS}" || -n "${NON_RESERVED_SEATS}" )]]; then
   echo "Cannot both randomize and provide test case parameters!"
@@ -97,6 +101,14 @@ if [[ -n "${RESERVED_SEATS}" && -n "${NON_RESERVED_SEATS}" ]]; then
   )
 else
   echo "Falling back on default test case param values."
+fi
+
+if [[ -n "${UPGRADE_VERSION}" && -n "${UPGRADE_SESSION}" && -n "${UPGRADE_FINALIZATION_WAIT_SESSIONS}" ]]; then
+    ARGS+=(
+        -e "${UPGRADE_VERSION}"
+        -e "${UPGRADE_SESSION}"
+        -e "${UPGRADE_FINALIZATION_WAIT_SESSIONS}"
+    )
 fi
 
 docker run -v $(pwd)/docker/data:/data "${ARGS[@]}" aleph-e2e-client:latest

--- a/.github/scripts/run_e2e_test.sh
+++ b/.github/scripts/run_e2e_test.sh
@@ -71,10 +71,6 @@ RANDOMIZED="${RANDOMIZED:-"false"}"
 RESERVED_SEATS="${RESERVED_SEATS:-}"
 NON_RESERVED_SEATS="${NON_RESERVED_SEATS:-}"
 
-UPGRADE_VERSION="${UPGRADE_VERSION:-}"
-UPGRADE_SESSION="${UPGRADE_SESSION:-}"
-UPGRADE_FINALIZATION_WAIT_SESSIONS="${UPGRADE_FINALIZATION_WAIT_SESSIONS:-}"
-
 # Do not accept randomization together with test case parameters.
 if [[ "${RANDOMIZED}" == "true" && ( -n "${RESERVED_SEATS}" || -n "${NON_RESERVED_SEATS}" )]]; then
   echo "Cannot both randomize and provide test case parameters!"
@@ -103,7 +99,7 @@ else
   echo "Falling back on default test case param values."
 fi
 
-if [[ -n "${UPGRADE_VERSION}" && -n "${UPGRADE_SESSION}" && -n "${UPGRADE_FINALIZATION_WAIT_SESSIONS}" ]]; then
+if [[ -n "${UPGRADE_VERSION:-}" && -n "${UPGRADE_SESSION:-}" && -n "${UPGRADE_FINALIZATION_WAIT_SESSIONS:-}" ]]; then
     ARGS+=(
         -e "${UPGRADE_VERSION}"
         -e "${UPGRADE_SESSION}"

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -402,6 +402,23 @@ jobs:
           follow-up-finalization-check: true
         timeout-minutes: 15
 
+  run-e2e-version-upgrade:
+    needs: [build-test-docker, build-test-client]
+    name: Run basic (positive) version upgrade test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Run e2e test
+        uses: ./.github/actions/run-e2e-test
+        with:
+          test-case: version_upgrade
+          upgrade_to_version: 1,
+          upgrade_session: 3,
+          upgrade_finalization_wait_sessions: 2,
+        timeout-minutes: 10
+
   check-e2e-test-suite-completion:
     needs: [
       run-e2e-finalization-test,

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -414,9 +414,11 @@ jobs:
         uses: ./.github/actions/run-e2e-test
         with:
           test-case: version_upgrade
-          upgrade_to_version: 1,
-          upgrade_session: 3,
-          upgrade_finalization_wait_sessions: 2,
+          follow-up-finalization-check: true
+        env:
+          UPGRADE_VERSION: 1,
+          UPGRADE_SESSION: 3,
+          UPGRADE_FINALIZATION_WAIT_SESSIONS: 2,
         timeout-minutes: 10
 
   check-e2e-test-suite-completion:

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -18,6 +18,7 @@ pub use multisig::{
     compute_call_hash, perform_multisig_with_threshold_1, MultisigError, MultisigParty,
     SignatureAggregation,
 };
+use primitives::SessionIndex;
 pub use primitives::{Balance, BlockHash, BlockNumber, Header};
 pub use rpc::{emergency_finalize, rotate_keys, rotate_keys_raw_result, state_query_storage_at};
 pub use session::{
@@ -75,6 +76,7 @@ mod staking;
 mod system;
 mod transfer;
 mod treasury;
+mod version_upgrade;
 mod vesting;
 mod waiting;
 
@@ -256,6 +258,17 @@ pub trait CallSystem {
     type Error: StdError;
 
     fn fill_block(&self, target_ratio: u32, status: XtStatus) -> Result<(), Self::Error>;
+}
+
+pub trait VersionUpgrade {
+    type Version;
+    type Error: StdError;
+
+    fn schedule_upgrade(
+        &self,
+        version: Self::Version,
+        session: SessionIndex,
+    ) -> anyhow::Result<(), Self::Error>;
 }
 
 pub trait ManageParams {

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -18,7 +18,6 @@ pub use multisig::{
     compute_call_hash, perform_multisig_with_threshold_1, MultisigError, MultisigParty,
     SignatureAggregation,
 };
-use primitives::SessionIndex;
 pub use primitives::{Balance, BlockHash, BlockNumber, Header};
 pub use rpc::{emergency_finalize, rotate_keys, rotate_keys_raw_result, state_query_storage_at};
 pub use session::{
@@ -56,6 +55,7 @@ pub use treasury::{
     propose as make_treasury_proposal, reject as reject_treasury_proposal, staking_treasury_payout,
     treasury_account,
 };
+pub use version_upgrade::{schedule_upgrade, Version};
 pub use vesting::{
     get_schedules, merge_schedules, vest, vest_other, vested_transfer, VestingError,
     VestingSchedule,
@@ -258,17 +258,6 @@ pub trait CallSystem {
     type Error: StdError;
 
     fn fill_block(&self, target_ratio: u32, status: XtStatus) -> Result<(), Self::Error>;
-}
-
-pub trait VersionUpgrade {
-    type Version;
-    type Error: StdError;
-
-    fn schedule_upgrade(
-        &self,
-        version: Self::Version,
-        session: SessionIndex,
-    ) -> anyhow::Result<(), Self::Error>;
 }
 
 pub trait ManageParams {

--- a/aleph-client/src/session.rs
+++ b/aleph-client/src/session.rs
@@ -111,7 +111,7 @@ pub fn get_session<C: ReadStorage>(connection: &C, block_hash: Option<H256>) -> 
 pub fn wait_for_predicate<C: ReadStorage, P: Fn(SessionIndex) -> bool>(
     connection: &C,
     session_predicate: P,
-) -> anyhow::Result<BlockNumber> {
+) -> anyhow::Result<SessionIndex> {
     info!(target: "aleph-client", "Waiting for session");
 
     #[derive(Debug, Decode, Clone)]

--- a/aleph-client/src/version_upgrade.rs
+++ b/aleph-client/src/version_upgrade.rs
@@ -1,9 +1,6 @@
 use anyhow::Result;
 use primitives::SessionIndex;
-use sp_core::Pair;
-use substrate_api_client::{
-    compose_call, compose_extrinsic, ApiClientError, ExtrinsicParams, XtStatus,
-};
+use substrate_api_client::{compose_call, compose_extrinsic, ApiClientError, XtStatus};
 
 use crate::{try_send_xt, AnyConnection, RootConnection};
 

--- a/aleph-client/src/version_upgrade.rs
+++ b/aleph-client/src/version_upgrade.rs
@@ -1,0 +1,39 @@
+use primitives::SessionIndex;
+use sp_core::Pair;
+use substrate_api_client::{compose_call, compose_extrinsic, ExtrinsicParams, XtStatus};
+
+use crate::{try_send_xt, AnyConnection, RootConnection, VersionUpgrade};
+
+impl VersionUpgrade for RootConnection {
+    type Version = u32;
+    type Error = substrate_api_client::ApiClientError;
+
+    fn schedule_upgrade(
+        &self,
+        version: Self::Version,
+        session: SessionIndex,
+    ) -> anyhow::Result<(), Self::Error> {
+        let connection = self.as_connection();
+        let upgrade_call = compose_call!(
+            connection.metadata,
+            "Aleph",
+            "schedule_finality_version_change",
+            version,
+            session
+        );
+        let xt = compose_extrinsic!(
+            connection,
+            "Sudo",
+            "sudo_unchecked_weight",
+            upgrade_call,
+            0_u64
+        );
+        try_send_xt(
+            &connection,
+            xt,
+            Some("schedule finality version change"),
+            XtStatus::Finalized,
+        )
+        .map(|_| ())
+    }
+}

--- a/e2e-tests/docker_entrypoint.sh
+++ b/e2e-tests/docker_entrypoint.sh
@@ -17,6 +17,14 @@ if [[ -n "${RESERVED_SEATS:-}" && -n "${NON_RESERVED_SEATS:-}" ]]; then
   )
 fi
 
+if [[ -n "${UPGRADE_VERSION:-}" && -n "${UPGRADE_SESSION:-}" && -n "${UPGRADE_FINALIZATION_WAIT_SESSIONS:-}" ]]; then
+    ARGS+=(
+        --upgrade-to-version "${UPGRADE_VERSION}"
+        --upgrade-session "${UPGRADE_SESSION}"
+        --upgrade-finalization-wait-sessions "${UPGRADE_FINALIZATION_WAIT_SESSIONS}"
+    )
+fi
+
 aleph-e2e-client "${ARGS[@]}"
 
 echo "Done!"

--- a/e2e-tests/src/cases.rs
+++ b/e2e-tests/src/cases.rs
@@ -26,8 +26,8 @@ pub type PossibleTestCases = Vec<(&'static str, TestCase)>;
 /// This comes up in local tests.
 pub fn possible_test_cases() -> PossibleTestCases {
     vec![
-        ("version_upgrade", test_schedule_version_change),
         ("finalization", test_finalization as TestCase),
+        ("version_upgrade", test_schedule_version_change),
         ("rewards_disable_node", test_disable_node as TestCase),
         ("token_transfer", test_token_transfer as TestCase),
         (

--- a/e2e-tests/src/cases.rs
+++ b/e2e-tests/src/cases.rs
@@ -10,6 +10,7 @@ use crate::{
         fee_calculation as test_fee_calculation, finalization as test_finalization,
         force_new_era as test_force_new_era, points_basic as test_points_basic,
         points_stake_change as test_points_stake_change,
+        schedule_version_change as test_schedule_version_change,
         staking_era_payouts as test_staking_era_payouts,
         staking_new_validator as test_staking_new_validator, token_transfer as test_token_transfer,
         treasury_access as test_treasury_access, validators_rotate as test_validators_rotate,
@@ -25,6 +26,7 @@ pub type PossibleTestCases = Vec<(&'static str, TestCase)>;
 /// This comes up in local tests.
 pub fn possible_test_cases() -> PossibleTestCases {
     vec![
+        ("version_upgrade", test_schedule_version_change),
         ("finalization", test_finalization as TestCase),
         ("rewards_disable_node", test_disable_node as TestCase),
         ("token_transfer", test_token_transfer as TestCase),

--- a/e2e-tests/src/config.rs
+++ b/e2e-tests/src/config.rs
@@ -1,5 +1,6 @@
 use aleph_client::{RootConnection, SignedConnection};
 use clap::{Args, Parser};
+use primitives::SessionIndex;
 
 use crate::accounts::{get_sudo_key, get_validators_keys, get_validators_seeds, NodeKeys};
 
@@ -62,19 +63,21 @@ impl Config {
 pub struct TestCaseParams {
     /// Desired number of reserved seats for validators, may be set within the test.
     #[clap(long)]
-    reserved_seats: Option<u32>,
+    pub reserved_seats: Option<u32>,
 
     /// Desired number of non-reserved seats for validators, may be set within the test.
     #[clap(long)]
-    non_reserved_seats: Option<u32>,
-}
+    pub non_reserved_seats: Option<u32>,
 
-impl TestCaseParams {
-    pub fn reserved_seats(&self) -> Option<u32> {
-        self.reserved_seats
-    }
+    /// Version for the VersionUpgrade test.
+    #[clap(long)]
+    pub upgrade_to_version: Option<u32>,
 
-    pub fn non_reserved_seats(&self) -> Option<u32> {
-        self.non_reserved_seats
-    }
+    /// Session in which we should schedule an upgrade in VersionUpgrade test.
+    #[clap(long)]
+    pub upgrade_session: Option<SessionIndex>,
+
+    /// How many sessions we should wait after upgrade in VersionUpgrade test.
+    #[clap(long)]
+    pub upgrade_finalization_wait_sessions: Option<u32>,
 }

--- a/e2e-tests/src/test/electing_validators.rs
+++ b/e2e-tests/src/test/electing_validators.rs
@@ -145,11 +145,11 @@ pub fn authorities_are_staking(config: &Config) -> anyhow::Result<()> {
     // `MinimumValidatorCount` from `pallet_staking`, set in chain spec.
     let min_validator_count = get_minimum_validator_count(&root_connection);
 
-    let reserved_seats = match config.test_case_params.reserved_seats() {
+    let reserved_seats = match config.test_case_params.reserved_seats {
         Some(seats) => seats,
         None => RESERVED_SEATS_DEFAULT,
     };
-    let non_reserved_seats = match config.test_case_params.non_reserved_seats() {
+    let non_reserved_seats = match config.test_case_params.non_reserved_seats {
         Some(seats) => seats,
         None => NON_RESERVED_SEATS_DEFAULT,
     };

--- a/e2e-tests/src/test/mod.rs
+++ b/e2e-tests/src/test/mod.rs
@@ -12,6 +12,7 @@ pub use treasury::{channeling_fee_and_tip, treasury_access};
 pub use utility::batch_transactions;
 pub use validators_change::change_validators;
 pub use validators_rotate::validators_rotate;
+pub use version_upgrade::schedule_version_change;
 
 mod electing_validators;
 mod era_payout;
@@ -25,3 +26,4 @@ mod treasury;
 mod utility;
 mod validators_change;
 mod validators_rotate;
+mod version_upgrade;

--- a/e2e-tests/src/test/version_upgrade.rs
+++ b/e2e-tests/src/test/version_upgrade.rs
@@ -1,0 +1,38 @@
+use aleph_client::{
+    get_current_session, get_session_period, wait_for_at_least_session, wait_for_finalized_block,
+    VersionUpgrade,
+};
+use primitives::SessionIndex;
+
+use crate::Config;
+
+const UPGRADE_TO_VERSION: u32 = 1;
+
+const UPGRADE_SESSION: SessionIndex = 3;
+
+const UPGRADE_FINALIZATION_WAIT_SESSIONS: u32 = 3;
+
+// Simple test that schedules a version upgrade, awaits it, and checks if node is still finalizing after planned upgrade session.
+pub fn schedule_version_change(config: &Config) -> anyhow::Result<()> {
+    let connection = config.create_root_connection();
+    let test_case_params = config.test_case_params.clone();
+
+    let current_session = get_current_session(&connection);
+    let version_for_upgrade = test_case_params
+        .upgrade_to_version
+        .unwrap_or(UPGRADE_TO_VERSION);
+    let session_for_upgrade =
+        current_session + test_case_params.upgrade_session.unwrap_or(UPGRADE_SESSION);
+    let wait_sessions_after_upgrade = test_case_params
+        .upgrade_finalization_wait_sessions
+        .unwrap_or(UPGRADE_FINALIZATION_WAIT_SESSIONS);
+    let session_after_upgrade = session_for_upgrade + wait_sessions_after_upgrade;
+
+    connection.schedule_upgrade(version_for_upgrade, session_for_upgrade)?;
+
+    wait_for_at_least_session(&connection, session_after_upgrade)?;
+    let block_number = session_after_upgrade * get_session_period(&connection);
+    wait_for_finalized_block(&connection, block_number)?;
+
+    Ok(())
+}

--- a/e2e-tests/src/test/version_upgrade.rs
+++ b/e2e-tests/src/test/version_upgrade.rs
@@ -1,6 +1,6 @@
 use aleph_client::{
-    get_current_session, get_session_period, wait_for_at_least_session, wait_for_finalized_block,
-    VersionUpgrade,
+    get_current_session, get_session_period, schedule_upgrade, wait_for_at_least_session,
+    wait_for_finalized_block,
 };
 use primitives::SessionIndex;
 
@@ -28,7 +28,7 @@ pub fn schedule_version_change(config: &Config) -> anyhow::Result<()> {
         .unwrap_or(UPGRADE_FINALIZATION_WAIT_SESSIONS);
     let session_after_upgrade = session_for_upgrade + wait_sessions_after_upgrade;
 
-    connection.schedule_upgrade(version_for_upgrade, session_for_upgrade)?;
+    schedule_upgrade(&connection, version_for_upgrade, session_for_upgrade)?;
 
     wait_for_at_least_session(&connection, session_after_upgrade)?;
     let block_number = session_after_upgrade * get_session_period(&connection);


### PR DESCRIPTION
# Description

Simple e2e-test for interaction with the new message-compatibility feature. It sets version-upgrade, awaits it, and verify if finalization is ok. WARNING: dummy/fake implementation of version message-compatibiliy should pass this test as well. Next there will be `negative` test verifying if an upgrade, where not enough nodes decides to switch version, will fail.

## Type of change

new e2e-test
