### PR TITLE
Support Marlin system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,6 @@ dependencies = [
 name = "aleph-runtime"
 version = "0.7.0"
 dependencies = [
- "ark-bls12-381",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,19 +317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-ed-on-bls12-381"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b7ada17db3854f5994e74e60b18e10e818594935ee7e1d329800c117b32970"
-dependencies = [
- "ark-bls12-381",
- "ark-ec",
- "ark-ff",
- "ark-r1cs-std",
- "ark-std",
-]
-
-[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +387,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-marlin"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8510faa8e64f0a6841ee4b58efe2d56f7a80d86fa0ce9891bbb3aa20166d9"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-poly-commit",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.9.0",
+ "rand_chacha 0.3.1",
+]
+
+[[package]]
+name = "ark-nonnative-field"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440ad4569974910adbeb84422b7e622b79e08d27142afd113785b7fcfb446186"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-std",
+ "derivative",
+ "num-bigint 0.4.3",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +432,24 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "ark-poly-commit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71ddfa72bad1446cab7bbecb6018dbbdc9abcbc3a0065483ae5186ad2a64dcd"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-nonnative-field",
+ "ark-poly",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.9.0",
+ "tracing",
 ]
 
 [[package]]
@@ -5239,10 +5279,12 @@ dependencies = [
  "ark-bls12-381",
  "ark-crypto-primitives",
  "ark-ec",
- "ark-ed-on-bls12-381",
  "ark-ff",
  "ark-gm17",
  "ark-groth16",
+ "ark-marlin",
+ "ark-poly",
+ "ark-poly-commit",
  "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -11,8 +11,6 @@ license = "GPL-3.0-or-later"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-ark-bls12-381 = { version = "^0.3.0" }
-
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
@@ -74,7 +72,6 @@ substrate-wasm-builder = { git = "https://github.com/Cardinal-Cryptography/subst
 [features]
 default = ["std"]
 std = [
-    "ark-bls12-381/std",
     "codec/std",
     "frame-executive/std",
     "frame-support/std",

--- a/bin/runtime/src/chain_extension/snarcos-extension/lib.rs
+++ b/bin/runtime/src/chain_extension/snarcos-extension/lib.rs
@@ -64,6 +64,7 @@ pub type VerificationKeyIdentifier = [u8; 4];
 pub enum ProvingSystem {
     Groth16,
     Gm17,
+    Marlin,
 }
 
 #[ink::chain_extension]

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -8,7 +8,6 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod chain_extension;
 
-use ark_bls12_381::Bls12_381;
 pub use frame_support::{
     construct_runtime, log, parameter_types,
     traits::{
@@ -326,7 +325,6 @@ parameter_types! {
 
 impl pallet_snarcos::Config for Runtime {
     type Event = Event;
-    type Pairing = Bls12_381;
     type WeightInfo = pallet_snarcos::AlephWeight<Runtime>;
     type MaximumVerificationKeyLength = MaximumVerificationKeyLength;
 }

--- a/pallets/snarcos/Cargo.toml
+++ b/pallets/snarcos/Cargo.toml
@@ -11,20 +11,21 @@ codec = { package = "parity-scale-codec", version = "3.0", default-features = fa
 digest = "0.9"
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 
-ark-ff = { version = "^0.3.0", default-features = false }
+ark-crypto-primitives = { version = "^0.3.0", default-features = false }
 ark-ec = { version = "^0.3.0", default-features = false }
-ark-ed-on-bls12-381 = { version = "^0.3.0", features = ["r1cs"] }
-ark-bls12-381 = { version = "^0.3.0" }
-ark-std = { version = "^0.3.0", default-features = false }
+ark-ff = { version = "^0.3.0", default-features = false }
+ark-poly = { version = "^0.3.0", default-features = false }
+ark-poly-commit = { version = "^0.3.0", default-features = false }
 ark-relations = { version = "^0.3.0", default-features = false }
-
+ark-serialize = { version = "^0.3.0", default-features = false }
+ark-std = { version = "^0.3.0", default-features = false }
 ark-r1cs-std = { version = "^0.3.0", default-features = false }
 ark-snark = { version = "^0.3.0", default-features = false }
+
+ark-bls12-381 = { version = "^0.3.0" }
 ark-groth16 = { version = "^0.3.0", default-features = false }
 ark-gm17 = { version = "^0.3.0", default-features = false }
-
-ark-serialize = { version = "^0.3.0", default-features = false }
-ark-crypto-primitives = { version = "^0.3.0", default-features = false }
+ark-marlin = { version = "^0.3.0", default-features = false }
 
 frame-benchmarking = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.26", optional = true }
 frame-support = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.26" }
@@ -38,17 +39,18 @@ primitives = { path = "../../primitives", default-features = false }
 [features]
 default = ["std"]
 std = [
-    "ark-ff/std",
-    "ark-ec/std",
-    "ark-ed-on-bls12-381/std",
+    "ark-crypto-primitives/std",
     "ark-bls12-381/std",
-    "ark-std/std",
+    "ark-ec/std",
+    "ark-ff/std",
+    "ark-gm17/std",
+    "ark-groth16/std",
+    "ark-poly/std",
+    "ark-poly-commit/std",
     "ark-relations/std",
     "ark-r1cs-std/std",
-    "ark-groth16/std",
-    "ark-gm17/std",
     "ark-serialize/std",
-    "ark-crypto-primitives/std",
+    "ark-std/std",
 
     "blake2/std",
     "codec/std",

--- a/pallets/snarcos/src/lib.rs
+++ b/pallets/snarcos/src/lib.rs
@@ -18,26 +18,17 @@ pub use systems::ProvingSystem;
 
 #[frame_support::pallet]
 pub mod pallet {
-    use ark_ec::PairingEngine;
-    use ark_gm17::GM17;
-    use ark_groth16::Groth16;
     use ark_serialize::CanonicalDeserialize;
-    use ark_snark::SNARK;
     use frame_support::{log, pallet_prelude::*};
     use frame_system::pallet_prelude::OriginFor;
     use sp_std::prelude::Vec;
 
     use super::*;
-
-    /// Pack of helpful type aliases.
-    type Fr<T> = <<T as Config>::Pairing as PairingEngine>::Fr;
-    type VerifyingKey<S, T> = <S as SNARK<Fr<T>>>::VerifyingKey;
-    type Proof<S, T> = <S as SNARK<Fr<T>>>::Proof;
+    use crate::systems::{Gm17, Groth16, VerifyingSystem};
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
         type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
-        type Pairing: PairingEngine;
         type WeightInfo: WeightInfo;
 
         #[pallet::constant]
@@ -166,42 +157,34 @@ pub mod pallet {
             system: ProvingSystem,
         ) -> Result<(), Error<T>> {
             match system {
-                ProvingSystem::Groth16 => Self::_bare_verify::<Groth16<T::Pairing>>(
-                    verification_key_identifier,
-                    proof,
-                    public_input,
-                ),
-                ProvingSystem::Gm17 => Self::_bare_verify::<GM17<T::Pairing>>(
-                    verification_key_identifier,
-                    proof,
-                    public_input,
-                ),
+                ProvingSystem::Groth16 => {
+                    Self::_bare_verify::<Groth16>(verification_key_identifier, proof, public_input)
+                }
+                ProvingSystem::Gm17 => {
+                    Self::_bare_verify::<Gm17>(verification_key_identifier, proof, public_input)
+                }
             }
         }
 
-        fn _bare_verify<S: SNARK<Fr<T>>>(
+        fn _bare_verify<S: VerifyingSystem>(
             verification_key_identifier: VerificationKeyIdentifier,
             proof: Vec<u8>,
             public_input: Vec<u8>,
-        ) -> Result<(), Error<T>>
-        where
-            VerifyingKey<S, T>: CanonicalDeserialize,
-            Proof<S, T>: CanonicalDeserialize,
-        {
-            let proof: Proof<S, T> = CanonicalDeserialize::deserialize(&*proof).map_err(|e| {
+        ) -> Result<(), Error<T>> {
+            let proof: S::Proof = CanonicalDeserialize::deserialize(&*proof).map_err(|e| {
                 log::error!("Deserializing proof failed: {:?}", e);
                 Error::<T>::DeserializingProofFailed
             })?;
 
-            let public_input: Vec<Fr<T>> = CanonicalDeserialize::deserialize(&*public_input)
-                .map_err(|e| {
+            let public_input: Vec<S::CircuitField> =
+                CanonicalDeserialize::deserialize(&*public_input).map_err(|e| {
                     log::error!("Deserializing public input failed: {:?}", e);
                     Error::<T>::DeserializingPublicInputFailed
                 })?;
 
             let verification_key = VerificationKeys::<T>::get(verification_key_identifier)
                 .ok_or(Error::<T>::UnknownVerificationKeyIdentifier)?;
-            let verification_key: VerifyingKey<S, T> =
+            let verification_key: S::VerifyingKey =
                 CanonicalDeserialize::deserialize(&**verification_key).map_err(|e| {
                     log::error!("Deserializing verification key failed: {:?}", e);
                     Error::<T>::DeserializingVerificationKeyFailed

--- a/pallets/snarcos/src/lib.rs
+++ b/pallets/snarcos/src/lib.rs
@@ -24,7 +24,7 @@ pub mod pallet {
     use sp_std::prelude::Vec;
 
     use super::*;
-    use crate::systems::{Gm17, Groth16, VerifyingSystem};
+    use crate::systems::{Gm17, Groth16, Marlin, VerifyingSystem};
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -162,6 +162,9 @@ pub mod pallet {
                 }
                 ProvingSystem::Gm17 => {
                     Self::_bare_verify::<Gm17>(verification_key_identifier, proof, public_input)
+                }
+                ProvingSystem::Marlin => {
+                    Self::_bare_verify::<Marlin>(verification_key_identifier, proof, public_input)
                 }
             }
         }

--- a/pallets/snarcos/src/lib.rs
+++ b/pallets/snarcos/src/lib.rs
@@ -3,10 +3,8 @@
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 mod weights;
-use codec::{Decode, Encode};
 use frame_support::pallet_prelude::StorageVersion;
 pub use pallet::*;
-use scale_info::TypeInfo;
 pub use weights::{AlephWeight, WeightInfo};
 
 /// The current storage version.
@@ -15,11 +13,8 @@ const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 /// We store verification keys under short identifiers.
 pub type VerificationKeyIdentifier = [u8; 4];
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Decode, Encode, TypeInfo)]
-pub enum ProvingSystem {
-    Groth16,
-    Gm17,
-}
+mod systems;
+pub use systems::ProvingSystem;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/snarcos/src/lib.rs
+++ b/pallets/snarcos/src/lib.rs
@@ -193,10 +193,9 @@ pub mod pallet {
                     Error::<T>::DeserializingVerificationKeyFailed
                 })?;
 
-            let valid_proof = S::verify(&verification_key, &public_input, &proof).map_err(|e| {
-                log::error!("Verifying failed: {:?}", e);
-                Error::<T>::VerificationFailed
-            })?;
+            // At some point we should enhance error type from `S::verify` and be more verbose here.
+            let valid_proof = S::verify(&verification_key, &public_input, &proof)
+                .map_err(|_| Error::<T>::VerificationFailed)?;
 
             ensure!(valid_proof, Error::<T>::IncorrectProof);
 

--- a/pallets/snarcos/src/systems.rs
+++ b/pallets/snarcos/src/systems.rs
@@ -1,0 +1,54 @@
+use ark_bls12_381::{Bls12_381, Fr};
+use ark_serialize::CanonicalDeserialize;
+use ark_snark::SNARK;
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use sp_std::vec::Vec;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Decode, Encode, TypeInfo)]
+pub enum ProvingSystem {
+    Groth16,
+    Gm17,
+}
+
+pub(super) trait VerifyingSystem {
+    type CircuitField: CanonicalDeserialize;
+    type Proof: CanonicalDeserialize;
+    type VerifyingKey: CanonicalDeserialize;
+
+    fn verify(
+        key: &Self::VerifyingKey,
+        input: &Vec<Self::CircuitField>,
+        proof: &Self::Proof,
+    ) -> Result<bool, ()>;
+}
+
+pub(super) struct Groth16;
+impl VerifyingSystem for Groth16 {
+    type CircuitField = Fr;
+    type Proof = ark_groth16::Proof<Bls12_381>;
+    type VerifyingKey = ark_groth16::VerifyingKey<Bls12_381>;
+
+    fn verify(
+        key: &Self::VerifyingKey,
+        input: &Vec<Self::CircuitField>,
+        proof: &Self::Proof,
+    ) -> Result<bool, ()> {
+        ark_groth16::Groth16::verify(&key, &input, &proof).map_err(|_| ())
+    }
+}
+
+pub(super) struct Gm17;
+impl VerifyingSystem for Gm17 {
+    type CircuitField = Fr;
+    type Proof = ark_gm17::Proof<Bls12_381>;
+    type VerifyingKey = ark_gm17::VerifyingKey<Bls12_381>;
+
+    fn verify(
+        key: &Self::VerifyingKey,
+        input: &Vec<Self::CircuitField>,
+        proof: &Self::Proof,
+    ) -> Result<bool, ()> {
+        ark_gm17::GM17::verify(&key, &input, &proof).map_err(|_| ())
+    }
+}

--- a/pallets/snarcos/src/systems.rs
+++ b/pallets/snarcos/src/systems.rs
@@ -1,14 +1,17 @@
-use ark_bls12_381::{Bls12_381, Fr};
+use ark_poly::polynomial::univariate::DensePolynomial;
+use ark_poly_commit::marlin_pc::MarlinKZG10;
 use ark_serialize::CanonicalDeserialize;
 use ark_snark::SNARK;
+use ark_std::rand::{prelude::StdRng, SeedableRng};
+use blake2::Blake2s;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
-use sp_std::vec::Vec;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Decode, Encode, TypeInfo)]
 pub enum ProvingSystem {
     Groth16,
     Gm17,
+    Marlin,
 }
 
 pub(super) trait VerifyingSystem {
@@ -18,37 +21,62 @@ pub(super) trait VerifyingSystem {
 
     fn verify(
         key: &Self::VerifyingKey,
-        input: &Vec<Self::CircuitField>,
+        input: &[Self::CircuitField],
         proof: &Self::Proof,
     ) -> Result<bool, ()>;
 }
 
+/// Common pairing engine.
+pub type DefaultPairingEngine = ark_bls12_381::Bls12_381;
+/// Common scalar field.
+pub type DefaultCircuitField = ark_bls12_381::Fr;
+
 pub(super) struct Groth16;
 impl VerifyingSystem for Groth16 {
-    type CircuitField = Fr;
-    type Proof = ark_groth16::Proof<Bls12_381>;
-    type VerifyingKey = ark_groth16::VerifyingKey<Bls12_381>;
+    type CircuitField = DefaultCircuitField;
+    type Proof = ark_groth16::Proof<DefaultPairingEngine>;
+    type VerifyingKey = ark_groth16::VerifyingKey<DefaultPairingEngine>;
 
     fn verify(
         key: &Self::VerifyingKey,
-        input: &Vec<Self::CircuitField>,
+        input: &[Self::CircuitField],
         proof: &Self::Proof,
     ) -> Result<bool, ()> {
-        ark_groth16::Groth16::verify(&key, &input, &proof).map_err(|_| ())
+        ark_groth16::Groth16::verify(key, input, proof).map_err(|_| ())
     }
 }
 
 pub(super) struct Gm17;
 impl VerifyingSystem for Gm17 {
-    type CircuitField = Fr;
-    type Proof = ark_gm17::Proof<Bls12_381>;
-    type VerifyingKey = ark_gm17::VerifyingKey<Bls12_381>;
+    type CircuitField = DefaultCircuitField;
+    type Proof = ark_gm17::Proof<DefaultPairingEngine>;
+    type VerifyingKey = ark_gm17::VerifyingKey<DefaultPairingEngine>;
 
     fn verify(
         key: &Self::VerifyingKey,
-        input: &Vec<Self::CircuitField>,
+        input: &[Self::CircuitField],
         proof: &Self::Proof,
     ) -> Result<bool, ()> {
-        ark_gm17::GM17::verify(&key, &input, &proof).map_err(|_| ())
+        ark_gm17::GM17::verify(key, input, proof).map_err(|_| ())
+    }
+}
+
+type MarlinPolynomialCommitment =
+    MarlinKZG10<DefaultPairingEngine, DensePolynomial<DefaultCircuitField>>;
+
+pub(super) struct Marlin;
+impl VerifyingSystem for Marlin {
+    type CircuitField = DefaultCircuitField;
+    type Proof = ark_marlin::Proof<DefaultCircuitField, MarlinPolynomialCommitment>;
+    type VerifyingKey =
+        ark_marlin::IndexVerifierKey<DefaultCircuitField, MarlinPolynomialCommitment>;
+
+    fn verify(
+        key: &Self::VerifyingKey,
+        input: &[Self::CircuitField],
+        proof: &Self::Proof,
+    ) -> Result<bool, ()> {
+        let mut rng = StdRng::from_seed([0u8; 32]);
+        ark_marlin::Marlin::<_, _, Blake2s>::verify(key, input, proof, &mut rng).map_err(|_| ())
     }
 }


### PR DESCRIPTION
This PR introduces Marlin system to `pallet_snarcos`.

Notes:
 - `PairingEngine` config argument was removed (we use only one BLS curve across codebase and abstracting this at this moment just doesn't make sense)
 - we have to implement `VerifyingSystem` for every system separately, because `ark_marlin::Marlin` doesn't implement `ark_snark::SNARK` (or more generally, there is no common snarkish trait for Groth16, Gm17 and Marlin)