### PR TITLE
A0-1455: Add future protocol and decision process for connection direction

### DIFF
--- a/finality-aleph/src/validator_network/manager/direction.rs
+++ b/finality-aleph/src/validator_network/manager/direction.rs
@@ -1,0 +1,225 @@
+use std::collections::{HashMap, HashSet};
+
+use aleph_primitives::AuthorityId;
+
+use crate::validator_network::Data;
+
+pub struct DirectedPeers<A: Data> {
+    own_id: AuthorityId,
+    outgoing: HashMap<AuthorityId, Vec<A>>,
+    incoming: HashSet<AuthorityId>,
+}
+
+fn bit_xor_sum_parity((a, b): (u8, u8)) -> u8 {
+    let mut result = 0;
+    for i in 0..8 {
+        result += ((a >> i) ^ (b >> i)) % 2;
+    }
+    result % 2
+}
+
+// Whether we shold call the remote or the other way around. We xor the peer ids and based on the
+// parity of the sum of bits of the result decide whether the caller should be the smaller or
+// greated lexicographically. They are never equal, because cryptography.
+fn should_call(own_id: &[u8], remote_id: &[u8]) -> bool {
+    let xor_sum_parity: u8 = own_id
+        .iter()
+        .cloned()
+        .zip(remote_id.iter().cloned())
+        .map(bit_xor_sum_parity)
+        .fold(0u8, |a, b| (a + b) % 2);
+    match xor_sum_parity == 0 {
+        true => own_id < remote_id,
+        false => own_id > remote_id,
+    }
+}
+
+impl<A: Data> DirectedPeers<A> {
+    /// Create a new set of peers directed using our own peer id.
+    pub fn new(own_id: AuthorityId) -> Self {
+        DirectedPeers {
+            own_id,
+            outgoing: HashMap::new(),
+            incoming: HashSet::new(),
+        }
+    }
+
+    /// Add a peer to the list of peers we want to stay connected to, or
+    /// update the list of addresses if the peer was already added.
+    /// Returns whether we should start attampts at connecting with the peer, which is the case
+    /// exactly when the peer is one with which we should attempt connections AND it was added for
+    /// the first time.
+    pub fn add_peer(&mut self, peer_id: AuthorityId, addresses: Vec<A>) -> bool {
+        match should_call(self.own_id.as_ref(), peer_id.as_ref()) {
+            true => self.outgoing.insert(peer_id, addresses).is_none(),
+            false => {
+                // We discard the addresses here, as we will never want to call this peer anyway,
+                // so we don't need them.
+                self.incoming.insert(peer_id);
+                false
+            }
+        }
+    }
+
+    /// Return the addresses of the given peer, or None if we shouldn't attempt connecting with the peer.
+    pub fn peer_addresses(&self, peer_id: &AuthorityId) -> Option<Vec<A>> {
+        self.outgoing.get(peer_id).cloned()
+    }
+
+    /// Whether we should be maintaining a connection with this peer.
+    pub fn interested(&self, peer_id: &AuthorityId) -> bool {
+        self.incoming.contains(peer_id) || self.outgoing.contains_key(peer_id)
+    }
+
+    /// Iterator over the peers we want connections from.
+    pub fn incoming_peers(&self) -> impl Iterator<Item = &AuthorityId> {
+        self.incoming.iter()
+    }
+
+    /// Iterator over the peers we want to connect to.
+    pub fn outgoing_peers(&self) -> impl Iterator<Item = &AuthorityId> {
+        self.outgoing.keys()
+    }
+
+    /// Remove a peer from the list of peers that we want to stay connected with, whether the
+    /// connection was supposed to be incoming or outgoing.
+    pub fn remove_peer(&mut self, peer_id: &AuthorityId) {
+        self.incoming.remove(peer_id);
+        self.outgoing.remove(peer_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aleph_primitives::AuthorityId;
+
+    use super::DirectedPeers;
+    use crate::validator_network::mock::key;
+
+    type Address = String;
+
+    async fn container_with_id() -> (DirectedPeers<Address>, AuthorityId) {
+        let (own_id, _) = key().await;
+        let own_container = DirectedPeers::new(own_id.clone());
+        (own_container, own_id)
+    }
+
+    #[tokio::test]
+    async fn exactly_one_direction_attempts_connections() {
+        let (mut own_container, own_id) = container_with_id().await;
+        let (mut remote_container, remote_id) = container_with_id().await;
+        let addresses = vec![
+            String::from(""),
+            String::from("a/b/c"),
+            String::from("43.43.43.43:43000"),
+        ];
+        assert!(
+            own_container.add_peer(remote_id, addresses.clone())
+                != remote_container.add_peer(own_id, addresses.clone())
+        );
+    }
+
+    async fn container_with_added_connecting_peer() -> (DirectedPeers<Address>, AuthorityId) {
+        let (mut own_container, own_id) = container_with_id().await;
+        let (mut remote_container, remote_id) = container_with_id().await;
+        let addresses = vec![
+            String::from(""),
+            String::from("a/b/c"),
+            String::from("43.43.43.43:43000"),
+        ];
+        match own_container.add_peer(remote_id.clone(), addresses.clone()) {
+            true => (own_container, remote_id),
+            false => {
+                remote_container.add_peer(own_id.clone(), addresses);
+                (remote_container, own_id)
+            }
+        }
+    }
+
+    async fn container_with_added_nonconnecting_peer() -> (DirectedPeers<Address>, AuthorityId) {
+        let (mut own_container, own_id) = container_with_id().await;
+        let (mut remote_container, remote_id) = container_with_id().await;
+        let addresses = vec![
+            String::from(""),
+            String::from("a/b/c"),
+            String::from("43.43.43.43:43000"),
+        ];
+        match own_container.add_peer(remote_id.clone(), addresses.clone()) {
+            false => (own_container, remote_id),
+            true => {
+                remote_container.add_peer(own_id.clone(), addresses);
+                (remote_container, own_id)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn no_connecting_on_readd() {
+        let (mut own_container, remote_id) = container_with_added_connecting_peer().await;
+        let addresses = vec![
+            String::from(""),
+            String::from("a/b/c"),
+            String::from("43.43.43.43:43000"),
+        ];
+        assert!(!own_container.add_peer(remote_id, addresses));
+    }
+
+    #[tokio::test]
+    async fn peer_addresses_when_connecting() {
+        let (own_container, remote_id) = container_with_added_connecting_peer().await;
+        assert!(own_container.peer_addresses(&remote_id).is_some());
+    }
+
+    #[tokio::test]
+    async fn no_peer_addresses_when_nonconnecting() {
+        let (own_container, remote_id) = container_with_added_nonconnecting_peer().await;
+        assert!(own_container.peer_addresses(&remote_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn interested_in_connecting() {
+        let (own_container, remote_id) = container_with_added_connecting_peer().await;
+        assert!(own_container.interested(&remote_id));
+    }
+
+    #[tokio::test]
+    async fn interested_in_nonconnecting() {
+        let (own_container, remote_id) = container_with_added_nonconnecting_peer().await;
+        assert!(own_container.interested(&remote_id));
+    }
+
+    #[tokio::test]
+    async fn uninterested_in_unknown() {
+        let (own_container, _) = container_with_id().await;
+        let (_, remote_id) = container_with_id().await;
+        assert!(!own_container.interested(&remote_id));
+    }
+
+    #[tokio::test]
+    async fn connecting_are_outgoing() {
+        let (own_container, remote_id) = container_with_added_connecting_peer().await;
+        assert_eq!(
+            own_container.outgoing_peers().collect::<Vec<_>>(),
+            vec![&remote_id]
+        );
+        assert_eq!(own_container.incoming_peers().next(), None);
+    }
+
+    #[tokio::test]
+    async fn nonconnecting_are_incoming() {
+        let (own_container, remote_id) = container_with_added_nonconnecting_peer().await;
+        assert_eq!(
+            own_container.incoming_peers().collect::<Vec<_>>(),
+            vec![&remote_id]
+        );
+        assert_eq!(own_container.outgoing_peers().next(), None);
+    }
+
+    #[tokio::test]
+    async fn uninterested_in_removed() {
+        let (mut own_container, remote_id) = container_with_added_connecting_peer().await;
+        assert!(own_container.interested(&remote_id));
+        own_container.remove_peer(&remote_id);
+        assert!(!own_container.interested(&remote_id));
+    }
+}

--- a/finality-aleph/src/validator_network/manager/mod.rs
+++ b/finality-aleph/src/validator_network/manager/mod.rs
@@ -8,6 +8,9 @@ use futures::channel::mpsc;
 
 use crate::{network::PeerId, validator_network::Data};
 
+#[allow(dead_code)]
+mod direction;
+
 /// Error during sending data through the Manager
 #[derive(Debug, PartialEq, Eq)]
 pub enum SendError {

--- a/finality-aleph/src/validator_network/protocols/mod.rs
+++ b/finality-aleph/src/validator_network/protocols/mod.rs
@@ -14,6 +14,8 @@ use crate::{
 mod handshake;
 mod negotiation;
 mod v0;
+#[allow(dead_code)]
+mod v1;
 
 use handshake::HandshakeError;
 pub use negotiation::{protocol, ProtocolNegotiationError};
@@ -24,6 +26,7 @@ pub type Version = u32;
 /// protocol. Remove after it's no longer needed.
 #[derive(PartialEq, Debug, Eq, Clone, Copy)]
 pub enum ConnectionType {
+    New,
     LegacyIncoming,
     LegacyOutgoing,
 }

--- a/finality-aleph/src/validator_network/protocols/v1/mod.rs
+++ b/finality-aleph/src/validator_network/protocols/v1/mod.rs
@@ -103,7 +103,8 @@ pub async fn outgoing<D: Data, S: Splittable>(
 }
 
 /// Performs the incoming handshake, and then manages a connection sending and receiving data.
-/// Exits on parent request, or in case of broken or dead network connection.
+/// Exits on parent request (when the data source is dropped), or in case of broken or dead
+/// network connection.
 pub async fn incoming<D: Data, S: Splittable>(
     stream: S,
     authority_pen: AuthorityPen,

--- a/finality-aleph/src/validator_network/protocols/v1/mod.rs
+++ b/finality-aleph/src/validator_network/protocols/v1/mod.rs
@@ -1,0 +1,446 @@
+use aleph_primitives::AuthorityId;
+use codec::{Decode, Encode};
+use futures::{channel::mpsc, StreamExt};
+use log::{debug, info, trace};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    time::{timeout, Duration},
+};
+
+use crate::{
+    crypto::AuthorityPen,
+    validator_network::{
+        io::{receive_data, send_data},
+        protocols::{
+            handshake::{v0_handshake_incoming, v0_handshake_outgoing},
+            ConnectionType, ProtocolError, ResultForService,
+        },
+        Data, Splittable,
+    },
+};
+
+const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_MISSED_HEARTBEATS: u32 = 4;
+
+#[derive(Debug, Clone, Encode, Decode)]
+enum Message<D: Data> {
+    Data(D),
+    Heartbeat,
+}
+
+async fn sending<D: Data, S: AsyncWrite + Unpin + Send>(
+    mut sender: S,
+    mut data_from_user: mpsc::UnboundedReceiver<D>,
+) -> Result<(), ProtocolError> {
+    use Message::*;
+    loop {
+        let to_send = match timeout(HEARTBEAT_TIMEOUT, data_from_user.next()).await {
+            Ok(maybe_data) => match maybe_data {
+                Some(data) => Data(data),
+                // We have been closed by the parent service, all good.
+                None => return Ok(()),
+            },
+            _ => Heartbeat,
+        };
+        sender = send_data(sender, to_send).await?;
+    }
+}
+
+async fn receiving<D: Data, S: AsyncRead + Unpin + Send>(
+    mut stream: S,
+    data_for_user: mpsc::UnboundedSender<D>,
+) -> Result<(), ProtocolError> {
+    use Message::*;
+    loop {
+        let (old_stream, message) = timeout(
+            MAX_MISSED_HEARTBEATS * HEARTBEAT_TIMEOUT,
+            receive_data(stream),
+        )
+        .await
+        .map_err(|_| ProtocolError::CardiacArrest)??;
+        stream = old_stream;
+        match message {
+            Data(data) => data_for_user
+                .unbounded_send(data)
+                .map_err(|_| ProtocolError::NoUserConnection)?,
+            Heartbeat => (),
+        }
+    }
+}
+
+async fn manage_connection<D: Data, S: AsyncWrite + Unpin + Send, R: AsyncRead + Unpin + Send>(
+    sender: S,
+    receiver: R,
+    data_from_user: mpsc::UnboundedReceiver<D>,
+    data_for_user: mpsc::UnboundedSender<D>,
+) -> Result<(), ProtocolError> {
+    let sending = sending(sender, data_from_user);
+    let receiving = receiving(receiver, data_for_user);
+    tokio::select! {
+        result = receiving => result,
+        result = sending => result,
+    }
+}
+
+/// Performs the outgoing handshake, and then manages a connection sending and receiving data.
+/// Exits on parent request, or in case of broken or dead network connection.
+pub async fn outgoing<D: Data, S: Splittable>(
+    stream: S,
+    authority_pen: AuthorityPen,
+    peer_id: AuthorityId,
+    result_for_parent: mpsc::UnboundedSender<ResultForService<D>>,
+    data_for_user: mpsc::UnboundedSender<D>,
+) -> Result<(), ProtocolError> {
+    trace!(target: "validator-network", "Extending hand to {}.", peer_id);
+    let (sender, receiver) = v0_handshake_outgoing(stream, authority_pen, peer_id.clone()).await?;
+    info!(target: "validator-network", "Outgoing handshake with {} finished successfully.", peer_id);
+    let (data_for_network, data_from_user) = mpsc::unbounded();
+    result_for_parent
+        .unbounded_send((peer_id.clone(), Some(data_for_network), ConnectionType::New))
+        .map_err(|_| ProtocolError::NoParentConnection)?;
+    debug!(target: "validator-network", "Starting worker for communicating with {}.", peer_id);
+    manage_connection(sender, receiver, data_from_user, data_for_user).await
+}
+
+/// Performs the incoming handshake, and then manages a connection sending and receiving data.
+/// Exits on parent request, or in case of broken or dead network connection.
+pub async fn incoming<D: Data, S: Splittable>(
+    stream: S,
+    authority_pen: AuthorityPen,
+    result_for_parent: mpsc::UnboundedSender<ResultForService<D>>,
+    data_for_user: mpsc::UnboundedSender<D>,
+) -> Result<(), ProtocolError> {
+    trace!(target: "validator-network", "Waiting for extended hand...");
+    let (sender, receiver, peer_id) = v0_handshake_incoming(stream, authority_pen).await?;
+    info!(target: "validator-network", "Incoming handshake with {} finished successfully.", peer_id);
+    let (data_for_network, data_from_user) = mpsc::unbounded();
+    result_for_parent
+        .unbounded_send((peer_id.clone(), Some(data_for_network), ConnectionType::New))
+        .map_err(|_| ProtocolError::NoParentConnection)?;
+    debug!(target: "validator-network", "Starting worker for communicating with {}.", peer_id);
+    manage_connection(sender, receiver, data_from_user, data_for_user).await
+}
+
+#[cfg(test)]
+mod tests {
+    use aleph_primitives::AuthorityId;
+    use futures::{
+        channel::{mpsc, mpsc::UnboundedReceiver},
+        pin_mut, FutureExt, StreamExt,
+    };
+
+    use super::{incoming, outgoing, ProtocolError};
+    use crate::{
+        crypto::AuthorityPen,
+        validator_network::{
+            mock::{key, MockSplittable},
+            protocols::{ConnectionType, ResultForService},
+            Data,
+        },
+    };
+
+    async fn prepare<D: Data>() -> (
+        AuthorityId,
+        AuthorityPen,
+        AuthorityId,
+        AuthorityPen,
+        impl futures::Future<Output = Result<(), ProtocolError>>,
+        impl futures::Future<Output = Result<(), ProtocolError>>,
+        UnboundedReceiver<D>,
+        UnboundedReceiver<D>,
+        UnboundedReceiver<ResultForService<D>>,
+        UnboundedReceiver<ResultForService<D>>,
+    ) {
+        let (stream_incoming, stream_outgoing) = MockSplittable::new(4096);
+        let (id_incoming, pen_incoming) = key().await;
+        let (id_outgoing, pen_outgoing) = key().await;
+        assert_ne!(id_incoming, id_outgoing);
+        let (incoming_result_for_service, result_from_incoming) = mpsc::unbounded();
+        let (outgoing_result_for_service, result_from_outgoing) = mpsc::unbounded();
+        let (incoming_data_for_user, data_from_incoming) = mpsc::unbounded::<D>();
+        let (outgoing_data_for_user, data_from_outgoing) = mpsc::unbounded::<D>();
+        let incoming_handle = incoming(
+            stream_incoming,
+            pen_incoming.clone(),
+            incoming_result_for_service,
+            incoming_data_for_user,
+        );
+        let outgoing_handle = outgoing(
+            stream_outgoing,
+            pen_outgoing.clone(),
+            id_incoming.clone(),
+            outgoing_result_for_service,
+            outgoing_data_for_user,
+        );
+        (
+            id_incoming,
+            pen_incoming,
+            id_outgoing,
+            pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            data_from_incoming,
+            data_from_outgoing,
+            result_from_incoming,
+            result_from_outgoing,
+        )
+    }
+
+    #[tokio::test]
+    async fn send_data() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            mut data_from_incoming,
+            mut data_from_outgoing,
+            mut result_from_incoming,
+            mut result_from_outgoing,
+        ) = prepare::<Vec<i32>>().await;
+        let incoming_handle = incoming_handle.fuse();
+        let outgoing_handle = outgoing_handle.fuse();
+        pin_mut!(incoming_handle);
+        pin_mut!(outgoing_handle);
+        let _data_for_outgoing = tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            result = result_from_outgoing.next() => {
+                let (_, maybe_data_for_outgoing, connection_type) = result.expect("the chennel shouldn't be dropped");
+                assert_eq!(connection_type, ConnectionType::New);
+                let data_for_outgoing = maybe_data_for_outgoing.expect("successfully connected");
+                data_for_outgoing
+                    .unbounded_send(vec![4, 3, 43])
+                    .expect("should send");
+                data_for_outgoing
+                    .unbounded_send(vec![2, 1, 3, 7])
+                    .expect("should send");
+                data_for_outgoing
+            },
+        };
+        let _data_for_incoming = tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            result = result_from_incoming.next() => {
+                let (_, maybe_data_for_incoming, connection_type) = result.expect("the chennel shouldn't be dropped");
+                assert_eq!(connection_type, ConnectionType::New);
+                let data_for_incoming = maybe_data_for_incoming.expect("successfully connected");
+                data_for_incoming
+                    .unbounded_send(vec![5, 4, 44])
+                    .expect("should send");
+                data_for_incoming
+                    .unbounded_send(vec![3, 2, 4, 8])
+                    .expect("should send");
+                data_for_incoming
+            },
+        };
+        tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            v = data_from_incoming.next() => {
+                assert_eq!(v, Some(vec![4, 3, 43]));
+            },
+        };
+        tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            v = data_from_incoming.next() => {
+                assert_eq!(v, Some(vec![2, 1, 3, 7]));
+            },
+        };
+        tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            v = data_from_outgoing.next() => {
+                assert_eq!(v, Some(vec![5, 4, 44]));
+            },
+        };
+        tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            v = data_from_outgoing.next() => {
+                assert_eq!(v, Some(vec![3, 2, 4, 8]));
+            },
+        };
+    }
+
+    #[tokio::test]
+    async fn closed_by_parent_service() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_from_outgoing,
+            mut result_from_incoming,
+            _result_from_outgoing,
+        ) = prepare::<Vec<i32>>().await;
+        let incoming_handle = incoming_handle.fuse();
+        let outgoing_handle = outgoing_handle.fuse();
+        pin_mut!(incoming_handle);
+        pin_mut!(outgoing_handle);
+        tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            received = result_from_incoming.next() => {
+                // we drop the data sending channel, thus finishing incoming_handle
+                let (received_id, _, connection_type) = received.expect("the chennel shouldn't be dropped");
+                assert_eq!(connection_type, ConnectionType::New);
+                assert_eq!(received_id, id_outgoing);
+            },
+        };
+        incoming_handle
+            .await
+            .expect("closed manually, should finish with no error");
+    }
+
+    #[tokio::test]
+    async fn parent_service_dead() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_from_outgoing,
+            result_from_incoming,
+            _result_from_outgoing,
+        ) = prepare::<Vec<i32>>().await;
+        std::mem::drop(result_from_incoming);
+        let incoming_handle = incoming_handle.fuse();
+        let outgoing_handle = outgoing_handle.fuse();
+        pin_mut!(incoming_handle);
+        pin_mut!(outgoing_handle);
+        tokio::select! {
+            e = &mut incoming_handle => match e {
+                Err(ProtocolError::NoParentConnection) => (),
+                Err(e) => panic!("unexpected error: {}", e),
+                Ok(_) => panic!("successfully finished when parent dead"),
+            },
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+        };
+    }
+
+    #[tokio::test]
+    async fn parent_user_dead() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            data_from_incoming,
+            _data_from_outgoing,
+            _result_from_incoming,
+            mut result_from_outgoing,
+        ) = prepare::<Vec<i32>>().await;
+        std::mem::drop(data_from_incoming);
+        let incoming_handle = incoming_handle.fuse();
+        let outgoing_handle = outgoing_handle.fuse();
+        pin_mut!(incoming_handle);
+        pin_mut!(outgoing_handle);
+        let _data_for_outgoing = tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            result = result_from_outgoing.next() => {
+                let (_, maybe_data_for_outgoing, connection_type) = result.expect("the chennel shouldn't be dropped");
+                assert_eq!(connection_type, ConnectionType::New);
+                let data_for_outgoing = maybe_data_for_outgoing.expect("successfully connected");
+                data_for_outgoing
+                    .unbounded_send(vec![2, 1, 3, 7])
+                    .expect("should send");
+                data_for_outgoing
+            },
+        };
+        tokio::select! {
+            e = &mut incoming_handle => match e {
+                Err(ProtocolError::NoUserConnection) => (),
+                Err(e) => panic!("unexpected error: {}", e),
+                Ok(_) => panic!("successfully finished when user dead"),
+            },
+            _ = &mut outgoing_handle => panic!("outgoing process unexpectedly finished"),
+        };
+    }
+
+    #[tokio::test]
+    async fn sender_dead_before_handshake() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_from_outgoing,
+            _result_from_incoming,
+            _result_from_outgoing,
+        ) = prepare::<Vec<i32>>().await;
+        std::mem::drop(outgoing_handle);
+        match incoming_handle.await {
+            Err(ProtocolError::HandshakeError(_)) => (),
+            Err(e) => panic!("unexpected error: {}", e),
+            Ok(_) => panic!("successfully finished when connection dead"),
+        };
+    }
+
+    #[tokio::test]
+    async fn sender_dead_after_handshake() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_from_outgoing,
+            mut result_from_incoming,
+            _result_from_outgoing,
+        ) = prepare::<Vec<i32>>().await;
+        let incoming_handle = incoming_handle.fuse();
+        pin_mut!(incoming_handle);
+        let (_, _exit, connection_type) = tokio::select! {
+            _ = &mut incoming_handle => panic!("incoming process unexpectedly finished"),
+            _ = outgoing_handle => panic!("outgoing process unexpectedly finished"),
+            out = result_from_incoming.next() => out.expect("should receive"),
+        };
+        assert_eq!(connection_type, ConnectionType::New);
+        // outgoing_handle got consumed by tokio::select!, the sender is dead
+        match incoming_handle.await {
+            Err(ProtocolError::ReceiveError(_)) => (),
+            Err(e) => panic!("unexpected error: {}", e),
+            Ok(_) => panic!("successfully finished when connection dead"),
+        };
+    }
+
+    #[tokio::test]
+    async fn receiver_dead_before_handshake() {
+        let (
+            _id_incoming,
+            _pen_incoming,
+            _id_outgoing,
+            _pen_outgoing,
+            incoming_handle,
+            outgoing_handle,
+            _data_from_incoming,
+            _data_from_outgoing,
+            _result_from_incoming,
+            _result_from_outgoing,
+        ) = prepare::<Vec<i32>>().await;
+        std::mem::drop(incoming_handle);
+        match outgoing_handle.await {
+            Err(ProtocolError::HandshakeError(_)) => (),
+            Err(e) => panic!("unexpected error: {}", e),
+            Ok(_) => panic!("successfully finished when connection dead"),
+        };
+    }
+}


### PR DESCRIPTION
# Description

Not used for now, that'll be in the next PR. This is PR 2/3. For more context still see #709 .

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have added tests
- I have made corresponding changes to the existing documentation
- I have created new documentation
