### PR TITLE
List all contracts in excluded packages

### DIFF
--- a/.github/workflows/check-excluded-packages.yml
+++ b/.github/workflows/check-excluded-packages.yml
@@ -72,6 +72,7 @@ jobs:
             pushd "$p"
             cargo fmt --all --check
             cargo clippy --all-features -- --no-deps -D warnings
+            cargo test
             popd
           done
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,13 @@ exclude = [
   "fork-off",
   "benches/payout-stakers",
   "bin/cliain",
-  "contracts",
+  "contracts/access_control",
+  "contracts/button",
+  "contracts/game_token",
+  "contracts/marketplace",
+  "contracts/simple_dex",
+  "contracts/ticket_token",
+  "contracts/wrapped_azero"
 ]
 
 [profile.release]

--- a/contracts/access_control/lib.rs
+++ b/contracts/access_control/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::let_unit_value)]
 
 pub use crate::access_control::{
     AccessControlError, ACCESS_CONTROL_PUBKEY, CHECK_ROLE_SELECTOR, HAS_ROLE_SELECTOR,
@@ -68,7 +69,7 @@ mod access_control {
         pub fn new() -> Self {
             // This call is required in order to correctly initialize the
             // `Mapping`s of our contract.
-            ink_lang::utils::initialize_contract(|contract| Self::new_init(contract))
+            ink_lang::utils::initialize_contract(Self::new_init)
         }
 
         /// Initializes the contract.
@@ -154,6 +155,12 @@ mod access_control {
 
         fn emit_event<EE: EmitEvent<Self>>(emitter: EE, event: Event) {
             emitter.emit_event(event);
+        }
+    }
+
+    impl Default for AccessControl {
+        fn default() -> Self {
+            Self::new()
         }
     }
 

--- a/contracts/button/lib.rs
+++ b/contracts/button/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::let_unit_value)]
 
 mod errors;
 

--- a/contracts/game_token/lib.rs
+++ b/contracts/game_token/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(min_specialization)]
+#![allow(clippy::let_unit_value)]
 
 pub use crate::game_token::{
     ALLOWANCE_SELECTOR, BALANCE_OF_SELECTOR, BURN_SELECTOR, MINT_SELECTOR, TRANSFER_FROM_SELECTOR,

--- a/contracts/marketplace/lib.rs
+++ b/contracts/marketplace/lib.rs
@@ -18,6 +18,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(min_specialization)]
+#![allow(clippy::let_unit_value)]
 
 use ink_lang as ink;
 
@@ -198,7 +199,7 @@ pub mod marketplace {
         /// current price is greater than that.
         #[ink(message)]
         pub fn buy(&mut self, max_price: Option<Balance>) -> Result<(), Error> {
-            if self.ticket_balance()? <= 0 {
+            if self.ticket_balance()? == 0 {
                 return Err(Error::MarketplaceEmpty);
             }
 
@@ -250,7 +251,7 @@ pub mod marketplace {
 
         fn current_price(&self) -> Balance {
             let block = self.env().block_number();
-            let elapsed = block.saturating_sub(self.current_start_block.into());
+            let elapsed = block.saturating_sub(self.current_start_block);
             self.average_price()
                 .saturating_mul(self.sale_multiplier)
                 .saturating_sub(self.per_block_reduction().saturating_mul(elapsed.into()))
@@ -312,7 +313,7 @@ pub mod marketplace {
                 Self::env().caller(),
                 role,
                 |reason| reason.into(),
-                |role| Error::MissingRole(role),
+                Error::MissingRole,
             )
         }
 

--- a/contracts/simple_dex/Cargo.lock
+++ b/contracts/simple_dex/Cargo.lock
@@ -521,6 +521,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "obce"
+version = "0.1.0"
+source = "git+https://github.com/Supercolony-net/obce?branch=polkadot-v0.9.32#163c456e79d2ed084b29e47637f0ec9fd9ac4376"
+dependencies = [
+ "ink_engine",
+ "ink_env",
+ "ink_lang",
+ "ink_metadata",
+ "ink_prelude",
+ "ink_primitives",
+ "ink_storage",
+ "obce-macro",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "obce-codegen"
+version = "0.1.0"
+source = "git+https://github.com/Supercolony-net/obce?branch=polkadot-v0.9.32#163c456e79d2ed084b29e47637f0ec9fd9ac4376"
+dependencies = [
+ "blake2 0.10.4",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "obce-macro"
+version = "0.1.0"
+source = "git+https://github.com/Supercolony-net/obce?branch=polkadot-v0.9.32#163c456e79d2ed084b29e47637f0ec9fd9ac4376"
+dependencies = [
+ "obce-codegen",
+ "proc-macro2",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,8 +573,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openbrush"
-version = "2.1.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts.git?rev=8a20f95#8a20f951feaf8c6ea72c4bf113bf115bad9f158f"
+version = "2.2.0"
+source = "git+https://github.com/Supercolony-net/openbrush-contracts.git?rev=15e6366#15e63664d87124f4cc0e7ba55b21a71222983677"
 dependencies = [
  "ink_env",
  "ink_lang",
@@ -551,8 +590,8 @@ dependencies = [
 
 [[package]]
 name = "openbrush_contracts"
-version = "2.1.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts.git?rev=8a20f95#8a20f951feaf8c6ea72c4bf113bf115bad9f158f"
+version = "2.2.0"
+source = "git+https://github.com/Supercolony-net/openbrush-contracts.git?rev=15e6366#15e63664d87124f4cc0e7ba55b21a71222983677"
 dependencies = [
  "ink_env",
  "ink_lang",
@@ -561,19 +600,21 @@ dependencies = [
  "ink_primitives",
  "ink_storage",
  "openbrush_lang",
+ "pallet-assets-chain-extension",
  "parity-scale-codec",
  "scale-info",
 ]
 
 [[package]]
 name = "openbrush_lang"
-version = "2.1.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts.git?rev=8a20f95#8a20f951feaf8c6ea72c4bf113bf115bad9f158f"
+version = "2.2.0"
+source = "git+https://github.com/Supercolony-net/openbrush-contracts.git?rev=15e6366#15e63664d87124f4cc0e7ba55b21a71222983677"
 dependencies = [
  "const_format",
  "ink_env",
  "ink_lang",
  "ink_metadata",
+ "ink_prelude",
  "ink_primitives",
  "ink_storage",
  "openbrush_lang_macro",
@@ -584,8 +625,8 @@ dependencies = [
 
 [[package]]
 name = "openbrush_lang_codegen"
-version = "2.1.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts.git?rev=8a20f95#8a20f951feaf8c6ea72c4bf113bf115bad9f158f"
+version = "2.2.0"
+source = "git+https://github.com/Supercolony-net/openbrush-contracts.git?rev=15e6366#15e63664d87124f4cc0e7ba55b21a71222983677"
 dependencies = [
  "blake2 0.9.2",
  "cargo_metadata",
@@ -603,13 +644,26 @@ dependencies = [
 
 [[package]]
 name = "openbrush_lang_macro"
-version = "2.1.0"
-source = "git+https://github.com/Supercolony-net/openbrush-contracts.git?rev=8a20f95#8a20f951feaf8c6ea72c4bf113bf115bad9f158f"
+version = "2.2.0"
+source = "git+https://github.com/Supercolony-net/openbrush-contracts.git?rev=15e6366#15e63664d87124f4cc0e7ba55b21a71222983677"
 dependencies = [
  "openbrush_lang_codegen",
  "proc-macro2",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "pallet-assets-chain-extension"
+version = "0.1.1"
+source = "git+https://github.com/Supercolony-net/pallet-assets-chain-extension#a5a99eca8a37c295b8170321605c8f06906f6aff"
+dependencies = [
+ "ink_metadata",
+ "ink_primitives",
+ "ink_storage",
+ "obce",
+ "parity-scale-codec",
+ "scale-info",
 ]
 
 [[package]]

--- a/contracts/simple_dex/lib.rs
+++ b/contracts/simple_dex/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::let_unit_value)]
 
 use ink_lang as ink;
 
@@ -133,7 +134,7 @@ mod simple_dex {
             );
 
             match role_check {
-                Ok(_) => initialize_contract(|contract| Self::new_init(contract)),
+                Ok(_) => initialize_contract(Self::new_init),
                 Err(why) => panic!("Could not initialize the contract {:?}", why),
             }
         }
@@ -504,6 +505,12 @@ mod simple_dex {
             EE: EmitEvent<SimpleDex>,
         {
             emitter.emit_event(event);
+        }
+    }
+
+    impl Default for SimpleDex {
+        fn default() -> Self {
+            SimpleDex::new()
         }
     }
 }

--- a/contracts/ticket_token/lib.rs
+++ b/contracts/ticket_token/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(min_specialization)]
+#![allow(clippy::let_unit_value)]
 
 pub use crate::ticket_token::{BALANCE_OF_SELECTOR, TRANSFER_FROM_SELECTOR, TRANSFER_SELECTOR};
 

--- a/contracts/wrapped_azero/lib.rs
+++ b/contracts/wrapped_azero/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(min_specialization)]
+#![allow(clippy::let_unit_value)]
 
 pub use crate::wrapped_azero::{
     ALLOWANCE_SELECTOR, BALANCE_OF_SELECTOR, TRANSFER_FROM_SELECTOR, TRANSFER_SELECTOR,


### PR DESCRIPTION
... so that they will be checked on CI.

I noticed that we only have `/contracts` listed as an excluded package. Running cargo commands in that directory makes them execute against `aleph-node` which is pointless. I listed all of the contracts explicitly and added `cargo test`, because we were not running unit tests for excluded packages either. I also fixed all the clippy issues in contracts.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
