### PR TITLE
A0-1574: Remove unnecessary implementations in the substrate network

### DIFF
--- a/finality-aleph/src/network/mock.rs
+++ b/finality-aleph/src/network/mock.rs
@@ -152,7 +152,7 @@ impl<T> Default for Channel<T> {
     }
 }
 
-pub type MockEvent = Event<MockMultiaddress>;
+pub type MockEvent = Event<MockMultiaddress, MockPeerId>;
 
 pub type MockData = Vec<u8>;
 type MessageForUser<D, M> = (NetworkData<D, M>, DataCommand<<M as Multiaddress>::PeerId>);
@@ -183,7 +183,7 @@ impl<M: Multiaddress + 'static> MockIO<M> {
 pub struct MockEventStream(mpsc::UnboundedReceiver<MockEvent>);
 
 #[async_trait]
-impl EventStream<MockMultiaddress> for MockEventStream {
+impl EventStream<MockMultiaddress, MockPeerId> for MockEventStream {
     async fn next_event(&mut self) -> Option<MockEvent> {
         self.0.next().await
     }

--- a/finality-aleph/src/network/mod.rs
+++ b/finality-aleph/src/network/mod.rs
@@ -89,26 +89,26 @@ pub trait NetworkSender: Send + Sync + 'static {
 }
 
 #[derive(Clone)]
-pub enum Event<M: Multiaddress> {
+pub enum Event<M, P> {
     Connected(M),
-    Disconnected(M::PeerId),
-    StreamOpened(M::PeerId, Protocol),
-    StreamClosed(M::PeerId, Protocol),
+    Disconnected(P),
+    StreamOpened(P, Protocol),
+    StreamClosed(P, Protocol),
     Messages(Vec<(Protocol, Bytes)>),
 }
 
 #[async_trait]
-pub trait EventStream<M: Multiaddress> {
-    async fn next_event(&mut self) -> Option<Event<M>>;
+pub trait EventStream<M, P> {
+    async fn next_event(&mut self) -> Option<Event<M, P>>;
 }
 
 /// Abstraction over a network.
 pub trait Network: Clone + Send + Sync + 'static {
     type SenderError: std::error::Error;
     type NetworkSender: NetworkSender;
-    type PeerId: PeerId;
-    type Multiaddress: Multiaddress<PeerId = Self::PeerId>;
-    type EventStream: EventStream<Self::Multiaddress>;
+    type PeerId: Clone + Debug + Eq + Hash + Send;
+    type Multiaddress: Debug + Eq + Hash;
+    type EventStream: EventStream<Self::Multiaddress, Self::PeerId>;
 
     /// Returns a stream of events representing what happens on the network.
     fn event_stream(&self) -> Self::EventStream;

--- a/finality-aleph/src/network/service.rs
+++ b/finality-aleph/src/network/service.rs
@@ -187,7 +187,7 @@ impl<
 
     fn handle_network_event(
         &mut self,
-        event: Event<N::Multiaddress>,
+        event: Event<N::Multiaddress, N::PeerId>,
     ) -> Result<(), mpsc::TrySendError<NetworkData<D, A>>> {
         use Event::*;
         match event {

--- a/finality-aleph/src/substrate_network.rs
+++ b/finality-aleph/src/substrate_network.rs
@@ -17,8 +17,7 @@ use sp_consensus::SyncOracle;
 use sp_runtime::traits::Block;
 
 use crate::network::{
-    Event, EventStream, Multiaddress as MultiaddressT, Network, NetworkSender,
-    PeerId as PeerIdT, Protocol, RequestBlocks,
+    Event, EventStream, Network, NetworkSender, Protocol, RequestBlocks,
 };
 
 impl<B: Block, H: ExHashT> RequestBlocks<B> for Arc<NetworkService<B, H>> {
@@ -80,19 +79,6 @@ impl fmt::Display for PeerId {
     }
 }
 
-impl PeerIdT for PeerId {}
-
-fn peer_id(protocol: &MultiaddressProtocol<'_>) -> Option<PeerId> {
-    match protocol {
-        MultiaddressProtocol::P2p(hashed_peer_id) => {
-            SubstratePeerId::from_multihash(*hashed_peer_id)
-                .ok()
-                .map(PeerId)
-        }
-        _ => None,
-    }
-}
-
 /// A wrapper for the Substrate multiaddress to allow encoding & decoding.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Multiaddress(Multiaddr);
@@ -121,66 +107,6 @@ impl Decode for Multiaddress {
         Multiaddr::try_from(bytes)
             .map_err(|_| "Multiaddr not encoded as bytes".into())
             .map(|multiaddr| multiaddr.into())
-    }
-}
-
-enum CommonPeerId {
-    Unknown,
-    Unique(PeerId),
-    NotUnique,
-}
-
-impl From<CommonPeerId> for Option<PeerId> {
-    fn from(cpi: CommonPeerId) -> Self {
-        use CommonPeerId::*;
-        match cpi {
-            Unique(peer_id) => Some(peer_id),
-            Unknown | NotUnique => None,
-        }
-    }
-}
-
-impl CommonPeerId {
-    fn aggregate(self, peer_id: PeerId) -> Self {
-        use CommonPeerId::*;
-        match self {
-            Unknown => Unique(peer_id),
-            Unique(current_peer_id) => match peer_id == current_peer_id {
-                true => Unique(current_peer_id),
-                false => NotUnique,
-            },
-            NotUnique => NotUnique,
-        }
-    }
-}
-
-impl MultiaddressT for Multiaddress {
-    type PeerId = PeerId;
-
-    fn get_peer_id(&self) -> Option<Self::PeerId> {
-        self.0
-            .iter()
-            .fold(
-                CommonPeerId::Unknown,
-                |common_peer_id, protocol| match peer_id(&protocol) {
-                    Some(peer_id) => common_peer_id.aggregate(peer_id),
-                    None => common_peer_id,
-                },
-            )
-            .into()
-    }
-
-    fn add_matching_peer_id(mut self, peer_id: Self::PeerId) -> Option<Self> {
-        match self.get_peer_id() {
-            Some(peer) => match peer == peer_id {
-                true => Some(self),
-                false => None,
-            },
-            None => {
-                self.0.push(MultiaddressProtocol::P2p(peer_id.0.into()));
-                Some(self)
-            }
-        }
     }
 }
 
@@ -267,8 +193,8 @@ impl NetworkSender for SubstrateNetworkSender {
 type NetworkEventStream = Pin<Box<dyn Stream<Item = SubstrateEvent> + Send>>;
 
 #[async_trait]
-impl EventStream<Multiaddress> for NetworkEventStream {
-    async fn next_event(&mut self) -> Option<Event<Multiaddress>> {
+impl EventStream<Multiaddress, PeerId> for NetworkEventStream {
+    async fn next_event(&mut self) -> Option<Event<Multiaddress, PeerId>> {
         use Event::*;
         use SubstrateEvent::*;
         loop {
@@ -364,64 +290,9 @@ mod tests {
     use codec::{Decode, Encode};
 
     use super::Multiaddress;
-    use crate::network::Multiaddress as _;
 
     fn address(text: &str) -> Multiaddress {
         Multiaddress(text.parse().unwrap())
-    }
-
-    #[test]
-    fn non_p2p_addresses_are_not_p2p() {
-        assert!(address("/dns4/example.com/udt/sctp/5678")
-            .get_peer_id()
-            .is_none());
-    }
-
-    #[test]
-    fn p2p_addresses_are_p2p() {
-        assert!(address(
-            "/dns4/example.com/tcp/30333/p2p/12D3KooWRkGLz4YbVmrsWK75VjFTs8NvaBu42xhAmQaP4KeJpw1L"
-        )
-        .get_peer_id()
-        .is_some());
-    }
-
-    #[test]
-    fn non_p2p_address_matches_peer_id() {
-        let address = address(
-            "/dns4/example.com/tcp/30333/p2p/12D3KooWRkGLz4YbVmrsWK75VjFTs8NvaBu42xhAmQaP4KeJpw1L",
-        );
-        let peer_id = address.get_peer_id().unwrap();
-        let mut peerless_address = address.clone().0;
-        peerless_address.pop();
-        let peerless_address = Multiaddress(peerless_address);
-        assert!(peerless_address.get_peer_id().is_none());
-        assert_eq!(
-            peerless_address.add_matching_peer_id(peer_id),
-            Some(address),
-        );
-    }
-
-    #[test]
-    fn p2p_address_matches_own_peer_id() {
-        let address = address(
-            "/dns4/example.com/tcp/30333/p2p/12D3KooWRkGLz4YbVmrsWK75VjFTs8NvaBu42xhAmQaP4KeJpw1L",
-        );
-        let peer_id = address.get_peer_id().unwrap();
-        let expected_address = address.clone();
-        assert_eq!(
-            address.add_matching_peer_id(peer_id),
-            Some(expected_address),
-        );
-    }
-
-    #[test]
-    fn p2p_address_does_not_match_other_peer_id() {
-        let nonmatching_address = address(
-            "/dns4/example.com/tcp/30333/p2p/12D3KooWRkGLz4YbVmrsWK75VjFTs8NvaBu42xhAmQaP4KeJpw1L",
-        );
-        let peer_id = address("/dns4/peer.example.com/tcp/30333/p2p/12D3KooWFVXnvJdPuGnGYMPn5qLQAQYwmRBgo6SmEQsKZSrDoo2k").get_peer_id().unwrap();
-        assert!(nonmatching_address.add_matching_peer_id(peer_id).is_none());
     }
 
     #[test]

--- a/finality-aleph/src/substrate_network.rs
+++ b/finality-aleph/src/substrate_network.rs
@@ -7,7 +7,7 @@ use log::error;
 use sc_consensus::JustificationSyncLink;
 use sc_network::{
     multiaddr::Protocol as MultiaddressProtocol, Event as SubstrateEvent, ExHashT, Multiaddr,
-    NetworkService, NetworkStateInfo, NetworkSyncForkRequest, PeerId as SubstratePeerId,
+    NetworkService, NetworkSyncForkRequest, PeerId as SubstratePeerId,
 };
 use sc_network_common::service::{
     NetworkEventStream as _, NetworkNotification, NetworkPeers, NotificationSender,
@@ -17,7 +17,7 @@ use sp_consensus::SyncOracle;
 use sp_runtime::traits::Block;
 
 use crate::network::{
-    Event, EventStream, Multiaddress as MultiaddressT, Network, NetworkIdentity, NetworkSender,
+    Event, EventStream, Multiaddress as MultiaddressT, Network, NetworkSender,
     PeerId as PeerIdT, Protocol, RequestBlocks,
 };
 
@@ -356,21 +356,6 @@ impl<B: Block, H: ExHashT> Network for Arc<NetworkService<B, H>> {
     fn remove_reserved(&self, peers: HashSet<Self::PeerId>, protocol: Protocol) {
         let addresses = peers.into_iter().map(|peer_id| peer_id.0).collect();
         self.remove_peers_from_reserved_set(protocol_name(&protocol), addresses);
-    }
-}
-
-impl<B: Block, H: ExHashT> NetworkIdentity for Arc<NetworkService<B, H>> {
-    type PeerId = PeerId;
-    type Multiaddress = Multiaddress;
-
-    fn identity(&self) -> (Vec<Self::Multiaddress>, Self::PeerId) {
-        (
-            self.external_addresses()
-                .into_iter()
-                .map(|address| address.into())
-                .collect(),
-            self.local_peer_id().into(),
-        )
     }
 }
 

--- a/finality-aleph/src/substrate_network.rs
+++ b/finality-aleph/src/substrate_network.rs
@@ -1,13 +1,12 @@
 use std::{borrow::Cow, collections::HashSet, fmt, iter, pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
-use codec::{Decode, Encode};
 use futures::stream::{Stream, StreamExt};
 use log::error;
 use sc_consensus::JustificationSyncLink;
 use sc_network::{
     multiaddr::Protocol as MultiaddressProtocol, Event as SubstrateEvent, ExHashT, Multiaddr,
-    NetworkService, NetworkSyncForkRequest, PeerId as SubstratePeerId,
+    NetworkService, NetworkSyncForkRequest, PeerId,
 };
 use sc_network_common::service::{
     NetworkEventStream as _, NetworkNotification, NetworkPeers, NotificationSender,
@@ -16,9 +15,7 @@ use sp_api::NumberFor;
 use sp_consensus::SyncOracle;
 use sp_runtime::traits::Block;
 
-use crate::network::{
-    Event, EventStream, Network, NetworkSender, Protocol, RequestBlocks,
-};
+use crate::network::{Event, EventStream, Network, NetworkSender, Protocol, RequestBlocks};
 
 impl<B: Block, H: ExHashT> RequestBlocks<B> for Arc<NetworkService<B, H>> {
     fn request_justification(&self, hash: &B::Hash, number: NumberFor<B>) {
@@ -40,73 +37,6 @@ impl<B: Block, H: ExHashT> RequestBlocks<B> for Arc<NetworkService<B, H>> {
 
     fn is_major_syncing(&self) -> bool {
         NetworkService::is_major_syncing(self)
-    }
-}
-
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
-pub struct PeerId(SubstratePeerId);
-
-impl From<PeerId> for SubstratePeerId {
-    fn from(wrapper: PeerId) -> Self {
-        wrapper.0
-    }
-}
-
-impl From<SubstratePeerId> for PeerId {
-    fn from(id: SubstratePeerId) -> Self {
-        PeerId(id)
-    }
-}
-
-impl Encode for PeerId {
-    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-        self.0.to_bytes().using_encoded(f)
-    }
-}
-
-impl Decode for PeerId {
-    fn decode<I: codec::Input>(value: &mut I) -> Result<Self, codec::Error> {
-        let bytes = Vec::<u8>::decode(value)?;
-        SubstratePeerId::from_bytes(&bytes)
-            .map_err(|_| "PeerId not encoded with to_bytes".into())
-            .map(|pid| pid.into())
-    }
-}
-
-impl fmt::Display for PeerId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// A wrapper for the Substrate multiaddress to allow encoding & decoding.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct Multiaddress(Multiaddr);
-
-impl From<Multiaddr> for Multiaddress {
-    fn from(addr: Multiaddr) -> Self {
-        Multiaddress(addr)
-    }
-}
-
-impl From<Multiaddress> for Multiaddr {
-    fn from(addr: Multiaddress) -> Self {
-        addr.0
-    }
-}
-
-impl Encode for Multiaddress {
-    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-        self.0.to_vec().using_encoded(f)
-    }
-}
-
-impl Decode for Multiaddress {
-    fn decode<I: codec::Input>(value: &mut I) -> Result<Self, codec::Error> {
-        let bytes = Vec::<u8>::decode(value)?;
-        Multiaddr::try_from(bytes)
-            .map_err(|_| "Multiaddr not encoded as bytes".into())
-            .map(|multiaddr| multiaddr.into())
     }
 }
 
@@ -193,28 +123,28 @@ impl NetworkSender for SubstrateNetworkSender {
 type NetworkEventStream = Pin<Box<dyn Stream<Item = SubstrateEvent> + Send>>;
 
 #[async_trait]
-impl EventStream<Multiaddress, PeerId> for NetworkEventStream {
-    async fn next_event(&mut self) -> Option<Event<Multiaddress, PeerId>> {
+impl EventStream<Multiaddr, PeerId> for NetworkEventStream {
+    async fn next_event(&mut self) -> Option<Event<Multiaddr, PeerId>> {
         use Event::*;
         use SubstrateEvent::*;
         loop {
             match self.next().await {
                 Some(event) => match event {
                     SyncConnected { remote } => {
-                        return Some(Connected(Multiaddress(
+                        return Some(Connected(
                             iter::once(MultiaddressProtocol::P2p(remote.into())).collect(),
-                        )))
+                        ))
                     }
-                    SyncDisconnected { remote } => return Some(Disconnected(remote.into())),
+                    SyncDisconnected { remote } => return Some(Disconnected(remote)),
                     NotificationStreamOpened {
                         remote, protocol, ..
                     } => match to_protocol(protocol.as_ref()) {
-                        Ok(protocol) => return Some(StreamOpened(remote.into(), protocol)),
+                        Ok(protocol) => return Some(StreamOpened(remote, protocol)),
                         Err(_) => continue,
                     },
                     NotificationStreamClosed { remote, protocol } => {
                         match to_protocol(protocol.as_ref()) {
-                            Ok(protocol) => return Some(StreamClosed(remote.into(), protocol)),
+                            Ok(protocol) => return Some(StreamClosed(remote, protocol)),
                             Err(_) => continue,
                         }
                     }
@@ -245,7 +175,7 @@ impl<B: Block, H: ExHashT> Network for Arc<NetworkService<B, H>> {
     type SenderError = SenderError;
     type NetworkSender = SubstrateNetworkSender;
     type PeerId = PeerId;
-    type Multiaddress = Multiaddress;
+    type Multiaddress = Multiaddr;
     type EventStream = NetworkEventStream;
 
     fn event_stream(&self) -> Self::EventStream {
@@ -261,48 +191,22 @@ impl<B: Block, H: ExHashT> Network for Arc<NetworkService<B, H>> {
             // Currently method `notification_sender` does not distinguish whether we are not connected to the peer
             // or there is no such protocol so we need to have this worthless `SenderError::CannotCreateSender` error here
             notification_sender: self
-                .notification_sender(peer_id.into(), protocol_name(&protocol))
+                .notification_sender(peer_id, protocol_name(&protocol))
                 .map_err(|_| SenderError::CannotCreateSender(peer_id, protocol))?,
             peer_id,
         })
     }
 
     fn add_reserved(&self, addresses: HashSet<Self::Multiaddress>, protocol: Protocol) {
-        if let Err(e) = self.add_peers_to_reserved_set(
-            protocol_name(&protocol),
-            addresses
-                .into_iter()
-                .map(|address| address.into())
-                .collect(),
-        ) {
+        if let Err(e) = self
+            .add_peers_to_reserved_set(protocol_name(&protocol), addresses.into_iter().collect())
+        {
             error!(target: "aleph-network", "add_reserved failed: {}", e);
         }
     }
 
     fn remove_reserved(&self, peers: HashSet<Self::PeerId>, protocol: Protocol) {
-        let addresses = peers.into_iter().map(|peer_id| peer_id.0).collect();
+        let addresses = peers.into_iter().collect();
         self.remove_peers_from_reserved_set(protocol_name(&protocol), addresses);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use codec::{Decode, Encode};
-
-    use super::Multiaddress;
-
-    fn address(text: &str) -> Multiaddress {
-        Multiaddress(text.parse().unwrap())
-    }
-
-    #[test]
-    fn multiaddr_encode_decode() {
-        let multiaddr: Multiaddress = address(
-            "/dns4/example.com/tcp/30333/p2p/12D3KooWRkGLz4YbVmrsWK75VjFTs8NvaBu42xhAmQaP4KeJpw1L",
-        );
-        assert_eq!(
-            Multiaddress::decode(&mut &multiaddr.encode()[..]).unwrap(),
-            multiaddr,
-        );
     }
 }


### PR DESCRIPTION
# Description

Remove all the implementations that were necessary when we used the substrate network for inter-validator communication, but now are superfluous.

## Type of change

# Checklist:
