### PR TITLE
A0-1586: At most one discovery message

### DIFF
--- a/finality-aleph/src/network/manager/service.rs
+++ b/finality-aleph/src/network/manager/service.rs
@@ -196,18 +196,15 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
         &mut self,
         session_id: &SessionId,
     ) -> Option<MessageForNetwork<D, NI::Multiaddress>> {
-        self.sessions
-            .get_mut(session_id)
-            .map(
-                |Session {
-                     handler, discovery, ..
-                 }| {
-                    discovery
-                        .discover_authorities(handler)
-                        .map(Self::network_message)
-                },
-            )
-            .flatten()
+        self.sessions.get_mut(session_id).and_then(
+            |Session {
+                 handler, discovery, ..
+             }| {
+                discovery
+                    .discover_authorities(handler)
+                    .map(Self::network_message)
+            },
+        )
     }
 
     /// Returns all the network messages that should be sent as part of discovery at this moment.


### PR DESCRIPTION
# Description

We always send at most one discovery message at a time in many places, so make that official by making them a `Option` instead of `Vec`.

## Type of change

# Checklist:

- I have made corresponding changes to the existing documentation
