### PR TITLE
Remove `only_owner` access modifier from `register_new_tokens`

### DIFF
--- a/contracts/blender/src/contract.rs
+++ b/contracts/blender/src/contract.rs
@@ -55,6 +55,13 @@ mod blender {
         new_note: Note,
     }
 
+    #[ink(event)]
+    pub struct TokenRegistered {
+        #[ink(topic)]
+        token_id: TokenId,
+        token_address: AccountId,
+    }
+
     type Result<T> = core::result::Result<T, BlenderError>;
     type Event = <Blender as ContractEventBase>::Type;
 
@@ -245,11 +252,19 @@ mod blender {
             token_id: TokenId,
             token_address: AccountId,
         ) -> Result<()> {
-            self.registered_tokens
+            let _ = self.registered_tokens
                 .contains(token_id)
                 .not()
                 .then(|| self.registered_tokens.insert(token_id, &token_address))
-                .ok_or(BlenderError::TokenIdAlreadyRegistered)
+                .ok_or(BlenderError::TokenIdAlreadyRegistered)?;
+            Self::emit_event(
+                self.env(),
+                Event::TokenRegistered(TokenRegistered {
+                    token_id,
+                    token_address,
+                }),
+            );
+            Ok(())
         }
     }
 

--- a/contracts/blender/src/contract.rs
+++ b/contracts/blender/src/contract.rs
@@ -240,7 +240,6 @@ mod blender {
         ///
         /// For owner use only.
         #[ink(message, selector = 10)]
-        #[modifiers(only_owner)]
         pub fn register_new_token(
             &mut self,
             token_id: TokenId,

--- a/contracts/blender/src/contract.rs
+++ b/contracts/blender/src/contract.rs
@@ -128,7 +128,7 @@ mod blender {
             proof: Vec<u8>,
         ) -> Result<()> {
             self.acquire_deposit(token_id, value)?;
-            // self.verify_deposit(token_id, value, note, proof)?;
+            self.verify_deposit(token_id, value, note, proof)?;
 
             self.create_new_leaf(note)?;
             self.merkle_roots.insert(self.current_root(), &());

--- a/contracts/blender/src/contract.rs
+++ b/contracts/blender/src/contract.rs
@@ -252,7 +252,8 @@ mod blender {
             token_id: TokenId,
             token_address: AccountId,
         ) -> Result<()> {
-            let _ = self.registered_tokens
+            let _ = self
+                .registered_tokens
                 .contains(token_id)
                 .not()
                 .then(|| self.registered_tokens.insert(token_id, &token_address))

--- a/pallets/snarcos/src/lib.rs
+++ b/pallets/snarcos/src/lib.rs
@@ -142,10 +142,11 @@ pub mod pallet {
                 key.len() <= T::MaximumVerificationKeyLength::get() as usize,
                 Error::<T>::VerificationKeyTooLong
             );
-            ensure!(
-                !VerificationKeys::<T>::contains_key(identifier),
-                Error::<T>::IdentifierAlreadyInUse
-            );
+            // NOTE: disabled for hackathon
+            // ensure!(
+            //     !VerificationKeys::<T>::contains_key(identifier),
+            //     Error::<T>::IdentifierAlreadyInUse
+            // );
 
             VerificationKeys::<T>::insert(
                 identifier,


### PR DESCRIPTION
Remove `#[modifiers(only_owner)]` from `register_new_tokens` so that anyone can do it.