### PR TITLE
network delay

### DIFF
--- a/docker/Dockerfile.network_tests
+++ b/docker/Dockerfile.network_tests
@@ -1,0 +1,6 @@
+FROM aleph-node:latest
+
+RUN apt update && \
+        apt install curl iproute2 iputils-ping net-tools netwox tcpdump gdb -y && \
+        apt clean && \
+        rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.network_tests
+++ b/docker/Dockerfile.network_tests
@@ -1,6 +1,5 @@
 FROM aleph-node:latest
 
 RUN apt update && \
-        apt install curl iproute2 iputils-ping net-tools netwox tcpdump gdb -y && \
-        apt clean && \
-        rm -rf /var/lib/apt/lists/*
+        apt install curl iproute2 iputils-ping net-tools netwox tcpdump gdb gdbserver -y && \
+        apt clean

--- a/docker/docker-compose.network_test.yml
+++ b/docker/docker-compose.network_test.yml
@@ -1,0 +1,45 @@
+services:
+  Node0:
+    image: aleph-node:network_tests
+    networks:
+      - main
+    environment:
+      - PURGE_BEFORE_START=false
+    cap_add:
+      - NET_ADMIN
+
+  Node1:
+    image: aleph-node:network_tests
+    networks:
+      - main
+    environment:
+      - PURGE_BEFORE_START=false
+    cap_add:
+      - NET_ADMIN
+
+  Node2:
+    image: aleph-node:network_tests
+    networks:
+      - main
+    environment:
+      - PURGE_BEFORE_START=false
+    cap_add:
+      - NET_ADMIN
+
+  Node3:
+    image: aleph-node:network_tests
+    networks:
+      - main
+    environment:
+      - PURGE_BEFORE_START=false
+    cap_add:
+      - NET_ADMIN
+
+  Node4:
+    image: aleph-node:network_tests
+    networks:
+      - main
+    environment:
+      - PURGE_BEFORE_START=false
+    cap_add:
+      - NET_ADMIN

--- a/docker/docker-compose.network_tests.yml
+++ b/docker/docker-compose.network_tests.yml
@@ -7,6 +7,7 @@ services:
       - PURGE_BEFORE_START=false
     cap_add:
       - NET_ADMIN
+      - SYS_PTRACE
 
   Node1:
     image: aleph-node:network_tests
@@ -16,6 +17,7 @@ services:
       - PURGE_BEFORE_START=false
     cap_add:
       - NET_ADMIN
+      - SYS_PTRACE
 
   Node2:
     image: aleph-node:network_tests
@@ -25,6 +27,7 @@ services:
       - PURGE_BEFORE_START=false
     cap_add:
       - NET_ADMIN
+      - SYS_PTRACE
 
   Node3:
     image: aleph-node:network_tests
@@ -34,6 +37,7 @@ services:
       - PURGE_BEFORE_START=false
     cap_add:
       - NET_ADMIN
+      - SYS_PTRACE
 
   Node4:
     image: aleph-node:network_tests
@@ -43,3 +47,4 @@ services:
       - PURGE_BEFORE_START=false
     cap_add:
       - NET_ADMIN
+      - SYS_PTRACE

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,72 @@
+#!/bin/env bash
+
+function log() {
+    echo $1 1>&2
+}
+
+function into_array() {
+    result=()
+    local tmp=$IFS
+    IFS=:
+    for e in $1; do
+        result+=($e)
+    done
+    IFS=$tmp
+}
+
+function check_finalization {
+    local block_to_check=$1
+    local -n nodes=$2
+    local -n ports=$3
+
+    log "checking finalization for block $block_to_check"
+
+    for i in "${!nodes[@]}"; do
+        local node=${nodes[$i]}
+        local rpc_port=${ports[$i]}
+
+        log "checking finalization at node $node"
+        wait_for_finalized_block $block_to_check $node $rpc_port
+    done
+}
+
+function get_best_finalized {
+    local validator=$1
+    local rpc_port=$2
+
+    local best_finalized=$(VALIDATOR=$validator RPC_HOST="127.0.0.1" RPC_PORT=$rpc_port ./.github/scripts/check_finalization.sh | sed 's/Last finalized block number: "\(.*\)"/\1/')
+    printf "%d" $best_finalized
+}
+
+function wait_for_finalized_block() {
+    local block_to_be_finalized=$1
+    local node=$2
+    local port=$3
+
+    while [[ $(get_best_finalized $node $port) -le $block_to_be_finalized ]]; do
+        sleep 3
+    done
+}
+
+function wait_for_block {
+    local block=$1
+    local validator=$2
+    local rpc_port=$3
+
+    local last_block=""
+    while [[ -z "$last_block" ]]; do
+        last_block=$(docker run --rm --network container:$validator appropriate/curl:latest \
+                            -H "Content-Type: application/json" \
+                            -d '{"id":1, "jsonrpc":"2.0", "method": "chain_getBlockHash", "params": '$block'}' http://127.0.0.1:$rpc_port | jq '.result')
+    done
+}
+
+function get_last_block {
+    local validator=$1
+    local rpc_port=$2
+
+    local last_block_number=$(docker run --rm --network container:$validator appropriate/curl:latest \
+                                     -H "Content-Type: application/json" \
+                                     -d '{"id":1, "jsonrpc":"2.0", "method": "chain_getBlock"}' http://127.0.0.1:$rpc_port | jq '.result.block.header.number')
+    printf "%d" $last_block_number
+}

--- a/scripts/run_consensus_network_delay.sh
+++ b/scripts/run_consensus_network_delay.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+NETWORK_DELAY=${NETWORK_DELAY:-500}
+BUILD_IMAGE=${BUILD_IMAGE:-true}
+NODES=${NODES:-"Node0:Node1:Node2:Node3:Node4"}
+
+function build_test_image() {
+    docker build -t aleph-node:network_tests -f docker/Dockerfile.network_tests .
+}
+
+function set_network_delay() {
+    local node=$1
+    local delay=$2
+
+    log "setting network delay for node $node"
+    docker exec $node tc qdisc add dev eth1 root netem delay ${delay}ms
+}
+
+function log() {
+    echo "$1" 1>&2
+}
+
+function into_array() {
+    result=()
+    local tmp=$IFS
+    IFS=:
+    for e in $1; do
+        result+=($e)
+    done
+    IFS=$tmp
+}
+
+into_array $NODES
+NODES=(${result[@]})
+
+if [[ "$BUILD_IMAGE" = true ]]; then
+    log "building docker image for network tests"
+    build_test_image
+fi
+
+log "starting network"
+OVERRIDE_DOCKER_COMPOSE=./docker/docker-compose.network_test.yml DOCKER_COMPOSE=./docker/docker-compose.bridged.yml ./.github/scripts/run_consensus.sh 1>&2
+log "network started"
+
+log "setting network delay"
+for node in ${NODES[@]}; do
+    set_network_delay $node $NETWORK_DELAY
+done
+
+log "done"

--- a/scripts/run_consensus_network_delay.sh
+++ b/scripts/run_consensus_network_delay.sh
@@ -41,7 +41,7 @@ if [[ "$BUILD_IMAGE" = true ]]; then
 fi
 
 log "starting network"
-OVERRIDE_DOCKER_COMPOSE=./docker/docker-compose.network_test.yml DOCKER_COMPOSE=./docker/docker-compose.bridged.yml ./.github/scripts/run_consensus.sh 1>&2
+OVERRIDE_DOCKER_COMPOSE=./docker/docker-compose.network_tests.yml DOCKER_COMPOSE=./docker/docker-compose.bridged.yml ./.github/scripts/run_consensus.sh 1>&2
 log "network started"
 
 log "setting network delay"

--- a/scripts/run_consensus_network_delay.sh
+++ b/scripts/run_consensus_network_delay.sh
@@ -101,7 +101,7 @@ done
 
 if [[ $CHECK_BLOCK_FINALIZATION -gt 0 ]]; then
     log "checking finalization"
-    check_finalization $CHECK_BLOCK_FINALIZATION NODES NODES_PORTS
+    check_relative_finalization $CHECK_BLOCK_FINALIZATION NODES NODES_PORTS
     log "finalization checked"
 fi
 


### PR DESCRIPTION
simple bash script for simulating network delay (default is 500ms on each node). 500ms is enough on my machine to create a lot of confusion between nodes. Try setting `NETWORK_DELAY` env variable for your needs.

NOTICE: you might experience problems with docker due to `cap_add` flag in compose configuration. Use sudo or configure docker to allow using it (I am using rootless docker for it https://docs.docker.com/engine/security/rootless/). There is also a chance, that network device on your docker container is named differently (eth0 instead of eth1).