### PR TITLE
[aleph-client]: Add decoders from `Value` into `String` and `Option<T>`.

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "ac-node-api",
  "ac-primitives",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 license = "Apache 2.0"
 

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -1,3 +1,7 @@
+// Needed for the generic `impl TryFrom<ConvertibleValue> for Option<T>`.
+#![feature(auto_traits)]
+#![feature(negative_impls)]
+
 use std::{default::Default, error::Error as StdError, fmt::Debug, thread::sleep, time::Duration};
 
 use ac_primitives::{PlainTip, PlainTipExtrinsicParamsBuilder, SubstrateDefaultSignedExtra};


### PR DESCRIPTION
# Description
Adds decoders from `ConvertibleValue` into `std::String` and `Option<T>`.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have created new documentation
- I have bumped aleph-client version if relevant

# Note

Mirror of #767 but now PR is made from not-a-fork repo.