### PR TITLE
A0-1503: Take e2e config from env

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,16 @@
+# e2e-tests
+
+This crate contains e2e test scenarios for the aleph-node.
+
+## Running
+
+The most basic way to run (assuming a local node is listening on 9944) is:
+
+```bash
+$ NODE=ws://127.0.0.1:9944 cargo test name_of_one_test
+```
+
+Note that the particular test cases might require different numbers of launched nodes, validators, or a particular
+configuration of the launched nodes, see the documentation for a particular test case for details.
+
+Additional options are passed to the tests via env variables. See `src/config.rs` for docs on available options.

--- a/e2e-tests/docker_entrypoint.sh
+++ b/e2e-tests/docker_entrypoint.sh
@@ -1,30 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ARGS=(
-  --node "${NODE_URL}"
-)
-
-if [[ -n "${TEST_CASES:-}" ]]; then
-  ARGS+=(--test-cases "${TEST_CASES}")
-fi
-
-# If test case params are both not empty, run client with them. Otherwise, run without params.
-if [[ -n "${RESERVED_SEATS:-}" && -n "${NON_RESERVED_SEATS:-}" ]]; then
-  ARGS+=(
-    --reserved-seats "${RESERVED_SEATS}"
-    --non-reserved-seats "${NON_RESERVED_SEATS}"
-  )
-fi
-
-if [[ -n "${UPGRADE_VERSION:-}" && -n "${UPGRADE_SESSION:-}" && -n "${UPGRADE_FINALIZATION_WAIT_SESSIONS:-}" ]]; then
-    ARGS+=(
-        --upgrade-to-version "${UPGRADE_VERSION}"
-        --upgrade-session "${UPGRADE_SESSION}"
-        --upgrade-finalization-wait-sessions "${UPGRADE_FINALIZATION_WAIT_SESSIONS}"
-    )
-fi
-
-E2E_CONFIG="${ARGS[*]}" aleph-e2e-client $TEST_CASES --nocapture
+aleph-e2e-client $TEST_CASES --nocapture --test-threads 1
 
 echo "Done!"

--- a/e2e-tests/src/config.rs
+++ b/e2e-tests/src/config.rs
@@ -1,49 +1,71 @@
-use std::env;
+use std::{env, str::FromStr};
 
 use aleph_client::{RootConnection, SignedConnection};
-use clap::{Args, Parser};
 use once_cell::sync::Lazy;
 use primitives::SessionIndex;
 
 use crate::accounts::{get_sudo_key, get_validators_keys, get_validators_seeds, NodeKeys};
 
 static GLOBAL_CONFIG: Lazy<Config> = Lazy::new(|| {
-    let unparsed = env::var("E2E_CONFIG").unwrap_or("".to_string());
-    let unparsed = format!("e2e {}", unparsed);
-    Config::parse_from(unparsed.split_whitespace())
+    let node = get_env("NODE_URL").unwrap_or_else(|| "ws://127.0.0.1:9943".to_string());
+    let validator_count = get_env("VALIDATOR_COUNT").unwrap_or_else(|| 5);
+    let validators_seeds = env::var("VALIDATORS_SEEDS")
+        .ok()
+        .map(|s| s.split(',').map(|s| s.to_string()).collect());
+    let sudo_seed = get_env("SUDO_SEED").unwrap_or_else(|| "//Alice".to_string());
+    let reserved_seats = get_env("RESERVED_SEATS");
+    let non_reserved_seats = get_env("NON_RESERVED_SEATS");
+    let upgrade_to_version = get_env("UPGRADE_VERSION");
+    let upgrade_session = get_env("UPGRADE_SESSION");
+    let upgrade_finalization_wait_sessions = get_env("UPGRADE_FINALIZATION_WAIT_SESSIONS");
+
+    Config {
+        node,
+        validator_count,
+        validators_seeds,
+        sudo_seed,
+        test_case_params: TestCaseParams {
+            reserved_seats,
+            non_reserved_seats,
+            upgrade_to_version,
+            upgrade_session,
+            upgrade_finalization_wait_sessions,
+        },
+    }
 });
+
+fn get_env<T>(name: &str) -> Option<T>
+where
+    T: FromStr,
+    <T as FromStr>::Err: std::fmt::Debug,
+{
+    env::var(name).ok().map(|v| {
+        v.parse()
+            .expect(&format!("Failed to parse env var {}", name))
+    })
+}
 
 pub fn setup_test() -> &'static Config {
     let _ = env_logger::builder().is_test(true).try_init();
     &GLOBAL_CONFIG
 }
 
-#[derive(Debug, Parser, Clone)]
-#[clap(version = "1.0")]
+#[derive(Debug, Clone)]
 pub struct Config {
     /// WS endpoint address of the node to connect to
-    #[clap(long, default_value = "ws://127.0.0.1:9943")]
     pub node: String,
 
-    /// Test cases to run.
-    #[clap(long)]
-    pub test_cases: Option<Vec<String>>,
-
     /// Number of //0, //1, ... validators to run e2e tests on
-    #[clap(long, default_value = "5")]
     pub validator_count: u32,
 
     /// Seed values to create accounts
     /// Optional: by default we use //0, //1, ... seeds for validators
-    #[clap(long)]
     pub validators_seeds: Option<Vec<String>>,
 
     /// Seed value of sudo account
-    #[clap(long, default_value = "//Alice")]
     pub sudo_seed: String,
 
     /// Test case parameters, used for test setup.
-    #[clap(flatten)]
     pub test_case_params: TestCaseParams,
 }
 
@@ -75,25 +97,20 @@ impl Config {
 }
 
 /// Parameters which can be passed to test cases.
-#[derive(Args, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct TestCaseParams {
     /// Desired number of reserved seats for validators, may be set within the test.
-    #[clap(long)]
     pub reserved_seats: Option<u32>,
 
     /// Desired number of non-reserved seats for validators, may be set within the test.
-    #[clap(long)]
     pub non_reserved_seats: Option<u32>,
 
     /// Version for the VersionUpgrade test.
-    #[clap(long)]
     pub upgrade_to_version: Option<u32>,
 
     /// Session in which we should schedule an upgrade in VersionUpgrade test.
-    #[clap(long)]
     pub upgrade_session: Option<SessionIndex>,
 
     /// How many sessions we should wait after upgrade in VersionUpgrade test.
-    #[clap(long)]
     pub upgrade_finalization_wait_sessions: Option<u32>,
 }

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -4,6 +4,6 @@ set -e
 
 cd e2e-tests/
 
-E2E_CONFIG="--node ws://127.0.0.1:9943" RUST_LOG=info cargo test -- --nocapture
+NODE_URL="ws://127.0.0.1:9944" RUST_LOG=info cargo test -- --nocapture --test-threads 1
 
 exit $?


### PR DESCRIPTION
# Description

Takes all parts of the e2e config from the environment instead of using clap. When using `cargo test` to run the tests, this seems more natural. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)