### PR TITLE
Added pending_rewards API call to Testnet 8.X branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-runtime"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -301,6 +301,7 @@ dependencies = [
  "pallet-identity",
  "pallet-multisig",
  "pallet-nomination-pools",
+ "pallet-nomination-pools-runtime-api",
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-session",
@@ -5071,6 +5072,16 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-nomination-pools-runtime-api"
+version = "1.0.0-dev"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.28#5e8b6fa2130236497878e53c169e41f1f7871e6b"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
  "sp-std",
 ]
 

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-runtime"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Cardinal Cryptography"]
 edition = "2021"
 homepage = "https://alephzero.org"
@@ -41,6 +41,7 @@ pallet-vesting = { default-features = false, git = "https://github.com/Cardinal-
 pallet-multisig = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 pallet-utility = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 pallet-nomination-pools = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
+pallet-nomination-pools-runtime-api = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 
 sp-api = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 sp-block-builder = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
@@ -109,6 +110,7 @@ std = [
     "pallet-contracts-rpc-runtime-api/std",
     "pallet-contracts/std",
     "pallet-nomination-pools/std",
+    "pallet-nomination-pools-runtime-api/std",
 ]
 short_session = ["primitives/short_session"]
 try-runtime = [

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -108,7 +108,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 38,
+    spec_version: 44,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 13,
@@ -954,6 +954,12 @@ impl_runtime_apis! {
             Contracts::get_storage(address, key)
         }
 
+    }
+
+     impl pallet_nomination_pools_runtime_api::NominationPoolsApi<Block, AccountId, Balance> for Runtime {
+        fn pending_rewards(member_account: AccountId) -> Balance {
+            NominationPools::pending_rewards(member_account)
+        }
     }
 
     #[cfg(feature = "try-runtime")]


### PR DESCRIPTION
This is a slightly modified port of https://github.com/Cardinal-Cryptography/aleph-node/pull/778 to Testnet 8.X brach

Runtime `spec_version` is 44 which might sound controversial, but we need to use the first free number that is not used. This ie because spec_version needs to identify uniquely aleph-runtime, just in case of wrongly updated runtime on Tesnet or Mainnet.