### PR TITLE
A0-1592: make connection manager operate of validator network directly

### DIFF
--- a/finality-aleph/src/network/io.rs
+++ b/finality-aleph/src/network/io.rs
@@ -1,42 +1,43 @@
 use futures::channel::mpsc;
 
-use crate::network::{
-    manager::{DataInSession, VersionedAuthentication},
-    ConnectionManagerIO, Data, Multiaddress, NetworkServiceIO as NetworkIO, SessionManagerIO,
+use crate::{
+    network::{
+        manager::{DataInSession, VersionedAuthentication},
+        ConnectionManagerIO, Data, Multiaddress, NetworkServiceIO as NetworkIO, SessionManagerIO,
+    },
+    validator_network::{Network as ValidatorNetwork, PublicKey},
 };
 
-type AuthenticationNetworkIO<D, M> = NetworkIO<VersionedAuthentication<M>, DataInSession<D>, M>;
+type AuthenticationNetworkIO<M> = NetworkIO<VersionedAuthentication<M>>;
 
-pub fn setup<D: Data, M: Multiaddress + 'static>() -> (
-    ConnectionManagerIO<D, M>,
-    AuthenticationNetworkIO<D, M>,
+pub fn setup<
+    D: Data,
+    M: Multiaddress + 'static,
+    VN: ValidatorNetwork<M::PeerId, M, DataInSession<D>>,
+>(
+    validator_network: VN,
+) -> (
+    ConnectionManagerIO<D, M, VN>,
+    AuthenticationNetworkIO<M>,
     SessionManagerIO<D>,
-) {
+)
+where
+    M::PeerId: PublicKey,
+{
     // Prepare and start the network
-    let (commands_for_network, commands_from_io) = mpsc::unbounded();
-    let (data_for_network, data_from_user) = mpsc::unbounded();
     let (messages_for_network, messages_from_user) = mpsc::unbounded();
     let (commands_for_service, commands_from_user) = mpsc::unbounded();
     let (messages_for_service, commands_from_manager) = mpsc::unbounded();
-    let (data_for_user, data_from_network) = mpsc::unbounded();
     let (messages_for_user, messages_from_network) = mpsc::unbounded();
 
     let connection_io = ConnectionManagerIO::new(
-        commands_for_network,
-        data_for_network,
         messages_for_network,
         commands_from_user,
         commands_from_manager,
-        data_from_network,
         messages_from_network,
+        validator_network,
     );
-    let channels_for_network = NetworkIO::new(
-        data_from_user,
-        messages_from_user,
-        data_for_user,
-        messages_for_user,
-        commands_from_io,
-    );
+    let channels_for_network = NetworkIO::new(messages_from_user, messages_for_user);
     let channels_for_session_manager =
         SessionManagerIO::new(commands_for_service, messages_for_service);
 

--- a/finality-aleph/src/network/mock.rs
+++ b/finality-aleph/src/network/mock.rs
@@ -17,10 +17,7 @@ use tokio::time::timeout;
 
 use crate::{
     crypto::{AuthorityPen, AuthorityVerifier},
-    network::{
-        manager::VersionedAuthentication, AddressedData, ConnectionCommand, Event, EventStream,
-        Multiaddress, Network, NetworkIdentity, NetworkSender, NetworkServiceIO, Protocol,
-    },
+    network::{Event, EventStream, Network, NetworkIdentity, NetworkSender, Protocol},
     testing::mocks::validator_network::{random_identity, MockMultiaddress},
     validator_network::mock::MockPublicKey,
     AuthorityId, NodeIndex,
@@ -100,43 +97,6 @@ impl<T> Default for Channel<T> {
 pub type MockEvent = Event<MockMultiaddress, MockPublicKey>;
 
 pub type MockData = Vec<u8>;
-
-pub struct MockIO<M: Multiaddress> {
-    pub messages_for_network: mpsc::UnboundedSender<VersionedAuthentication<M>>,
-    pub data_for_network: mpsc::UnboundedSender<AddressedData<MockData, M::PeerId>>,
-    pub messages_from_network: mpsc::UnboundedReceiver<VersionedAuthentication<M>>,
-    pub data_from_network: mpsc::UnboundedReceiver<MockData>,
-    pub commands_for_network: mpsc::UnboundedSender<ConnectionCommand<M>>,
-}
-
-impl<M: Multiaddress + 'static> MockIO<M> {
-    pub fn new() -> (
-        MockIO<M>,
-        NetworkServiceIO<VersionedAuthentication<M>, MockData, M>,
-    ) {
-        let (messages_for_network, messages_from_user) = mpsc::unbounded();
-        let (data_for_network, data_from_user) = mpsc::unbounded();
-        let (messages_for_user, messages_from_network) = mpsc::unbounded();
-        let (data_for_user, data_from_network) = mpsc::unbounded();
-        let (commands_for_network, commands_from_manager) = mpsc::unbounded();
-        (
-            MockIO {
-                messages_for_network,
-                data_for_network,
-                messages_from_network,
-                data_from_network,
-                commands_for_network,
-            },
-            NetworkServiceIO::new(
-                data_from_user,
-                messages_from_user,
-                data_for_user,
-                messages_for_user,
-                commands_from_manager,
-            ),
-        )
-    }
-}
 
 pub struct MockEventStream(mpsc::UnboundedReceiver<MockEvent>);
 

--- a/finality-aleph/src/network/mod.rs
+++ b/finality-aleph/src/network/mod.rs
@@ -59,7 +59,7 @@ pub trait PeerId: PartialEq + Eq + Clone + Debug + Display + Hash + Codec + Send
 }
 
 /// Represents the address of an arbitrary node.
-pub trait Multiaddress: Debug + Hash + Codec + Clone + Eq + Send + Sync {
+pub trait Multiaddress: Debug + Hash + Codec + Clone + Eq + Send + Sync + 'static {
     type PeerId: PeerId;
 
     /// Returns the peer id associated with this multiaddress if it exists and is unique.

--- a/finality-aleph/src/nodes/validator_node.rs
+++ b/finality-aleph/src/nodes/validator_node.rs
@@ -115,7 +115,7 @@ where
             session_map: session_authorities.clone(),
         });
 
-    let (connection_io, network_io, session_io) = setup_io();
+    let (connection_io, network_io, session_io) = setup_io(validator_network);
 
     let connection_manager = ConnectionManager::new(
         network_identity,
@@ -130,12 +130,7 @@ where
     };
 
     let session_manager = SessionManager::new(session_io);
-    let network = NetworkService::new(
-        network.clone(),
-        validator_network,
-        spawn_handle.clone(),
-        network_io,
-    );
+    let network = NetworkService::new(network.clone(), spawn_handle.clone(), network_io);
     let network_task = async move { network.run().await };
 
     spawn_handle.spawn("aleph/justification_handler", None, handler_task);

--- a/finality-aleph/src/testing/network.rs
+++ b/finality-aleph/src/testing/network.rs
@@ -102,7 +102,7 @@ async fn prepare_one_session_test_data() -> TestData {
     let validator_network =
         MockValidatorNetwork::from(authorities[0].addresses(), authorities[0].peer_id());
 
-    let (connection_io, network_io, session_io) = setup_io();
+    let (connection_io, network_io, session_io) = setup_io(validator_network.clone());
 
     let connection_manager = ConnectionManager::new(
         validator_network.clone(),
@@ -111,12 +111,8 @@ async fn prepare_one_session_test_data() -> TestData {
 
     let session_manager = SessionManager::new(session_io);
 
-    let network_service = NetworkService::new(
-        network.clone(),
-        validator_network.clone(),
-        task_manager.spawn_handle(),
-        network_io,
-    );
+    let network_service =
+        NetworkService::new(network.clone(), task_manager.spawn_handle(), network_io);
 
     let network_manager_task = async move {
         tokio::select! {


### PR DESCRIPTION
# Description
* Moved Validator Network to ConnectionManagerIO
* Simplified tests in Network Service. They are no longer dependent on VersionedAuthentication
 
## Type of change

- Refactor/SImplification of code

# Checklist:

- I have not added any tests, but they are not necessary
- I have made corresponding changes to the existing documentation
