### PR TITLE
A0-1667 Add timeouts to the dialer

### DIFF
--- a/finality-aleph/src/validator_network/outgoing.rs
+++ b/finality-aleph/src/validator_network/outgoing.rs
@@ -38,7 +38,8 @@ impl<PK: PublicKey, A: Data, ND: Dialer<A>> Display for OutgoingError<PK, A, ND>
     }
 }
 
-const DIAL_TIMEOUT: Duration = Duration::from_secs(43);
+/// Arbitrarily chosen timeout, should be more than enough.
+const DIAL_TIMEOUT: Duration = Duration::from_secs(60);
 
 async fn manage_outgoing<SK: SecretKey, D: Data, A: Data, ND: Dialer<A>>(
     secret_key: SK,

--- a/finality-aleph/src/validator_network/outgoing.rs
+++ b/finality-aleph/src/validator_network/outgoing.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display, Error as FmtError, Formatter};
 
 use futures::channel::mpsc;
 use log::{debug, info};
-use tokio::time::{sleep, Duration};
+use tokio::time::{sleep, timeout, Duration};
 
 use crate::validator_network::{
     protocols::{
@@ -15,6 +15,7 @@ enum OutgoingError<PK: PublicKey, A: Data, ND: Dialer<A>> {
     Dial(ND::Error),
     ProtocolNegotiation(PeerAddressInfo, ProtocolNegotiationError),
     Protocol(PeerAddressInfo, ProtocolError<PK>),
+    TimedOut,
 }
 
 impl<PK: PublicKey, A: Data, ND: Dialer<A>> Display for OutgoingError<PK, A, ND> {
@@ -32,9 +33,12 @@ impl<PK: PublicKey, A: Data, ND: Dialer<A>> Display for OutgoingError<PK, A, ND>
                 "communication with {} failed, protocol error: {}",
                 addr, e
             ),
+            TimedOut => write!(f, "dial timeout",),
         }
     }
 }
+
+const DIAL_TIMEOUT: Duration = Duration::from_secs(43);
 
 async fn manage_outgoing<SK: SecretKey, D: Data, A: Data, ND: Dialer<A>>(
     secret_key: SK,
@@ -45,9 +49,10 @@ async fn manage_outgoing<SK: SecretKey, D: Data, A: Data, ND: Dialer<A>>(
     data_for_user: mpsc::UnboundedSender<D>,
 ) -> Result<(), OutgoingError<SK::PublicKey, A, ND>> {
     debug!(target: "validator-network", "Trying to connect to {}.", public_key);
-    let stream = dialer
-        .connect(addresses)
+
+    let stream = timeout(DIAL_TIMEOUT, dialer.connect(addresses))
         .await
+        .map_err(|_| OutgoingError::TimedOut)?
         .map_err(OutgoingError::Dial)?;
     let peer_address_info = stream.peer_address_info();
     debug!(target: "validator-network", "Performing outgoing protocol negotiation.");


### PR DESCRIPTION
# Description

https://cardinal-cryptography.atlassian.net/browse/A0-1667

Currently the `TcpDialer` depends on OS timeouts, which are probably too long. We should wrap the `connect` call with a `timeout`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)