### PR TITLE
A0-1575: Addressing information refactor

### DIFF
--- a/finality-aleph/src/network/io.rs
+++ b/finality-aleph/src/network/io.rs
@@ -1,28 +1,32 @@
+use std::fmt::Debug;
+
 use futures::channel::mpsc;
 
 use crate::{
     network::{
         manager::{DataInSession, VersionedAuthentication},
-        ConnectionManagerIO, Data, Multiaddress, NetworkServiceIO as NetworkIO, SessionManagerIO,
+        AddressingInformation, ConnectionManagerIO, Data, NetworkServiceIO as NetworkIO,
+        SessionManagerIO,
     },
     validator_network::{Network as ValidatorNetwork, PublicKey},
 };
 
-type AuthenticationNetworkIO<M> = NetworkIO<VersionedAuthentication<M>>;
+type AuthenticationNetworkIO<M, A> = NetworkIO<VersionedAuthentication<M, A>>;
 
 pub fn setup<
     D: Data,
-    M: Multiaddress + 'static,
-    VN: ValidatorNetwork<M::PeerId, M, DataInSession<D>>,
+    M: Data + Debug,
+    A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>,
+    VN: ValidatorNetwork<A::PeerId, A, DataInSession<D>>,
 >(
     validator_network: VN,
 ) -> (
-    ConnectionManagerIO<D, M, VN>,
-    AuthenticationNetworkIO<M>,
+    ConnectionManagerIO<D, M, A, VN>,
+    AuthenticationNetworkIO<M, A>,
     SessionManagerIO<D>,
 )
 where
-    M::PeerId: PublicKey,
+    A::PeerId: PublicKey,
 {
     // Prepare and start the network
     let (messages_for_network, messages_from_user) = mpsc::unbounded();

--- a/finality-aleph/src/network/io.rs
+++ b/finality-aleph/src/network/io.rs
@@ -13,6 +13,12 @@ use crate::{
 
 type AuthenticationNetworkIO<M, A> = NetworkIO<VersionedAuthentication<M, A>>;
 
+type FullIO<D, M, A, VN> = (
+    ConnectionManagerIO<D, M, A, VN>,
+    AuthenticationNetworkIO<M, A>,
+    SessionManagerIO<D>,
+);
+
 pub fn setup<
     D: Data,
     M: Data + Debug,
@@ -20,11 +26,7 @@ pub fn setup<
     VN: ValidatorNetwork<A::PeerId, A, DataInSession<D>>,
 >(
     validator_network: VN,
-) -> (
-    ConnectionManagerIO<D, M, A, VN>,
-    AuthenticationNetworkIO<M, A>,
-    SessionManagerIO<D>,
-)
+) -> FullIO<D, M, A, VN>
 where
     A::PeerId: PublicKey,
 {

--- a/finality-aleph/src/network/manager/discovery.rs
+++ b/finality-aleph/src/network/manager/discovery.rs
@@ -1,51 +1,38 @@
 use std::{
     collections::HashMap,
+    fmt::Debug,
     marker::PhantomData,
     time::{Duration, Instant},
 };
 
-use codec::{Decode, Encode};
 use log::{debug, info, trace};
 
 use crate::{
     network::{
-        manager::{Authentication, SessionHandler},
-        Multiaddress,
+        manager::{
+            compatibility::PeerAuthentications, Authentication, LegacyAuthentication,
+            SessionHandler,
+        },
+        AddressingInformation, Data,
     },
-    NodeIndex, SessionId,
+    NodeIndex,
 };
 
-/// Messages used for discovery and authentication.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Encode, Decode)]
-pub enum DiscoveryMessage<M: Multiaddress> {
-    AuthenticationBroadcast(Authentication<M>),
-    Authentication(Authentication<M>),
-}
-
-impl<M: Multiaddress> DiscoveryMessage<M> {
-    pub fn session_id(&self) -> SessionId {
-        use DiscoveryMessage::*;
-        match self {
-            AuthenticationBroadcast((auth_data, _)) | Authentication((auth_data, _)) => {
-                auth_data.session()
-            }
-        }
-    }
-}
-
 /// Handles creating and rebroadcasting discovery messages.
-pub struct Discovery<M: Multiaddress> {
+pub struct Discovery<M: Data, A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>> {
     cooldown: Duration,
     last_broadcast: HashMap<NodeIndex, Instant>,
-    _phantom: PhantomData<M>,
+    last_legacy_broadcast: HashMap<NodeIndex, Instant>,
+    _phantom: PhantomData<(M, A)>,
 }
 
-impl<M: Multiaddress> Discovery<M> {
+impl<M: Data + Debug, A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>> Discovery<M, A> {
     /// Create a new discovery handler with the given response/broadcast cooldown.
     pub fn new(cooldown: Duration) -> Self {
         Discovery {
             cooldown,
             last_broadcast: HashMap::new(),
+            last_legacy_broadcast: HashMap::new(),
             _phantom: PhantomData,
         }
     }
@@ -53,8 +40,8 @@ impl<M: Multiaddress> Discovery<M> {
     /// Returns a message that should be sent as part of authority discovery at this moment.
     pub fn discover_authorities(
         &mut self,
-        handler: &SessionHandler<M>,
-    ) -> Option<DiscoveryMessage<M>> {
+        handler: &SessionHandler<M, A>,
+    ) -> Option<PeerAuthentications<M, A>> {
         let authentication = match handler.authentication() {
             Some(authentication) => authentication,
             None => return None,
@@ -63,20 +50,7 @@ impl<M: Multiaddress> Discovery<M> {
         let missing_authorities = handler.missing_nodes();
         let node_count = handler.node_count();
         info!(target: "aleph-network", "{}/{} authorities known for session {}.", node_count.0-missing_authorities.len(), node_count.0, handler.session_id().0);
-        Some(DiscoveryMessage::AuthenticationBroadcast(authentication))
-    }
-
-    /// Checks the authentication using the handler and returns the addresses we should be
-    /// connected to if the authentication is correct.
-    fn handle_authentication(
-        &mut self,
-        authentication: Authentication<M>,
-        handler: &mut SessionHandler<M>,
-    ) -> Vec<M> {
-        if !handler.handle_authentication(authentication.clone()) {
-            return Vec::new();
-        }
-        authentication.0.addresses()
+        Some(authentication)
     }
 
     fn should_rebroadcast(&self, node_id: &NodeIndex) -> bool {
@@ -86,45 +60,58 @@ impl<M: Multiaddress> Discovery<M> {
         }
     }
 
-    fn handle_broadcast(
-        &mut self,
-        authentication: Authentication<M>,
-        handler: &mut SessionHandler<M>,
-    ) -> (Vec<M>, Option<DiscoveryMessage<M>>) {
-        debug!(target: "aleph-network", "Handling broadcast with authentication {:?}.", authentication);
-        let addresses = self.handle_authentication(authentication.clone(), handler);
-        if addresses.is_empty() {
-            return (Vec::new(), None);
+    fn should_legacy_rebroadcast(&self, node_id: &NodeIndex) -> bool {
+        match self.last_legacy_broadcast.get(node_id) {
+            Some(instant) => Instant::now() > *instant + self.cooldown,
+            None => true,
         }
+    }
+
+    /// Processes the provided authentication and returns any new address we should
+    /// be connected to if we want to stay connected to the committee and an optional
+    /// message that we should send as a result of it.
+    pub fn handle_authentication(
+        &mut self,
+        authentication: Authentication<A>,
+        handler: &mut SessionHandler<M, A>,
+    ) -> (Option<A>, Option<PeerAuthentications<M, A>>) {
+        debug!(target: "aleph-network", "Handling broadcast with authentication {:?}.", authentication);
+        let address = match handler.handle_authentication(authentication.clone()) {
+            Some(address) => Some(address),
+            None => return (None, None),
+        };
         let node_id = authentication.0.creator();
         if !self.should_rebroadcast(&node_id) {
-            return (addresses, None);
+            return (address, None);
         }
         trace!(target: "aleph-network", "Rebroadcasting {:?}.", authentication);
         self.last_broadcast.insert(node_id, Instant::now());
-        (
-            addresses,
-            Some(DiscoveryMessage::AuthenticationBroadcast(authentication)),
-        )
+        (address, Some(PeerAuthentications::NewOnly(authentication)))
     }
 
-    /// Analyzes the provided message and returns all the new multiaddresses we should
+    /// Processes the legacy authentication and returns any new address we should
     /// be connected to if we want to stay connected to the committee and an optional
     /// message that we should send as a result of it.
-    pub fn handle_message(
+    pub fn handle_legacy_authentication(
         &mut self,
-        message: DiscoveryMessage<M>,
-        handler: &mut SessionHandler<M>,
-    ) -> (Vec<M>, Option<DiscoveryMessage<M>>) {
-        use DiscoveryMessage::*;
-        match message {
-            AuthenticationBroadcast(authentication) => {
-                self.handle_broadcast(authentication, handler)
-            }
-            Authentication(authentication) => {
-                (self.handle_authentication(authentication, handler), None)
-            }
+        legacy_authentication: LegacyAuthentication<M>,
+        handler: &mut SessionHandler<M, A>,
+    ) -> (Option<A>, Option<PeerAuthentications<M, A>>) {
+        debug!(target: "aleph-network", "Handling broadcast with legacy authentication {:?}.", legacy_authentication);
+        let address = match handler.handle_legacy_authentication(legacy_authentication.clone()) {
+            Some(address) => Some(address),
+            None => return (None, None),
+        };
+        let node_id = legacy_authentication.0.creator();
+        if !self.should_legacy_rebroadcast(&node_id) {
+            return (address, None);
         }
+        trace!(target: "aleph-network", "Rebroadcasting {:?}.", legacy_authentication);
+        self.last_legacy_broadcast.insert(node_id, Instant::now());
+        (
+            address,
+            Some(PeerAuthentications::LegacyOnly(legacy_authentication)),
+        )
     }
 }
 
@@ -132,30 +119,30 @@ impl<M: Multiaddress> Discovery<M> {
 mod tests {
     use std::{thread::sleep, time::Duration};
 
-    use codec::Encode;
-
-    use super::{Discovery, DiscoveryMessage};
+    use super::Discovery;
     use crate::{
-        network::{manager::SessionHandler, mock::crypto_basics},
-        testing::mocks::validator_network::{
-            random_identity, random_multiaddress, MockMultiaddress,
+        network::{
+            manager::{compatibility::PeerAuthentications, SessionHandler},
+            mock::crypto_basics,
+            testing::{authentication, legacy_authentication},
         },
+        testing::mocks::validator_network::{random_address, MockAddressingInformation},
         SessionId,
     };
 
     const NUM_NODES: u8 = 7;
     const MS_COOLDOWN: u64 = 200;
 
-    fn addresses() -> Vec<MockMultiaddress> {
-        (0..NUM_NODES).map(|_| random_multiaddress()).collect()
+    fn addresses() -> Vec<MockAddressingInformation> {
+        (0..NUM_NODES).map(|_| random_address()).collect()
     }
 
     async fn build_number(
         num_nodes: u8,
     ) -> (
-        Discovery<MockMultiaddress>,
-        Vec<SessionHandler<MockMultiaddress>>,
-        SessionHandler<MockMultiaddress>,
+        Discovery<MockAddressingInformation, MockAddressingInformation>,
+        Vec<SessionHandler<MockAddressingInformation, MockAddressingInformation>>,
+        SessionHandler<MockAddressingInformation, MockAddressingInformation>,
     ) {
         let crypto_basics = crypto_basics(num_nodes.into()).await;
         let mut handlers = Vec::new();
@@ -165,20 +152,18 @@ mod tests {
                     Some(authority_index_and_pen),
                     crypto_basics.1.clone(),
                     SessionId(43),
-                    vec![address],
+                    address,
                 )
-                .await
-                .unwrap(),
+                .await,
             );
         }
         let non_validator = SessionHandler::new(
             None,
             crypto_basics.1.clone(),
             SessionId(43),
-            random_identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
+        .await;
         (
             Discovery::new(Duration::from_millis(MS_COOLDOWN)),
             handlers,
@@ -187,9 +172,9 @@ mod tests {
     }
 
     async fn build() -> (
-        Discovery<MockMultiaddress>,
-        Vec<SessionHandler<MockMultiaddress>>,
-        SessionHandler<MockMultiaddress>,
+        Discovery<MockAddressingInformation, MockAddressingInformation>,
+        Vec<SessionHandler<MockAddressingInformation, MockAddressingInformation>>,
+        SessionHandler<MockAddressingInformation, MockAddressingInformation>,
     ) {
         build_number(NUM_NODES).await
     }
@@ -199,10 +184,12 @@ mod tests {
         for num_nodes in 2..NUM_NODES {
             let (mut discovery, mut handlers, _) = build_number(num_nodes).await;
             let handler = &mut handlers[0];
-            let message = discovery.discover_authorities(handler);
+            let maybe_authentication = discovery.discover_authorities(handler);
             assert_eq!(
-                message.expect("there is a discovery message"),
-                DiscoveryMessage::AuthenticationBroadcast(handler.authentication().unwrap()),
+                maybe_authentication.expect("there is an authentication"),
+                handler
+                    .authentication()
+                    .expect("the handler has an authentication"),
             );
         }
     }
@@ -210,100 +197,118 @@ mod tests {
     #[tokio::test]
     async fn non_validator_discover_authorities_returns_empty_vector() {
         let (mut discovery, _, non_validator) = build().await;
-        let message = discovery.discover_authorities(&non_validator);
-        assert!(message.is_none());
+        let maybe_authentication = discovery.discover_authorities(&non_validator);
+        assert!(maybe_authentication.is_none());
     }
 
     #[tokio::test]
     async fn rebroadcasts_and_accepts_addresses() {
         let (mut discovery, mut handlers, _) = build().await;
-        let authentication = handlers[1].authentication().unwrap();
+        let authentication = authentication(&handlers[1]);
         let handler = &mut handlers[0];
-        let (addresses, command) = discovery.handle_message(
-            DiscoveryMessage::AuthenticationBroadcast(authentication.clone()),
-            handler,
-        );
-        assert_eq!(addresses, authentication.0.addresses());
+        let (address, command) = discovery.handle_authentication(authentication.clone(), handler);
+        assert_eq!(address, Some(authentication.0.address()));
         assert!(matches!(command, Some(
-                DiscoveryMessage::AuthenticationBroadcast(rebroadcast_authentication),
+                PeerAuthentications::NewOnly(rebroadcast_authentication),
             ) if rebroadcast_authentication == authentication));
     }
 
     #[tokio::test]
-    async fn non_validators_rebroadcasts() {
-        let (mut discovery, handlers, mut non_validator) = build().await;
-        let authentication = handlers[1].authentication().unwrap();
-        let (addresses, command) = discovery.handle_message(
-            DiscoveryMessage::AuthenticationBroadcast(authentication.clone()),
-            &mut non_validator,
-        );
-        assert_eq!(addresses, authentication.0.addresses());
+    async fn legacy_rebroadcasts_and_accepts_addresses() {
+        let (mut discovery, mut handlers, _) = build().await;
+        let authentication = legacy_authentication(&handlers[1]);
+        let handler = &mut handlers[0];
+        let (_, command) = discovery.handle_legacy_authentication(authentication.clone(), handler);
         assert!(matches!(command, Some(
-                DiscoveryMessage::AuthenticationBroadcast(rebroadcast_authentication),
+                PeerAuthentications::LegacyOnly(rebroadcast_authentication),
+            ) if rebroadcast_authentication == authentication));
+    }
+
+    #[tokio::test]
+    async fn non_validator_rebroadcasts() {
+        let (mut discovery, handlers, mut non_validator) = build().await;
+        let authentication = authentication(&handlers[1]);
+        let (address, command) =
+            discovery.handle_authentication(authentication.clone(), &mut non_validator);
+        assert_eq!(address, Some(authentication.0.address()));
+        assert!(matches!(command, Some(
+                PeerAuthentications::NewOnly(rebroadcast_authentication),
+            ) if rebroadcast_authentication == authentication));
+    }
+
+    #[tokio::test]
+    async fn legacy_non_validator_rebroadcasts() {
+        let (mut discovery, handlers, mut non_validator) = build().await;
+        let authentication = legacy_authentication(&handlers[1]);
+        let (_, command) =
+            discovery.handle_legacy_authentication(authentication.clone(), &mut non_validator);
+        assert!(matches!(command, Some(
+                PeerAuthentications::LegacyOnly(rebroadcast_authentication),
             ) if rebroadcast_authentication == authentication));
     }
 
     #[tokio::test]
     async fn does_not_rebroadcast_wrong_authentications() {
         let (mut discovery, mut handlers, _) = build().await;
-        let (auth_data, _) = handlers[1].authentication().unwrap();
-        let (_, signature) = handlers[2].authentication().unwrap();
+        let (auth_data, _) = authentication(&handlers[1]);
+        let (_, signature) = authentication(&handlers[2]);
         let authentication = (auth_data, signature);
         let handler = &mut handlers[0];
-        let (addresses, command) = discovery.handle_message(
-            DiscoveryMessage::AuthenticationBroadcast(authentication),
-            handler,
-        );
-        assert!(addresses.is_empty());
+        let (address, command) = discovery.handle_authentication(authentication, handler);
+        assert!(address.is_none());
+        assert!(command.is_none());
+    }
+
+    #[tokio::test]
+    async fn legacy_does_not_rebroadcast_wrong_authentications() {
+        let (mut discovery, mut handlers, _) = build().await;
+        let (auth_data, _) = legacy_authentication(&handlers[1]);
+        let (_, signature) = legacy_authentication(&handlers[2]);
+        let authentication = (auth_data, signature);
+        let handler = &mut handlers[0];
+        let (address, command) = discovery.handle_legacy_authentication(authentication, handler);
+        assert!(address.is_none());
         assert!(command.is_none());
     }
 
     #[tokio::test]
     async fn rebroadcasts_after_cooldown() {
         let (mut discovery, mut handlers, _) = build().await;
-        let authentication = handlers[1].authentication().unwrap();
+        let authentication = authentication(&handlers[1]);
         let handler = &mut handlers[0];
-        discovery.handle_message(
-            DiscoveryMessage::AuthenticationBroadcast(authentication.clone()),
-            handler,
-        );
+        discovery.handle_authentication(authentication.clone(), handler);
         sleep(Duration::from_millis(MS_COOLDOWN + 5));
-        let (addresses, command) = discovery.handle_message(
-            DiscoveryMessage::AuthenticationBroadcast(authentication.clone()),
-            handler,
-        );
-        assert_eq!(addresses, authentication.0.addresses());
+        let (address, command) = discovery.handle_authentication(authentication.clone(), handler);
+        assert_eq!(address, Some(authentication.0.address()));
         assert!(matches!(command, Some(
-                DiscoveryMessage::AuthenticationBroadcast(rebroadcast_authentication),
+                PeerAuthentications::NewOnly(rebroadcast_authentication),
             ) if rebroadcast_authentication == authentication));
     }
 
     #[tokio::test]
-    async fn accepts_correct_authentications() {
+    async fn legacy_rebroadcasts_after_cooldown() {
         let (mut discovery, mut handlers, _) = build().await;
-        let expected_address = handlers[1].authentication().unwrap().0.addresses()[0].encode();
-        let authentication = handlers[1].authentication().unwrap();
+        let authentication = legacy_authentication(&handlers[1]);
         let handler = &mut handlers[0];
-        let (addresses, command) =
-            discovery.handle_message(DiscoveryMessage::Authentication(authentication), handler);
-        assert_eq!(addresses.len(), 1);
-        let address = addresses[0].encode();
-        assert_eq!(address, expected_address);
-        assert!(command.is_none());
+        discovery.handle_legacy_authentication(authentication.clone(), handler);
+        sleep(Duration::from_millis(MS_COOLDOWN + 5));
+        let (_, command) = discovery.handle_legacy_authentication(authentication.clone(), handler);
+        assert!(matches!(command, Some(
+                PeerAuthentications::LegacyOnly(rebroadcast_authentication),
+            ) if rebroadcast_authentication == authentication));
     }
 
     #[tokio::test]
-    async fn does_not_accept_incorrect_authentications() {
+    async fn rebroadcasts_legacy_immediately() {
         let (mut discovery, mut handlers, _) = build().await;
-        let (auth_data, _) = handlers[1].authentication().unwrap();
-        let (_, signature) = handlers[2].authentication().unwrap();
-        let incorrect_authentication = (auth_data, signature);
+        let authentication = authentication(&handlers[1]);
+        let legacy_authentication = legacy_authentication(&handlers[1]);
         let handler = &mut handlers[0];
-        let (addresses, command) = discovery.handle_message(
-            DiscoveryMessage::Authentication(incorrect_authentication),
-            handler,
-        );
-        assert!(addresses.is_empty());
-        assert!(command.is_none());
+        discovery.handle_authentication(authentication, handler);
+        let (_, command) =
+            discovery.handle_legacy_authentication(legacy_authentication.clone(), handler);
+        assert!(matches!(command, Some(
+                PeerAuthentications::LegacyOnly(rebroadcast_authentication),
+            ) if rebroadcast_authentication == legacy_authentication));
     }
 }

--- a/finality-aleph/src/network/manager/mod.rs
+++ b/finality-aleph/src/network/manager/mod.rs
@@ -2,7 +2,7 @@ use codec::{Decode, Encode, Error, Input, Output};
 
 use crate::{
     crypto::Signature,
-    network::{Data, Multiaddress},
+    network::{AddressingInformation, Data},
     NodeIndex, SessionId,
 };
 
@@ -12,25 +12,46 @@ mod discovery;
 mod service;
 mod session;
 
-pub use compatibility::VersionedAuthentication;
+pub use compatibility::{
+    DiscoveryMessage, LegacyDiscoveryMessage, PeerAuthentications, VersionedAuthentication,
+};
 use connections::Connections;
-pub use discovery::{Discovery, DiscoveryMessage};
+pub use discovery::Discovery;
 pub use service::{
     Config as ConnectionManagerConfig, Service as ConnectionManager, SessionCommand,
     IO as ConnectionIO,
 };
 pub use session::{Handler as SessionHandler, HandlerError as SessionHandlerError};
 
-/// Data validators use to authenticate themselves for a single session
+/// Data validators used to use to authenticate themselves for a single session
 /// and disseminate their addresses.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Encode, Decode)]
-pub struct AuthData<M: Multiaddress> {
+pub struct LegacyAuthData<M: Data> {
     addresses: Vec<M>,
     node_id: NodeIndex,
     session_id: SessionId,
 }
 
-impl<M: Multiaddress> AuthData<M> {
+impl<M: Data> LegacyAuthData<M> {
+    pub fn session(&self) -> SessionId {
+        self.session_id
+    }
+
+    pub fn creator(&self) -> NodeIndex {
+        self.node_id
+    }
+}
+
+/// Data validators use to authenticate themselves for a single session
+/// and disseminate their addresses.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Encode, Decode)]
+pub struct AuthData<A: AddressingInformation> {
+    address: A,
+    node_id: NodeIndex,
+    session_id: SessionId,
+}
+
+impl<A: AddressingInformation> AuthData<A> {
     pub fn session(&self) -> SessionId {
         self.session_id
     }
@@ -39,13 +60,52 @@ impl<M: Multiaddress> AuthData<M> {
         self.node_id
     }
 
-    pub fn addresses(&self) -> Vec<M> {
-        self.addresses.clone()
+    pub fn address(&self) -> A {
+        self.address.clone()
     }
 }
 
+impl<M: Data, A: AddressingInformation + Into<Vec<M>>> From<AuthData<A>> for LegacyAuthData<M> {
+    fn from(auth_data: AuthData<A>) -> Self {
+        let AuthData {
+            address,
+            node_id,
+            session_id,
+        } = auth_data;
+        let addresses = address.into();
+        LegacyAuthData {
+            addresses,
+            node_id,
+            session_id,
+        }
+    }
+}
+
+impl<M: Data, A: AddressingInformation + TryFrom<Vec<M>>> TryFrom<LegacyAuthData<M>>
+    for AuthData<A>
+{
+    type Error = ();
+
+    fn try_from(legacy_auth_data: LegacyAuthData<M>) -> Result<Self, Self::Error> {
+        let LegacyAuthData {
+            addresses,
+            node_id,
+            session_id,
+        } = legacy_auth_data;
+        let address = addresses.try_into().map_err(|_| ())?;
+        Ok(AuthData {
+            address,
+            node_id,
+            session_id,
+        })
+    }
+}
+
+/// A full legacy authentication, consisting of a signed LegacyAuthData.
+pub type LegacyAuthentication<M> = (LegacyAuthData<M>, Signature);
+
 /// A full authentication, consisting of a signed AuthData.
-pub type Authentication<M> = (AuthData<M>, Signature);
+pub type Authentication<A> = (AuthData<A>, Signature);
 
 /// Data inside session, sent to validator network.
 /// Wrapper for data send over network. We need it to ensure compatibility.

--- a/finality-aleph/src/network/manager/service.rs
+++ b/finality-aleph/src/network/manager/service.rs
@@ -597,7 +597,7 @@ where
     }
 }
 
-/// Input/output interface for the connectiona manager service.
+/// Input/output interface for the connection manager service.
 pub struct IO<
     D: Data,
     M: Data,

--- a/finality-aleph/src/network/manager/service.rs
+++ b/finality-aleph/src/network/manager/service.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp,
     collections::{HashMap, HashSet},
+    fmt::Debug,
     time::Duration,
 };
 
@@ -16,10 +17,11 @@ use crate::{
     crypto::{AuthorityPen, AuthorityVerifier},
     network::{
         manager::{
+            compatibility::{LegacyDiscoveryMessage, PeerAuthentications},
             Connections, DataInSession, Discovery, DiscoveryMessage, SessionHandler,
             SessionHandlerError, VersionedAuthentication,
         },
-        AddressedData, ConnectionCommand, Data, Multiaddress, NetworkIdentity, PeerId,
+        AddressedData, AddressingInformation, ConnectionCommand, Data, NetworkIdentity, PeerId,
     },
     validator_network::{Network as ValidatorNetwork, PublicKey},
     MillisecsPerBlock, NodeIndex, SessionId, SessionPeriod, STATUS_REPORT_INTERVAL,
@@ -39,9 +41,9 @@ pub enum SessionCommand<D: Data> {
     Stop(SessionId),
 }
 
-struct Session<D: Data, M: Multiaddress> {
-    handler: SessionHandler<M>,
-    discovery: Discovery<M>,
+struct Session<D: Data, M: Data, A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>> {
+    handler: SessionHandler<M, A>,
+    discovery: Discovery<M, A>,
     data_for_user: Option<mpsc::UnboundedSender<D>>,
 }
 
@@ -114,12 +116,12 @@ impl Config {
 /// Actions that the service wants to take as the result of some information. Might contain a
 /// command for connecting to or disconnecting from some peers or a message to broadcast for
 /// discovery  purposes.
-pub struct ServiceActions<M: Multiaddress> {
-    maybe_command: Option<ConnectionCommand<M>>,
-    maybe_message: Option<DiscoveryMessage<M>>,
+pub struct ServiceActions<M: Data, A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>> {
+    maybe_command: Option<ConnectionCommand<A>>,
+    maybe_message: Option<PeerAuthentications<M, A>>,
 }
 
-impl<M: Multiaddress> ServiceActions<M> {
+impl<M: Data, A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>> ServiceActions<M, A> {
     fn noop() -> Self {
         ServiceActions {
             maybe_command: None,
@@ -137,10 +139,13 @@ impl<M: Multiaddress> ServiceActions<M> {
 ///    1. In-session messages are forwarded to the user.
 ///    2. Authentication messages forwarded to session handlers.
 /// 4. Running periodic maintenance, mostly related to node discovery.
-pub struct Service<NI: NetworkIdentity, D: Data> {
+pub struct Service<NI: NetworkIdentity, M: Data, D: Data>
+where
+    NI::AddressingInformation: TryFrom<Vec<M>> + Into<Vec<M>>,
+{
     network_identity: NI,
-    connections: Connections<<NI::Multiaddress as Multiaddress>::PeerId>,
-    sessions: HashMap<SessionId, Session<D, NI::Multiaddress>>,
+    connections: Connections<NI::PeerId>,
+    sessions: HashMap<SessionId, Session<D, M, NI::AddressingInformation>>,
     to_retry: Vec<(
         PreSession,
         Option<oneshot::Sender<mpsc::UnboundedReceiver<D>>>,
@@ -150,7 +155,10 @@ pub struct Service<NI: NetworkIdentity, D: Data> {
     initial_delay: Duration,
 }
 
-impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
+impl<NI: NetworkIdentity, M: Data + Debug, D: Data> Service<NI, M, D>
+where
+    NI::AddressingInformation: TryFrom<Vec<M>> + Into<Vec<M>>,
+{
     /// Create a new connection manager service.
     pub fn new(network_identity: NI, config: Config) -> Self {
         let Config {
@@ -171,7 +179,7 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
 
     fn delete_reserved(
         to_remove: HashSet<NI::PeerId>,
-    ) -> Option<ConnectionCommand<NI::Multiaddress>> {
+    ) -> Option<ConnectionCommand<NI::AddressingInformation>> {
         match to_remove.is_empty() {
             true => None,
             false => Some(ConnectionCommand::DelReserved(to_remove)),
@@ -181,7 +189,7 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
     fn finish_session(
         &mut self,
         session_id: SessionId,
-    ) -> Option<ConnectionCommand<NI::Multiaddress>> {
+    ) -> Option<ConnectionCommand<NI::AddressingInformation>> {
         self.sessions.remove(&session_id);
         self.to_retry
             .retain(|(pre_session, _)| pre_session.session_id() != session_id);
@@ -191,7 +199,7 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
     fn discover_authorities(
         &mut self,
         session_id: &SessionId,
-    ) -> Option<DiscoveryMessage<NI::Multiaddress>> {
+    ) -> Option<PeerAuthentications<M, NI::AddressingInformation>> {
         self.sessions.get_mut(session_id).and_then(
             |Session {
                  handler, discovery, ..
@@ -200,7 +208,7 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
     }
 
     /// Returns all the network messages that should be sent as part of discovery at this moment.
-    pub fn discovery(&mut self) -> Vec<DiscoveryMessage<NI::Multiaddress>> {
+    pub fn discovery(&mut self) -> Vec<PeerAuthentications<M, NI::AddressingInformation>> {
         let sessions: Vec<_> = self.sessions.keys().cloned().collect();
         sessions
             .iter()
@@ -208,26 +216,14 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
             .collect()
     }
 
-    fn addresses(&self) -> Vec<NI::Multiaddress> {
-        let (addresses, peer_id) = self.network_identity.identity();
-        debug!(target: "aleph-network", "Got addresses:\n{:?}\n and peer_id:{:?}", addresses, peer_id);
-        addresses
-            .into_iter()
-            .filter_map(|address| address.add_matching_peer_id(peer_id.clone()))
-            .collect()
-    }
-
     async fn start_validator_session(
         &mut self,
         pre_session: PreValidatorSession,
-        addresses: Vec<NI::Multiaddress>,
-    ) -> Result<
-        (
-            Option<DiscoveryMessage<NI::Multiaddress>>,
-            mpsc::UnboundedReceiver<D>,
-        ),
-        SessionHandlerError,
-    > {
+        address: NI::AddressingInformation,
+    ) -> (
+        Option<PeerAuthentications<M, NI::AddressingInformation>>,
+        mpsc::UnboundedReceiver<D>,
+    ) {
         let PreValidatorSession {
             session_id,
             verifier,
@@ -235,7 +231,7 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
             pen,
         } = pre_session;
         let handler =
-            SessionHandler::new(Some((node_id, pen)), verifier, session_id, addresses).await?;
+            SessionHandler::new(Some((node_id, pen)), verifier, session_id, address).await;
         let discovery = Discovery::new(self.discovery_cooldown);
         let (data_for_user, data_from_network) = mpsc::unbounded();
         let data_for_user = Some(data_for_user);
@@ -247,20 +243,25 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
                 data_for_user,
             },
         );
-        Ok((self.discover_authorities(&session_id), data_from_network))
+        (self.discover_authorities(&session_id), data_from_network)
     }
 
     async fn update_validator_session(
         &mut self,
         pre_session: PreValidatorSession,
-    ) -> Result<(ServiceActions<NI::Multiaddress>, mpsc::UnboundedReceiver<D>), SessionHandlerError>
-    {
-        let addresses = self.addresses();
+    ) -> Result<
+        (
+            ServiceActions<M, NI::AddressingInformation>,
+            mpsc::UnboundedReceiver<D>,
+        ),
+        SessionHandlerError,
+    > {
+        let address = self.network_identity.identity();
         let session = match self.sessions.get_mut(&pre_session.session_id) {
             Some(session) => session,
             None => {
                 let (maybe_message, data_from_network) =
-                    self.start_validator_session(pre_session, addresses).await?;
+                    self.start_validator_session(pre_session, address).await;
                 return Ok((
                     ServiceActions {
                         maybe_command: None,
@@ -278,10 +279,10 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
         } = pre_session;
         let peers_to_stay = session
             .handler
-            .update(Some((node_id, pen)), verifier, addresses)
+            .update(Some((node_id, pen)), verifier, address)
             .await?
             .iter()
-            .flat_map(|address| address.get_peer_id())
+            .map(|address| address.peer_id())
             .collect();
         let maybe_command = Self::delete_reserved(
             self.connections
@@ -306,7 +307,7 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
         &mut self,
         pre_session: PreValidatorSession,
         result_for_user: Option<oneshot::Sender<mpsc::UnboundedReceiver<D>>>,
-    ) -> Result<ServiceActions<NI::Multiaddress>, SessionHandlerError> {
+    ) -> Result<ServiceActions<M, NI::AddressingInformation>, SessionHandlerError> {
         match self.update_validator_session(pre_session.clone()).await {
             Ok((actions, data_from_network)) => {
                 if let Some(result_for_user) = result_for_user {
@@ -327,13 +328,13 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
     async fn start_nonvalidator_session(
         &mut self,
         pre_session: PreNonvalidatorSession,
-        addresses: Vec<NI::Multiaddress>,
-    ) -> Result<(), SessionHandlerError> {
+        address: NI::AddressingInformation,
+    ) {
         let PreNonvalidatorSession {
             session_id,
             verifier,
         } = pre_session;
-        let handler = SessionHandler::new(None, verifier, session_id, addresses).await?;
+        let handler = SessionHandler::new(None, verifier, session_id, address).await;
         let discovery = Discovery::new(self.discovery_cooldown);
         self.sessions.insert(
             session_id,
@@ -343,25 +344,22 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
                 data_for_user: None,
             },
         );
-        Ok(())
     }
 
     async fn update_nonvalidator_session(
         &mut self,
         pre_session: PreNonvalidatorSession,
     ) -> Result<(), SessionHandlerError> {
-        let addresses = self.addresses();
+        let address = self.network_identity.identity();
         let session = match self.sessions.get_mut(&pre_session.session_id) {
             Some(session) => session,
             None => {
-                return self
-                    .start_nonvalidator_session(pre_session, addresses)
-                    .await;
+                return Ok(self.start_nonvalidator_session(pre_session, address).await);
             }
         };
         session
             .handler
-            .update(None, pre_session.verifier, addresses)
+            .update(None, pre_session.verifier, address)
             .await?;
         Ok(())
     }
@@ -384,7 +382,7 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
     pub async fn on_command(
         &mut self,
         command: SessionCommand<D>,
-    ) -> Result<ServiceActions<NI::Multiaddress>, SessionHandlerError> {
+    ) -> Result<ServiceActions<M, NI::AddressingInformation>, SessionHandlerError> {
         use SessionCommand::*;
         match command {
             StartValidator(session_id, verifier, node_id, pen, result_for_user) => {
@@ -419,7 +417,7 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
         data: D,
         session_id: SessionId,
         recipient: Recipient,
-    ) -> Vec<AddressedData<DataInSession<D>, <NI::Multiaddress as Multiaddress>::PeerId>> {
+    ) -> Vec<AddressedData<DataInSession<D>, NI::PeerId>> {
         if let Some(handler) = self
             .sessions
             .get(&session_id)
@@ -447,26 +445,29 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
     /// Returns actions the service wants to take.
     pub fn on_discovery_message(
         &mut self,
-        message: DiscoveryMessage<NI::Multiaddress>,
-    ) -> ServiceActions<NI::Multiaddress> {
+        message: DiscoveryMessage<M, NI::AddressingInformation>,
+    ) -> ServiceActions<M, NI::AddressingInformation> {
+        use DiscoveryMessage::*;
         let session_id = message.session_id();
         match self.sessions.get_mut(&session_id) {
             Some(Session {
                 handler, discovery, ..
             }) => {
-                let (addresses, maybe_message) = discovery.handle_message(message, handler);
-                let maybe_command = match !addresses.is_empty() && handler.is_validator() {
-                    true => {
-                        debug!(target: "aleph-network", "Adding addresses for session {:?} to reserved: {:?}", session_id, addresses);
-                        self.connections.add_peers(
-                            session_id,
-                            addresses.iter().flat_map(|address| address.get_peer_id()),
-                        );
-                        Some(ConnectionCommand::AddReserved(
-                            addresses.into_iter().collect(),
-                        ))
+                let (maybe_address, maybe_message) = match message {
+                    Authentication(authentication) => {
+                        discovery.handle_authentication(authentication, handler)
                     }
-                    false => None,
+                    LegacyAuthentication(legacy_authentication) => {
+                        discovery.handle_legacy_authentication(legacy_authentication, handler)
+                    }
+                };
+                let maybe_command = match (maybe_address, handler.is_validator()) {
+                    (Some(address), true) => {
+                        debug!(target: "aleph-network", "Adding addresses for session {:?} to reserved: {:?}", session_id, address);
+                        self.connections.add_peers(session_id, [address.peer_id()]);
+                        Some(ConnectionCommand::AddReserved([address].into()))
+                    }
+                    _ => None,
                 };
                 ServiceActions {
                     maybe_command,
@@ -499,7 +500,7 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
     /// the request.
     pub async fn retry_session_start(
         &mut self,
-    ) -> Result<ServiceActions<NI::Multiaddress>, SessionHandlerError> {
+    ) -> Result<ServiceActions<M, NI::AddressingInformation>, SessionHandlerError> {
         let (pre_session, result_for_user) = match self.to_retry.pop() {
             Some(to_retry) => to_retry,
             None => return Ok(ServiceActions::noop()),
@@ -596,15 +597,19 @@ impl<NI: NetworkIdentity, D: Data> Service<NI, D> {
     }
 }
 
-/// Input/output interface for the connection manager service.
-pub struct IO<D: Data, M: Multiaddress, VN: ValidatorNetwork<M::PeerId, M, DataInSession<D>>>
-where
-    M::PeerId: PublicKey,
+/// Input/output interface for the connectiona manager service.
+pub struct IO<
+    D: Data,
+    M: Data,
+    A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>,
+    VN: ValidatorNetwork<A::PeerId, A, DataInSession<D>>,
+> where
+    A::PeerId: PublicKey,
 {
-    authentications_for_network: mpsc::UnboundedSender<VersionedAuthentication<M>>,
+    authentications_for_network: mpsc::UnboundedSender<VersionedAuthentication<M, A>>,
     commands_from_user: mpsc::UnboundedReceiver<SessionCommand<D>>,
     messages_from_user: mpsc::UnboundedReceiver<(D, SessionId, Recipient)>,
-    authentications_from_network: mpsc::UnboundedReceiver<VersionedAuthentication<M>>,
+    authentications_from_network: mpsc::UnboundedReceiver<VersionedAuthentication<M, A>>,
     validator_network: VN,
 }
 
@@ -621,17 +626,22 @@ pub enum Error {
     NetworkChannel,
 }
 
-impl<D: Data, M: Multiaddress, VN: ValidatorNetwork<M::PeerId, M, DataInSession<D>>> IO<D, M, VN>
+impl<
+        D: Data,
+        M: Data + Debug,
+        A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>,
+        VN: ValidatorNetwork<A::PeerId, A, DataInSession<D>>,
+    > IO<D, M, A, VN>
 where
-    M::PeerId: PublicKey,
+    A::PeerId: PublicKey,
 {
     pub fn new(
-        authentications_for_network: mpsc::UnboundedSender<VersionedAuthentication<M>>,
+        authentications_for_network: mpsc::UnboundedSender<VersionedAuthentication<M, A>>,
         commands_from_user: mpsc::UnboundedReceiver<SessionCommand<D>>,
         messages_from_user: mpsc::UnboundedReceiver<(D, SessionId, Recipient)>,
-        authentications_from_network: mpsc::UnboundedReceiver<VersionedAuthentication<M>>,
+        authentications_from_network: mpsc::UnboundedReceiver<VersionedAuthentication<M, A>>,
         validator_network: VN,
-    ) -> IO<D, M, VN> {
+    ) -> IO<D, M, A, VN> {
         IO {
             authentications_for_network,
             commands_from_user,
@@ -641,23 +651,42 @@ where
         }
     }
 
-    fn send_data(&self, to_send: AddressedData<DataInSession<D>, M::PeerId>) {
+    fn send_data(&self, to_send: AddressedData<DataInSession<D>, A::PeerId>) {
         self.validator_network.send(to_send.0, to_send.1)
     }
 
-    fn send_authentication(&self, to_send: DiscoveryMessage<M>) -> Result<(), Error> {
-        self.authentications_for_network
-            .unbounded_send(VersionedAuthentication::V1(to_send))
-            .map_err(|_| Error::NetworkSend)
+    fn send_authentication(&self, to_send: PeerAuthentications<M, A>) -> Result<(), Error> {
+        use PeerAuthentications::*;
+        match to_send {
+            NewOnly(authentication) => self
+                .authentications_for_network
+                .unbounded_send(VersionedAuthentication::V2(authentication))
+                .map_err(|_| Error::NetworkSend),
+            LegacyOnly(legacy_authentication) => self
+                .authentications_for_network
+                .unbounded_send(VersionedAuthentication::V1(
+                    LegacyDiscoveryMessage::AuthenticationBroadcast(legacy_authentication),
+                ))
+                .map_err(|_| Error::NetworkSend),
+            Both(authentication, legacy_authentication) => {
+                self.authentications_for_network
+                    .unbounded_send(VersionedAuthentication::V2(authentication))
+                    .map_err(|_| Error::NetworkSend)?;
+                self.authentications_for_network
+                    .unbounded_send(VersionedAuthentication::V1(
+                        LegacyDiscoveryMessage::AuthenticationBroadcast(legacy_authentication),
+                    ))
+                    .map_err(|_| Error::NetworkSend)
+            }
+        }
     }
 
-    fn handle_connection_command(&mut self, connection_command: ConnectionCommand<M>) {
+    fn handle_connection_command(&mut self, connection_command: ConnectionCommand<A>) {
         match connection_command {
             ConnectionCommand::AddReserved(addresses) => {
-                for multi in addresses {
-                    if let Some(peer_id) = multi.get_peer_id() {
-                        self.validator_network.add_connection(peer_id, vec![multi]);
-                    }
+                for address in addresses {
+                    self.validator_network
+                        .add_connection(address.peer_id(), address);
                 }
             }
             ConnectionCommand::DelReserved(peers) => {
@@ -673,7 +702,7 @@ where
         ServiceActions {
             maybe_command,
             maybe_message,
-        }: ServiceActions<M>,
+        }: ServiceActions<M, A>,
     ) -> Result<(), Error> {
         if let Some(command) = maybe_command {
             self.handle_connection_command(command);
@@ -685,9 +714,9 @@ where
     }
 
     /// Run the connection manager service with this IO.
-    pub async fn run<NI: NetworkIdentity<Multiaddress = M, PeerId = M::PeerId>>(
+    pub async fn run<NI: NetworkIdentity<AddressingInformation = A, PeerId = A::PeerId>>(
         mut self,
-        mut service: Service<NI, D>,
+        mut service: Service<NI, M, D>,
     ) -> Result<(), Error> {
         // Initial delay is needed so that Network is fully set up and we received some first discovery broadcasts from other nodes.
         // Otherwise this might cause first maintenance never working, as it happens before first broadcasts.
@@ -749,7 +778,7 @@ where
                         Err(e) => warn!(target: "aleph-network", "Retry failed to update handler: {:?}", e),
                     }
                     for to_send in service.discovery() {
-                        self.send_authentication(to_send)?;
+                        self.send_authentication(to_send.into())?;
                     }
                 },
                 _ = status_ticker.tick() => {
@@ -762,17 +791,18 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{iter, time::Duration};
 
     use futures::{channel::oneshot, StreamExt};
 
     use super::{Config, Error, Service, ServiceActions, SessionCommand};
     use crate::{
         network::{
-            manager::{DataInSession, DiscoveryMessage},
-            mock::{crypto_basics, MockNetworkIdentity},
+            manager::{compatibility::PeerAuthentications, DataInSession, DiscoveryMessage},
+            mock::crypto_basics,
             ConnectionCommand,
         },
+        testing::mocks::validator_network::{random_address, MockAddressingInformation},
         Recipient, SessionId,
     };
 
@@ -781,9 +811,9 @@ mod tests {
     const DISCOVERY_PERIOD: Duration = Duration::from_secs(60);
     const INITIAL_DELAY: Duration = Duration::from_secs(5);
 
-    fn build() -> Service<MockNetworkIdentity, i32> {
+    fn build() -> Service<MockAddressingInformation, MockAddressingInformation, i32> {
         Service::new(
-            MockNetworkIdentity::new(),
+            random_address(),
             Config::new(MAINTENANCE_PERIOD, DISCOVERY_PERIOD, INITIAL_DELAY),
         )
     }
@@ -900,9 +930,12 @@ mod tests {
             .await
             .unwrap();
         let message = maybe_message.expect("there should be a discovery message");
-        let addresses = match &message {
-            DiscoveryMessage::AuthenticationBroadcast((auth_data, _)) => auth_data.addresses(),
-            _ => panic!("Expected an authentication broadcast, got {:?}", message),
+        let (address, message) = match message {
+            PeerAuthentications::Both(authentication, _) => (
+                authentication.0.address(),
+                DiscoveryMessage::Authentication(authentication),
+            ),
+            message => panic!("Expected both authentications, got {:?}", message),
         };
         let ServiceActions {
             maybe_command,
@@ -911,7 +944,7 @@ mod tests {
         assert_eq!(
             maybe_command,
             Some(ConnectionCommand::AddReserved(
-                addresses.into_iter().collect()
+                iter::once(address).collect()
             ))
         );
         assert!(maybe_message.is_some());
@@ -941,7 +974,12 @@ mod tests {
             ))
             .await
             .unwrap();
-        let message = maybe_message.expect("there should be a discovery message");
+        let message = match maybe_message.expect("there should be a discovery message") {
+            PeerAuthentications::Both(authentication, _) => {
+                DiscoveryMessage::Authentication(authentication)
+            }
+            message => panic!("Expected both authentications, got {:?}", message),
+        };
         service.on_discovery_message(message);
         let messages = service.on_user_message(2137, session_id, Recipient::Everyone);
         assert_eq!(messages.len(), 1);

--- a/finality-aleph/src/network/manager/session.rs
+++ b/finality-aleph/src/network/manager/session.rs
@@ -6,36 +6,39 @@ use crate::{
     abft::NodeCount,
     crypto::{AuthorityPen, AuthorityVerifier},
     network::{
-        manager::{AuthData, Authentication},
-        Multiaddress, PeerId,
+        manager::{
+            compatibility::PeerAuthentications, AuthData, Authentication, LegacyAuthData,
+            LegacyAuthentication,
+        },
+        AddressingInformation, Data,
     },
     NodeIndex, SessionId,
 };
 
 #[derive(Debug)]
-pub enum SessionInfo<M: Multiaddress> {
+pub enum SessionInfo<M: Data, A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>> {
     SessionId(SessionId),
-    OwnAuthentication(Authentication<M>),
+    OwnAuthentication(PeerAuthentications<M, A>),
 }
 
-impl<M: Multiaddress> SessionInfo<M> {
+impl<M: Data, A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>> SessionInfo<M, A> {
     fn session_id(&self) -> SessionId {
         match self {
             SessionInfo::SessionId(session_id) => *session_id,
-            SessionInfo::OwnAuthentication((auth_data, _)) => auth_data.session_id,
+            SessionInfo::OwnAuthentication(peer_authentications) => {
+                peer_authentications.session_id()
+            }
         }
     }
 }
 
-type PeerAuthentications<M> = (Authentication<M>, Option<Authentication<M>>);
-
 /// A struct for handling authentications for a given session and maintaining
 /// mappings between PeerIds and NodeIndexes within that session.
-pub struct Handler<M: Multiaddress> {
-    peers_by_node: HashMap<NodeIndex, M::PeerId>,
-    authentications: HashMap<M::PeerId, PeerAuthentications<M>>,
-    session_info: SessionInfo<M>,
-    own_peer_id: M::PeerId,
+pub struct Handler<M: Data, A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>> {
+    peers_by_node: HashMap<NodeIndex, A::PeerId>,
+    authentications: HashMap<A::PeerId, PeerAuthentications<M, A>>,
+    session_info: SessionInfo<M, A>,
+    own_peer_id: A::PeerId,
     authority_index_and_pen: Option<(NodeIndex, AuthorityPen)>,
     authority_verifier: AuthorityVerifier,
 }
@@ -45,105 +48,56 @@ pub enum HandlerError {
     /// Returned when handler is change from validator to nonvalidator
     /// or vice versa
     TypeChange,
-    /// Returned when a set of addresses is not usable for creating authentications.
-    /// Either because none of the addresses are externally reachable libp2p addresses,
-    /// or the addresses contain multiple libp2p PeerIds.
-    NoP2pAddresses,
-    MultiplePeerIds,
 }
 
-enum CommonPeerId<PID: PeerId> {
-    Unknown,
-    Unique(PID),
-    NotUnique,
-}
-
-impl<PID: PeerId> From<CommonPeerId<PID>> for Option<PID> {
-    fn from(cpi: CommonPeerId<PID>) -> Self {
-        use CommonPeerId::*;
-        match cpi {
-            Unique(peer_id) => Some(peer_id),
-            Unknown | NotUnique => None,
-        }
-    }
-}
-
-impl<PID: PeerId> CommonPeerId<PID> {
-    fn aggregate(self, peer_id: PID) -> Self {
-        use CommonPeerId::*;
-        match self {
-            Unknown => Unique(peer_id),
-            Unique(current_peer_id) => match peer_id == current_peer_id {
-                true => Unique(current_peer_id),
-                false => NotUnique,
-            },
-            NotUnique => NotUnique,
-        }
-    }
-}
-
-fn get_common_peer_id<M: Multiaddress>(addresses: &[M]) -> Option<M::PeerId> {
-    addresses
-        .iter()
-        .fold(
-            CommonPeerId::Unknown,
-            |common_peer_id, address| match address.get_peer_id() {
-                Some(peer_id) => common_peer_id.aggregate(peer_id),
-                None => CommonPeerId::NotUnique,
-            },
-        )
-        .into()
-}
-
-fn retrieve_peer_id<M: Multiaddress>(addresses: &[M]) -> Result<M::PeerId, HandlerError> {
-    if addresses.is_empty() {
-        return Err(HandlerError::NoP2pAddresses);
-    }
-    get_common_peer_id(addresses).ok_or(HandlerError::MultiplePeerIds)
-}
-
-async fn construct_session_info<M: Multiaddress>(
+async fn construct_session_info<
+    M: Data,
+    A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>,
+>(
     authority_index_and_pen: &Option<(NodeIndex, AuthorityPen)>,
     session_id: SessionId,
-    addresses: Vec<M>,
-) -> Result<(SessionInfo<M>, M::PeerId), HandlerError> {
-    let addresses: Vec<_> = addresses
-        .into_iter()
-        .filter(|address| address.get_peer_id().is_some())
-        .collect();
-    let peer = retrieve_peer_id(&addresses)?;
-
-    if let Some((node_index, authority_pen)) = authority_index_and_pen {
-        let auth_data = AuthData {
-            addresses,
-            node_id: *node_index,
-            session_id,
-        };
-        let signature = authority_pen.sign(&auth_data.encode()).await;
-        return Ok((SessionInfo::OwnAuthentication((auth_data, signature)), peer));
+    address: A,
+) -> (SessionInfo<M, A>, A::PeerId) {
+    let peer_id = address.peer_id();
+    match authority_index_and_pen {
+        Some((node_index, authority_pen)) => {
+            let auth_data = AuthData {
+                address,
+                node_id: *node_index,
+                session_id,
+            };
+            let legacy_auth_data: LegacyAuthData<M> = auth_data.clone().into();
+            let signature = authority_pen.sign(&auth_data.encode()).await;
+            let legacy_signature = authority_pen.sign(&legacy_auth_data.encode()).await;
+            let authentications = PeerAuthentications::Both(
+                (auth_data, signature),
+                (legacy_auth_data, legacy_signature),
+            );
+            (SessionInfo::OwnAuthentication(authentications), peer_id)
+        }
+        None => (SessionInfo::SessionId(session_id), peer_id),
     }
-    Ok((SessionInfo::SessionId(session_id), peer))
 }
 
-impl<M: Multiaddress> Handler<M> {
-    /// Returns an error if the set of addresses contains no external libp2p addresses, or contains
-    /// at least two such addresses with differing PeerIds.
+impl<M: Data, A: AddressingInformation + TryFrom<Vec<M>> + Into<Vec<M>>> Handler<M, A> {
+    /// Creates a new session handler. It will be a validator session handler if the authority
+    /// index and pen are provided.
     pub async fn new(
         authority_index_and_pen: Option<(NodeIndex, AuthorityPen)>,
         authority_verifier: AuthorityVerifier,
         session_id: SessionId,
-        addresses: Vec<M>,
-    ) -> Result<Handler<M>, HandlerError> {
+        address: A,
+    ) -> Handler<M, A> {
         let (session_info, own_peer_id) =
-            construct_session_info(&authority_index_and_pen, session_id, addresses).await?;
-        Ok(Handler {
+            construct_session_info(&authority_index_and_pen, session_id, address).await;
+        Handler {
             peers_by_node: HashMap::new(),
             authentications: HashMap::new(),
             session_info,
             authority_index_and_pen,
             authority_verifier,
             own_peer_id,
-        })
+        }
     }
 
     fn index(&self) -> Option<NodeIndex> {
@@ -166,10 +120,12 @@ impl<M: Multiaddress> Handler<M> {
     }
 
     /// Returns the authentication for the node and session this handler is responsible for.
-    pub fn authentication(&self) -> Option<Authentication<M>> {
+    pub fn authentication(&self) -> Option<PeerAuthentications<M, A>> {
         match &self.session_info {
             SessionInfo::SessionId(_) => None,
-            SessionInfo::OwnAuthentication(own_authentication) => Some(own_authentication.clone()),
+            SessionInfo::OwnAuthentication(own_authentications) => {
+                Some(own_authentications.clone())
+            }
         }
     }
 
@@ -187,61 +143,95 @@ impl<M: Multiaddress> Handler<M> {
             .collect()
     }
 
-    /// Verifies the authentication, uses it to update mappings, and returns whether we should
-    /// remain connected to the multiaddresses.
-    pub fn handle_authentication(&mut self, authentication: Authentication<M>) -> bool {
-        if authentication.0.session_id != self.session_id() {
-            return false;
+    /// Verifies the authentication, uses it to update mappings, and returns the address we
+    /// should stay connected to if any.
+    pub fn handle_authentication(&mut self, authentication: Authentication<A>) -> Option<A> {
+        if authentication.0.session() != self.session_id() {
+            return None;
         }
         let (auth_data, signature) = &authentication;
 
-        // The auth is completely useless if it doesn't have a consistent PeerId.
-        let peer_id = match get_common_peer_id(&auth_data.addresses) {
-            Some(peer_id) => peer_id,
-            None => return false,
-        };
+        let address = auth_data.address();
+        let peer_id = address.peer_id();
         if peer_id == self.own_peer_id {
-            return false;
+            return None;
         }
         if !self
             .authority_verifier
-            .verify(&auth_data.encode(), signature, auth_data.node_id)
+            .verify(&auth_data.encode(), signature, auth_data.creator())
         {
-            // This might be an authentication for a key that has been changed, but we are not yet
-            // aware of the change.
-            if let Some(auth_pair) = self.authentications.get_mut(&peer_id) {
-                auth_pair.1 = Some(authentication.clone());
-            }
-            return false;
+            return None;
         }
         self.peers_by_node
-            .insert(auth_data.node_id, peer_id.clone());
-        self.authentications.insert(peer_id, (authentication, None));
-        true
+            .insert(auth_data.creator(), peer_id.clone());
+        self.authentications
+            .entry(peer_id)
+            .and_modify(|authentications| {
+                authentications.add_authentication(authentication.clone())
+            })
+            .or_insert(PeerAuthentications::NewOnly(authentication));
+        Some(address)
+    }
+
+    /// Verifies the legacy authentication, uses it to update mappings, and returns the address we should stay connected to if any.
+    pub fn handle_legacy_authentication(
+        &mut self,
+        legacy_authentication: LegacyAuthentication<M>,
+    ) -> Option<A> {
+        if legacy_authentication.0.session() != self.session_id() {
+            return None;
+        }
+        let (legacy_auth_data, signature) = &legacy_authentication;
+
+        if !self.authority_verifier.verify(
+            &legacy_auth_data.encode(),
+            signature,
+            legacy_auth_data.creator(),
+        ) {
+            return None;
+        }
+
+        let maybe_auth_data: Option<AuthData<A>> = legacy_auth_data.clone().try_into().ok();
+        let address = match maybe_auth_data {
+            Some(auth_data) => auth_data.address(),
+            None => return None,
+        };
+        let peer_id = address.peer_id();
+        if peer_id == self.own_peer_id {
+            return None;
+        }
+        self.peers_by_node
+            .insert(legacy_auth_data.creator(), peer_id.clone());
+        self.authentications
+            .entry(peer_id)
+            .and_modify(|authentications| {
+                authentications.add_legacy_authentication(legacy_authentication.clone())
+            })
+            .or_insert(PeerAuthentications::LegacyOnly(legacy_authentication));
+        Some(address)
     }
 
     /// Returns the PeerId of the node with the given NodeIndex, if known.
-    pub fn peer_id(&self, node_id: &NodeIndex) -> Option<M::PeerId> {
+    pub fn peer_id(&self, node_id: &NodeIndex) -> Option<A::PeerId> {
         self.peers_by_node.get(node_id).cloned()
     }
 
     /// Returns maping from NodeIndex to PeerId
-    pub fn peers(&self) -> HashMap<NodeIndex, M::PeerId> {
+    pub fn peers(&self) -> HashMap<NodeIndex, A::PeerId> {
         self.peers_by_node.clone()
     }
 
     /// Updates the handler with the given keychain and set of own addresses.
     /// Returns an error if the set of addresses is not valid.
-    /// All authentications will be rechecked, invalid ones purged and cached ones that turn out to
-    /// now be valid canonalized.
+    /// All authentications will be rechecked, invalid ones purged.
     /// Own authentication will be regenerated.
     /// If successful returns a set of addresses that we should be connected to.
     pub async fn update(
         &mut self,
         authority_index_and_pen: Option<(NodeIndex, AuthorityPen)>,
         authority_verifier: AuthorityVerifier,
-        addresses: Vec<M>,
-    ) -> Result<Vec<M>, HandlerError> {
+        address: A,
+    ) -> Result<Vec<A>, HandlerError> {
         if authority_index_and_pen.is_none() != self.authority_index_and_pen.is_none() {
             return Err(HandlerError::TypeChange);
         }
@@ -252,76 +242,43 @@ impl<M: Multiaddress> Handler<M> {
             authority_index_and_pen,
             authority_verifier,
             self.session_id(),
-            addresses,
+            address,
         )
-        .await?;
+        .await;
 
-        for (_, (auth, maybe_auth)) in authentications {
-            self.handle_authentication(auth);
-            if let Some(auth) = maybe_auth {
-                self.handle_authentication(auth);
-            }
+        use PeerAuthentications::*;
+        for (_, authentication) in authentications {
+            match authentication {
+                NewOnly(auth) => self.handle_authentication(auth),
+                LegacyOnly(legacy_auth) => self.handle_legacy_authentication(legacy_auth),
+                Both(auth, legacy_auth) => {
+                    self.handle_legacy_authentication(legacy_auth);
+                    self.handle_authentication(auth)
+                }
+            };
         }
         Ok(self
             .authentications
             .values()
-            .flat_map(|((auth_data, _), _)| auth_data.addresses.iter().cloned())
+            .flat_map(|authentication| authentication.maybe_address())
             .collect())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{get_common_peer_id, Handler, HandlerError};
+    use super::{Handler, HandlerError};
     use crate::{
         network::{
-            mock::{crypto_basics, MockNetworkIdentity},
-            NetworkIdentity,
+            mock::crypto_basics,
+            testing::{authentication, legacy_authentication},
+            AddressingInformation,
         },
-        testing::mocks::validator_network::{random_multiaddress, MockMultiaddress},
+        testing::mocks::validator_network::random_address,
         NodeIndex, SessionId,
     };
 
     const NUM_NODES: usize = 7;
-
-    #[tokio::test]
-    async fn creates_with_correct_data() {
-        let mut crypto_basics = crypto_basics(NUM_NODES).await;
-        assert!(Handler::new(
-            Some(crypto_basics.0.pop().unwrap()),
-            crypto_basics.1,
-            SessionId(43),
-            MockNetworkIdentity::new().identity().0,
-        )
-        .await
-        .is_ok());
-    }
-
-    #[tokio::test]
-    async fn creates_with_local_address() {
-        let mut crypto_basics = crypto_basics(NUM_NODES).await;
-        assert!(Handler::new(
-            Some(crypto_basics.0.pop().unwrap()),
-            crypto_basics.1,
-            SessionId(43),
-            MockNetworkIdentity::new().identity().0,
-        )
-        .await
-        .is_ok());
-    }
-
-    #[tokio::test]
-    async fn creates_without_node_index_nor_authority_pen() {
-        let crypto_basics = crypto_basics(NUM_NODES).await;
-        assert!(Handler::new(
-            None,
-            crypto_basics.1,
-            SessionId(43),
-            MockNetworkIdentity::new().identity().0,
-        )
-        .await
-        .is_ok());
-    }
 
     #[tokio::test]
     async fn identifies_whether_node_is_authority_in_current_session() {
@@ -330,18 +287,16 @@ mod tests {
             None,
             crypto_basics.1.clone(),
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
+        .await;
         let authority_handler = Handler::new(
             Some(crypto_basics.0.pop().unwrap()),
             crypto_basics.1,
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
+        .await;
         assert!(!no_authority_handler.is_validator());
         assert!(authority_handler.is_validator());
     }
@@ -349,64 +304,28 @@ mod tests {
     #[tokio::test]
     async fn non_validator_handler_returns_none_for_authentication() {
         let crypto_basics = crypto_basics(NUM_NODES).await;
-        assert!(Handler::new(
-            None,
-            crypto_basics.1,
-            SessionId(43),
-            MockNetworkIdentity::new().identity().0
-        )
-        .await
-        .unwrap()
-        .authentication()
-        .is_none());
-    }
-
-    #[tokio::test]
-    async fn fails_to_create_with_no_addresses() {
-        let mut crypto_basics = crypto_basics(NUM_NODES).await;
-        assert!(matches!(
-            Handler::new(
-                Some(crypto_basics.0.pop().unwrap()),
-                crypto_basics.1,
-                SessionId(43),
-                Vec::<MockMultiaddress>::new()
-            )
-            .await,
-            Err(HandlerError::NoP2pAddresses)
-        ));
-    }
-
-    #[tokio::test]
-    async fn fails_to_create_with_non_unique_peer_id() {
-        let mut crypto_basics = crypto_basics(NUM_NODES).await;
-        let addresses = vec![random_multiaddress(), random_multiaddress()];
-        assert!(matches!(
-            Handler::new(
-                Some(crypto_basics.0.pop().unwrap()),
-                crypto_basics.1,
-                SessionId(43),
-                addresses
-            )
-            .await,
-            Err(HandlerError::MultiplePeerIds)
-        ));
+        assert!(
+            Handler::new(None, crypto_basics.1, SessionId(43), random_address(),)
+                .await
+                .authentication()
+                .is_none()
+        );
     }
 
     #[tokio::test]
     async fn fails_to_update_from_validator_to_non_validator() {
         let mut crypto_basics = crypto_basics(NUM_NODES).await;
-        let addresses = MockNetworkIdentity::new().identity().0;
+        let address = random_address();
         let mut handler0 = Handler::new(
             Some(crypto_basics.0.pop().unwrap()),
             crypto_basics.1.clone(),
             SessionId(43),
-            addresses.clone(),
+            address.clone(),
         )
-        .await
-        .unwrap();
+        .await;
         assert!(matches!(
             handler0
-                .update(None, crypto_basics.1.clone(), addresses)
+                .update(None, crypto_basics.1.clone(), address)
                 .await,
             Err(HandlerError::TypeChange)
         ));
@@ -415,21 +334,20 @@ mod tests {
     #[tokio::test]
     async fn fails_to_update_from_non_validator_to_validator() {
         let mut crypto_basics = crypto_basics(NUM_NODES).await;
-        let addresses = MockNetworkIdentity::new().identity().0;
+        let address = random_address();
         let mut handler0 = Handler::new(
             None,
             crypto_basics.1.clone(),
             SessionId(43),
-            addresses.clone(),
+            address.clone(),
         )
-        .await
-        .unwrap();
+        .await;
         assert!(matches!(
             handler0
                 .update(
                     Some(crypto_basics.0.pop().unwrap()),
                     crypto_basics.1.clone(),
-                    addresses,
+                    address,
                 )
                 .await,
             Err(HandlerError::TypeChange)
@@ -443,10 +361,9 @@ mod tests {
             Some(crypto_basics.0.pop().unwrap()),
             crypto_basics.1,
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
+        .await;
         assert!(handler0.peer_id(&NodeIndex(0)).is_none());
     }
 
@@ -457,10 +374,9 @@ mod tests {
             Some(crypto_basics.0.pop().unwrap()),
             crypto_basics.1,
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
+        .await;
         let missing_nodes = handler0.missing_nodes();
         let expected_missing: Vec<_> = (0..NUM_NODES - 1).map(NodeIndex).collect();
         assert_eq!(missing_nodes, expected_missing);
@@ -474,25 +390,28 @@ mod tests {
             Some(crypto_basics.0[0].clone()),
             crypto_basics.1.clone(),
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
-        let addresses = MockNetworkIdentity::new().identity().0;
+        .await;
+        let address = random_address();
         let handler1 = Handler::new(
             Some(crypto_basics.0[1].clone()),
             crypto_basics.1.clone(),
             SessionId(43),
-            addresses.clone(),
+            address.clone(),
         )
-        .await
-        .unwrap();
-        assert!(handler0.handle_authentication(handler1.authentication().unwrap()));
+        .await;
+        assert!(handler0
+            .handle_authentication(authentication(&handler1))
+            .is_some());
+        assert!(handler0
+            .handle_legacy_authentication(legacy_authentication(&handler1))
+            .is_some());
         let missing_nodes = handler0.missing_nodes();
         let expected_missing: Vec<_> = (2..NUM_NODES).map(NodeIndex).collect();
         assert_eq!(missing_nodes, expected_missing);
-        let peer_id1 = get_common_peer_id(&addresses);
-        assert_eq!(handler0.peer_id(&NodeIndex(1)), peer_id1);
+        let peer_id1 = address.peer_id();
+        assert_eq!(handler0.peer_id(&NodeIndex(1)), Some(peer_id1));
     }
 
     #[tokio::test]
@@ -502,26 +421,29 @@ mod tests {
             None,
             crypto_basics.1.clone(),
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
-        let addresses = MockNetworkIdentity::new().identity().0;
+        .await;
+        let address = random_address();
         let handler1 = Handler::new(
             Some(crypto_basics.0[1].clone()),
             crypto_basics.1.clone(),
             SessionId(43),
-            addresses.clone(),
+            address.clone(),
         )
-        .await
-        .unwrap();
-        assert!(handler0.handle_authentication(handler1.authentication().unwrap()));
+        .await;
+        assert!(handler0
+            .handle_authentication(authentication(&handler1))
+            .is_some());
+        assert!(handler0
+            .handle_legacy_authentication(legacy_authentication(&handler1))
+            .is_some());
         let missing_nodes = handler0.missing_nodes();
         let mut expected_missing: Vec<_> = (0..NUM_NODES).map(NodeIndex).collect();
         expected_missing.remove(1);
         assert_eq!(missing_nodes, expected_missing);
-        let peer_id1 = get_common_peer_id(&addresses);
-        assert_eq!(handler0.peer_id(&NodeIndex(1)), peer_id1);
+        let peer_id1 = address.peer_id();
+        assert_eq!(handler0.peer_id(&NodeIndex(1)), Some(peer_id1));
     }
 
     #[tokio::test]
@@ -531,21 +453,19 @@ mod tests {
             Some(crypto_basics.0[0].clone()),
             crypto_basics.1.clone(),
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
+        .await;
         let handler1 = Handler::new(
             Some(crypto_basics.0[1].clone()),
             crypto_basics.1.clone(),
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
-        let mut authentication = handler1.authentication().unwrap();
-        authentication.1 = handler0.authentication().unwrap().1;
-        assert!(!handler0.handle_authentication(authentication));
+        .await;
+        let mut bad_authentication = authentication(&handler1);
+        bad_authentication.1 = authentication(&handler0).1;
+        assert!(handler0.handle_authentication(bad_authentication).is_none());
         let missing_nodes = handler0.missing_nodes();
         let expected_missing: Vec<_> = (1..NUM_NODES).map(NodeIndex).collect();
         assert_eq!(missing_nodes, expected_missing);
@@ -558,19 +478,22 @@ mod tests {
             Some(crypto_basics.0[0].clone()),
             crypto_basics.1.clone(),
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
+        .await;
         let handler1 = Handler::new(
             Some(crypto_basics.0[1].clone()),
             crypto_basics.1.clone(),
             SessionId(44),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
-        assert!(!handler0.handle_authentication(handler1.authentication().unwrap()));
+        .await;
+        assert!(handler0
+            .handle_authentication(authentication(&handler1))
+            .is_none());
+        assert!(handler0
+            .handle_legacy_authentication(legacy_authentication(&handler1))
+            .is_none());
         let missing_nodes = handler0.missing_nodes();
         let expected_missing: Vec<_> = (1..NUM_NODES).map(NodeIndex).collect();
         assert_eq!(missing_nodes, expected_missing);
@@ -583,11 +506,15 @@ mod tests {
             Some(awaited_crypto_basics.0[0].clone()),
             awaited_crypto_basics.1.clone(),
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
-        assert!(!handler0.handle_authentication(handler0.authentication().unwrap()));
+        .await;
+        assert!(handler0
+            .handle_authentication(authentication(&handler0))
+            .is_none());
+        assert!(handler0
+            .handle_legacy_authentication(legacy_authentication(&handler0))
+            .is_none());
         let missing_nodes = handler0.missing_nodes();
         let expected_missing: Vec<_> = (1..NUM_NODES).map(NodeIndex).collect();
         assert_eq!(missing_nodes, expected_missing);
@@ -600,25 +527,28 @@ mod tests {
             Some(awaited_crypto_basics.0[0].clone()),
             awaited_crypto_basics.1.clone(),
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
+        .await;
         let handler1 = Handler::new(
             Some(awaited_crypto_basics.0[1].clone()),
             awaited_crypto_basics.1.clone(),
             SessionId(43),
-            MockNetworkIdentity::new().identity().0,
+            random_address(),
         )
-        .await
-        .unwrap();
-        assert!(handler0.handle_authentication(handler1.authentication().unwrap()));
+        .await;
+        assert!(handler0
+            .handle_authentication(authentication(&handler1))
+            .is_some());
+        assert!(handler0
+            .handle_legacy_authentication(legacy_authentication(&handler1))
+            .is_some());
         let new_crypto_basics = crypto_basics(NUM_NODES).await;
         handler0
             .update(
                 Some(new_crypto_basics.0[0].clone()),
                 new_crypto_basics.1.clone(),
-                MockNetworkIdentity::new().identity().0,
+                random_address(),
             )
             .await
             .unwrap();
@@ -626,55 +556,5 @@ mod tests {
         let expected_missing: Vec<_> = (1..NUM_NODES).map(NodeIndex).collect();
         assert_eq!(missing_nodes, expected_missing);
         assert!(handler0.peer_id(&NodeIndex(1)).is_none());
-    }
-
-    #[tokio::test]
-    async fn uses_cached_authentication() {
-        let awaited_crypto_basics = crypto_basics(NUM_NODES).await;
-        let addresses0 = MockNetworkIdentity::new().identity().0;
-        let mut handler0 = Handler::new(
-            Some(awaited_crypto_basics.0[0].clone()),
-            awaited_crypto_basics.1.clone(),
-            SessionId(43),
-            addresses0.clone(),
-        )
-        .await
-        .unwrap();
-        let addresses1 = MockNetworkIdentity::new().identity().0;
-        let mut handler1 = Handler::new(
-            Some(awaited_crypto_basics.0[1].clone()),
-            awaited_crypto_basics.1.clone(),
-            SessionId(43),
-            addresses1.clone(),
-        )
-        .await
-        .unwrap();
-        assert!(handler0.handle_authentication(handler1.authentication().unwrap()));
-        let new_crypto_basics = crypto_basics(NUM_NODES).await;
-        assert!(handler1
-            .update(
-                Some(new_crypto_basics.0[1].clone()),
-                new_crypto_basics.1.clone(),
-                addresses1.clone(),
-            )
-            .await
-            .unwrap()
-            .is_empty());
-        assert!(!handler0.handle_authentication(handler1.authentication().unwrap()));
-        handler0
-            .update(
-                Some(new_crypto_basics.0[0].clone()),
-                new_crypto_basics.1.clone(),
-                addresses0,
-            )
-            .await
-            .unwrap();
-        let missing_nodes = handler0.missing_nodes();
-        let expected_missing: Vec<_> = (2..NUM_NODES).map(NodeIndex).collect();
-        assert_eq!(missing_nodes, expected_missing);
-        assert_eq!(
-            handler0.peer_id(&NodeIndex(1)),
-            get_common_peer_id(&addresses1)
-        );
     }
 }

--- a/finality-aleph/src/network/mock.rs
+++ b/finality-aleph/src/network/mock.rs
@@ -12,32 +12,10 @@ use tokio::time::timeout;
 
 use crate::{
     crypto::{AuthorityPen, AuthorityVerifier},
-    network::{Event, EventStream, Network, NetworkIdentity, NetworkSender, Protocol},
-    testing::mocks::validator_network::{random_identity, MockMultiaddress},
+    network::{Event, EventStream, Network, NetworkSender, Protocol},
     validator_network::mock::MockPublicKey,
     AuthorityId, NodeIndex,
 };
-
-pub struct MockNetworkIdentity {
-    addresses: Vec<MockMultiaddress>,
-    peer_id: MockPublicKey,
-}
-
-impl MockNetworkIdentity {
-    pub fn new() -> Self {
-        let (addresses, peer_id) = random_identity();
-        MockNetworkIdentity { addresses, peer_id }
-    }
-}
-
-impl NetworkIdentity for MockNetworkIdentity {
-    type PeerId = MockPublicKey;
-    type Multiaddress = MockMultiaddress;
-
-    fn identity(&self) -> (Vec<Self::Multiaddress>, Self::PeerId) {
-        (self.addresses.clone(), self.peer_id.clone())
-    }
-}
 
 #[derive(Clone)]
 pub struct Channel<T>(

--- a/finality-aleph/src/network/mod.rs
+++ b/finality-aleph/src/network/mod.rs
@@ -36,9 +36,36 @@ pub use session::{Manager as SessionManager, ManagerError, Sender, IO as Session
 pub use split::{split, Split};
 #[cfg(test)]
 pub mod testing {
+    use super::manager::LegacyAuthentication;
     pub use super::manager::{
-        Authentication, DataInSession, DiscoveryMessage, SessionHandler, VersionedAuthentication,
+        Authentication, DataInSession, DiscoveryMessage, LegacyDiscoveryMessage,
+        PeerAuthentications, SessionHandler, VersionedAuthentication,
     };
+    use crate::testing::mocks::validator_network::MockAddressingInformation;
+
+    pub fn legacy_authentication(
+        handler: &SessionHandler<MockAddressingInformation, MockAddressingInformation>,
+    ) -> LegacyAuthentication<MockAddressingInformation> {
+        match handler
+            .authentication()
+            .expect("this is a validator handler")
+        {
+            PeerAuthentications::Both(_, authentication) => authentication,
+            _ => panic!("handler doesn't have both authentications"),
+        }
+    }
+
+    pub fn authentication(
+        handler: &SessionHandler<MockAddressingInformation, MockAddressingInformation>,
+    ) -> Authentication<MockAddressingInformation> {
+        match handler
+            .authentication()
+            .expect("this is a validator handler")
+        {
+            PeerAuthentications::Both(authentication, _) => authentication,
+            _ => panic!("handler doesn't have both authentications"),
+        }
+    }
 }
 
 /// Represents the id of an arbitrary node.
@@ -59,14 +86,11 @@ pub trait PeerId: PartialEq + Eq + Clone + Debug + Display + Hash + Codec + Send
 }
 
 /// Represents the address of an arbitrary node.
-pub trait Multiaddress: Debug + Hash + Codec + Clone + Eq + Send + Sync + 'static {
+pub trait AddressingInformation: Debug + Hash + Codec + Clone + Eq + Send + Sync + 'static {
     type PeerId: PeerId;
 
     /// Returns the peer id associated with this multiaddress if it exists and is unique.
-    fn get_peer_id(&self) -> Option<Self::PeerId>;
-
-    /// Returns the address extended by the peer id, unless it already contained another peer id.
-    fn add_matching_peer_id(self, peer_id: Self::PeerId) -> Option<Self>;
+    fn peer_id(&self) -> Self::PeerId;
 }
 
 /// The Authentication protocol is used for validator discovery.
@@ -117,13 +141,13 @@ pub trait Network: Clone + Send + Sync + 'static {
     ) -> Result<Self::NetworkSender, Self::SenderError>;
 }
 
-/// Abstraction for requesting own network addresses and PeerId.
+/// Abstraction for requesting own network addressing information.
 pub trait NetworkIdentity {
     type PeerId: PeerId;
-    type Multiaddress: Multiaddress<PeerId = Self::PeerId>;
+    type AddressingInformation: AddressingInformation<PeerId = Self::PeerId>;
 
-    /// The external identity of this node, consisting of addresses and the PeerId.
-    fn identity(&self) -> (Vec<Self::Multiaddress>, Self::PeerId);
+    /// The external identity of this node.
+    fn identity(&self) -> Self::AddressingInformation;
 }
 
 /// Abstraction for requesting justifications for finalized blocks and stale blocks.
@@ -148,9 +172,9 @@ pub trait RequestBlocks<B: Block>: Clone + Send + Sync + 'static {
 
 /// Commands for manipulating the reserved peers set.
 #[derive(Debug, PartialEq, Eq)]
-pub enum ConnectionCommand<M: Multiaddress> {
-    AddReserved(HashSet<M>),
-    DelReserved(HashSet<M::PeerId>),
+pub enum ConnectionCommand<A: AddressingInformation> {
+    AddReserved(HashSet<A>),
+    DelReserved(HashSet<A::PeerId>),
 }
 
 /// Returned when something went wrong when sending data using a DataNetwork.

--- a/finality-aleph/src/tcp_network.rs
+++ b/finality-aleph/src/tcp_network.rs
@@ -1,4 +1,4 @@
-use std::{io::Result as IoResult, net::ToSocketAddrs as _};
+use std::{io::Error as IoError, iter, net::ToSocketAddrs as _};
 
 use aleph_primitives::AuthorityId;
 use codec::{Decode, Encode};
@@ -11,7 +11,7 @@ use tokio::net::{
 
 use crate::{
     crypto::{verify, AuthorityPen, Signature},
-    network::{Multiaddress, NetworkIdentity, PeerId},
+    network::{AddressingInformation, NetworkIdentity, PeerId},
     validator_network::{ConnectionInfo, Dialer, Listener, PublicKey, SecretKey, Splittable},
 };
 
@@ -94,23 +94,97 @@ impl SecretKey for AuthorityPen {
 
 /// A representation of a single TCP address with an associated peer ID.
 #[derive(Debug, Hash, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct TcpMultiaddress {
+pub struct LegacyTcpMultiaddress {
     peer_id: AuthorityId,
     address: String,
 }
 
-impl Multiaddress for TcpMultiaddress {
+/// What can go wrong when handling addressing information.
+#[derive(Debug, Hash, Clone, PartialEq, Eq)]
+pub enum AddressingInformationError {
+    /// Construction of an addressing information object requires at least one address.
+    NoAddress,
+}
+
+/// A representation of TCP addressing information with an associated peer ID.
+#[derive(Debug, Hash, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct TcpAddressingInformation {
+    peer_id: AuthorityId,
+    // Easiest way to ensure that the Vec below is nonempty...
+    primary_address: String,
+    other_addresses: Vec<String>,
+}
+
+impl TryFrom<Vec<LegacyTcpMultiaddress>> for TcpAddressingInformation {
+    type Error = AddressingInformationError;
+
+    fn try_from(legacy: Vec<LegacyTcpMultiaddress>) -> Result<Self, Self::Error> {
+        let mut legacy = legacy.into_iter();
+        let (peer_id, primary_address) = match legacy.next() {
+            Some(LegacyTcpMultiaddress { peer_id, address }) => (peer_id, address),
+            None => return Err(AddressingInformationError::NoAddress),
+        };
+        let other_addresses = legacy
+            .filter(|la| la.peer_id == peer_id)
+            .map(|la| la.address)
+            .collect();
+        Ok(TcpAddressingInformation {
+            peer_id,
+            primary_address,
+            other_addresses,
+        })
+    }
+}
+
+impl From<TcpAddressingInformation> for Vec<LegacyTcpMultiaddress> {
+    fn from(address: TcpAddressingInformation) -> Self {
+        let TcpAddressingInformation {
+            peer_id,
+            primary_address,
+            other_addresses,
+        } = address;
+        iter::once(primary_address)
+            .chain(other_addresses)
+            .map(|address| LegacyTcpMultiaddress {
+                peer_id: peer_id.clone(),
+                address,
+            })
+            .collect()
+    }
+}
+
+impl AddressingInformation for TcpAddressingInformation {
     type PeerId = AuthorityId;
 
-    fn get_peer_id(&self) -> Option<Self::PeerId> {
-        Some(self.peer_id.clone())
+    fn peer_id(&self) -> Self::PeerId {
+        self.peer_id.clone()
     }
+}
 
-    fn add_matching_peer_id(self, peer_id: Self::PeerId) -> Option<Self> {
-        match self.peer_id == peer_id {
-            true => Some(self),
-            false => None,
-        }
+impl NetworkIdentity for TcpAddressingInformation {
+    type PeerId = AuthorityId;
+    type AddressingInformation = TcpAddressingInformation;
+
+    fn identity(&self) -> Self::AddressingInformation {
+        self.clone()
+    }
+}
+
+impl TcpAddressingInformation {
+    fn new(
+        addresses: Vec<String>,
+        peer_id: AuthorityId,
+    ) -> Result<TcpAddressingInformation, AddressingInformationError> {
+        let mut addresses = addresses.into_iter();
+        let primary_address = match addresses.next() {
+            Some(address) => address,
+            None => return Err(AddressingInformationError::NoAddress),
+        };
+        Ok(TcpAddressingInformation {
+            primary_address,
+            other_addresses: addresses.collect(),
+            peer_id,
+        })
     }
 }
 
@@ -118,17 +192,22 @@ impl Multiaddress for TcpMultiaddress {
 struct TcpDialer;
 
 #[async_trait::async_trait]
-impl Dialer<TcpMultiaddress> for TcpDialer {
+impl Dialer<TcpAddressingInformation> for TcpDialer {
     type Connection = TcpStream;
     type Error = std::io::Error;
 
     async fn connect(
         &mut self,
-        addresses: Vec<TcpMultiaddress>,
+        address: TcpAddressingInformation,
     ) -> Result<Self::Connection, Self::Error> {
-        let parsed_addresses: Vec<_> = addresses
-            .into_iter()
-            .filter_map(|address| address.address.to_socket_addrs().ok())
+        let TcpAddressingInformation {
+            primary_address,
+            other_addresses,
+            ..
+        } = address;
+        let parsed_addresses: Vec<_> = iter::once(primary_address)
+            .chain(other_addresses)
+            .filter_map(|address| address.to_socket_addrs().ok())
             .flatten()
             .collect();
         let stream = TcpStream::connect(&parsed_addresses[..]).await?;
@@ -139,32 +218,22 @@ impl Dialer<TcpMultiaddress> for TcpDialer {
     }
 }
 
-struct TcpNetworkIdentity {
-    peer_id: AuthorityId,
-    addresses: Vec<TcpMultiaddress>,
+/// Possible errors when creating a TCP network.
+#[derive(Debug)]
+pub enum Error {
+    Io(IoError),
+    AddressingInformation(AddressingInformationError),
 }
 
-impl NetworkIdentity for TcpNetworkIdentity {
-    type PeerId = AuthorityId;
-    type Multiaddress = TcpMultiaddress;
-
-    fn identity(&self) -> (Vec<Self::Multiaddress>, Self::PeerId) {
-        (self.addresses.clone(), self.peer_id.clone())
+impl From<IoError> for Error {
+    fn from(e: IoError) -> Self {
+        Error::Io(e)
     }
 }
 
-impl TcpNetworkIdentity {
-    fn new(external_addresses: Vec<String>, peer_id: AuthorityId) -> TcpNetworkIdentity {
-        TcpNetworkIdentity {
-            addresses: external_addresses
-                .into_iter()
-                .map(|address| TcpMultiaddress {
-                    peer_id: peer_id.clone(),
-                    address,
-                })
-                .collect(),
-            peer_id,
-        }
+impl From<AddressingInformationError> for Error {
+    fn from(e: AddressingInformationError) -> Self {
+        Error::AddressingInformation(e)
     }
 }
 
@@ -174,13 +243,16 @@ pub async fn new_tcp_network<A: ToSocketAddrs>(
     listening_addresses: A,
     external_addresses: Vec<String>,
     peer_id: AuthorityId,
-) -> IoResult<(
-    impl Dialer<TcpMultiaddress>,
-    impl Listener,
-    impl NetworkIdentity<Multiaddress = TcpMultiaddress, PeerId = AuthorityId>,
-)> {
+) -> Result<
+    (
+        impl Dialer<TcpAddressingInformation>,
+        impl Listener,
+        impl NetworkIdentity<AddressingInformation = TcpAddressingInformation, PeerId = AuthorityId>,
+    ),
+    Error,
+> {
     let listener = TcpListener::bind(listening_addresses).await?;
-    let identity = TcpNetworkIdentity::new(external_addresses, peer_id);
+    let identity = TcpAddressingInformation::new(external_addresses, peer_id)?;
     Ok((TcpDialer {}, listener, identity))
 }
 
@@ -188,13 +260,16 @@ pub async fn new_tcp_network<A: ToSocketAddrs>(
 pub mod testing {
     use aleph_primitives::AuthorityId;
 
-    use super::{TcpMultiaddress, TcpNetworkIdentity};
+    use super::TcpAddressingInformation;
     use crate::network::NetworkIdentity;
 
+    /// Creates a realistic identity.
     pub fn new_identity(
         external_addresses: Vec<String>,
         peer_id: AuthorityId,
-    ) -> impl NetworkIdentity<Multiaddress = TcpMultiaddress, PeerId = AuthorityId> {
-        TcpNetworkIdentity::new(external_addresses, peer_id)
+    ) -> impl NetworkIdentity<AddressingInformation = TcpAddressingInformation, PeerId = AuthorityId>
+    {
+        TcpAddressingInformation::new(external_addresses, peer_id)
+            .expect("the provided addresses are fine")
     }
 }

--- a/finality-aleph/src/validator_network/manager/mod.rs
+++ b/finality-aleph/src/validator_network/manager/mod.rs
@@ -184,17 +184,17 @@ impl<PK: PublicKey + PeerId, A: Data, D: Data> Manager<PK, A, D> {
     }
 
     /// Add a peer to the list of peers we want to stay connected to, or
-    /// update the list of addresses if the peer was already added.
+    /// update the address if the peer was already added.
     /// Returns whether we should start attempts at connecting with the peer, which depends on the
     /// coorddinated pseudorandom decision on the direction of the connection and whether this was
     /// added for the first time.
-    pub fn add_peer(&mut self, peer_id: PK, addresses: Vec<A>) -> bool {
-        self.wanted.add_peer(peer_id, addresses)
+    pub fn add_peer(&mut self, peer_id: PK, address: A) -> bool {
+        self.wanted.add_peer(peer_id, address)
     }
 
-    /// Return the addresses of the given peer, or None if we shouldn't attempt connecting with the peer.
-    pub fn peer_addresses(&self, peer_id: &PK) -> Option<Vec<A>> {
-        self.wanted.peer_addresses(peer_id)
+    /// Return the address of the given peer, or None if we shouldn't attempt connecting with the peer.
+    pub fn peer_address(&self, peer_id: &PK) -> Option<A> {
+        self.wanted.peer_address(peer_id)
     }
 
     /// Add an established connection with a known peer, but only if the peer is among the peers we want to be connected to.
@@ -253,26 +253,22 @@ mod tests {
         let mut manager = Manager::<MockPublicKey, Address, Data>::new(own_id);
         let (peer_id, _) = key();
         let (peer_id_b, _) = key();
-        let addresses = vec![
-            String::from(""),
-            String::from("a/b/c"),
-            String::from("43.43.43.43:43000"),
-        ];
+        let address = String::from("43.43.43.43:43000");
         // add new peer - might return either true or false, depending on the ids
-        let attempting_connections = manager.add_peer(peer_id.clone(), addresses.clone());
+        let attempting_connections = manager.add_peer(peer_id.clone(), address.clone());
         // add known peer - always returns false
-        assert!(!manager.add_peer(peer_id.clone(), addresses.clone()));
+        assert!(!manager.add_peer(peer_id.clone(), address.clone()));
         // get address
         match attempting_connections {
-            true => assert_eq!(manager.peer_addresses(&peer_id), Some(addresses)),
-            false => assert_eq!(manager.peer_addresses(&peer_id), None),
+            true => assert_eq!(manager.peer_address(&peer_id), Some(address)),
+            false => assert_eq!(manager.peer_address(&peer_id), None),
         }
         // try to get address of an unknown peer
-        assert_eq!(manager.peer_addresses(&peer_id_b), None);
+        assert_eq!(manager.peer_address(&peer_id_b), None);
         // remove peer
         manager.remove_peer(&peer_id);
         // try to get address of removed peer
-        assert_eq!(manager.peer_addresses(&peer_id), None);
+        assert_eq!(manager.peer_address(&peer_id), None);
         // remove again
         manager.remove_peer(&peer_id);
         // remove unknown peer
@@ -288,11 +284,7 @@ mod tests {
         let mut listening_manager =
             Manager::<MockPublicKey, Address, Data>::new(listening_id.clone());
         let data = String::from("DATA");
-        let addresses = vec![
-            String::from(""),
-            String::from("a/b/c"),
-            String::from("43.43.43.43:43000"),
-        ];
+        let address = String::from("43.43.43.43:43000");
         let (tx, _rx) = mpsc::unbounded();
         // try add unknown peer
         assert_eq!(
@@ -305,14 +297,14 @@ mod tests {
             Err(SendError::PeerNotFound)
         );
         // add peer, this time for real
-        if connecting_manager.add_peer(listening_id.clone(), addresses.clone()) {
-            assert!(!listening_manager.add_peer(connecting_id.clone(), addresses.clone()))
+        if connecting_manager.add_peer(listening_id.clone(), address.clone()) {
+            assert!(!listening_manager.add_peer(connecting_id.clone(), address.clone()))
         } else {
             // We need to switch the names around, because the connection was randomly the
             // other way around.
             std::mem::swap(&mut connecting_id, &mut listening_id);
             std::mem::swap(&mut connecting_manager, &mut listening_manager);
-            assert!(connecting_manager.add_peer(listening_id.clone(), addresses.clone()));
+            assert!(connecting_manager.add_peer(listening_id.clone(), address.clone()));
         }
         // add outgoing to connecting
         let (tx, mut rx) = mpsc::unbounded();

--- a/finality-aleph/src/validator_network/mod.rs
+++ b/finality-aleph/src/validator_network/mod.rs
@@ -31,7 +31,7 @@ impl<D: Clone + Codec + Send + Sync + 'static> Data for D {}
 #[async_trait::async_trait]
 pub trait Network<PK: PublicKey, A: Data, D: Data>: Send + 'static {
     /// Add the peer to the set of connected peers.
-    fn add_connection(&mut self, peer: PK, addresses: Vec<A>);
+    fn add_connection(&mut self, peer: PK, address: A);
 
     /// Remove the peer from the set of connected peers and close the connection.
     fn remove_connection(&mut self, peer: PK);
@@ -67,9 +67,8 @@ pub trait Dialer<A: Data>: Clone + Send + 'static {
     type Connection: Splittable;
     type Error: Display + Send;
 
-    /// Attempt to connect to a peer using the provided addresses. Should work if at least one of
-    /// the addresses is correct.
-    async fn connect(&mut self, addresses: Vec<A>) -> Result<Self::Connection, Self::Error>;
+    /// Attempt to connect to a peer using the provided addressing information.
+    async fn connect(&mut self, address: A) -> Result<Self::Connection, Self::Error>;
 }
 
 /// Accepts new connections. Usually will be created listening on a specific interface and this is


### PR DESCRIPTION
# Description

Makes the addressing information (formerly known as multiaddress) match the thing we are now using better and also just have a nicer interface. Unfortunately lots of changes were needed to make that happen.

## Type of change

Refactor.

# Checklist:

- I have added tests
- I have made corresponding changes to the existing documentation
- I have created new documentation
