### PR TITLE
A0-1663: remove unnecessary session start retries in connection manager

### DIFF
--- a/finality-aleph/src/network/manager/service.rs
+++ b/finality-aleph/src/network/manager/service.rs
@@ -56,7 +56,7 @@ struct PreValidatorSession {
 }
 
 #[derive(Clone)]
-/// Stores all data needed for starting non validator session
+/// Stores all data needed for starting non-validator session
 struct PreNonvalidatorSession {
     session_id: SessionId,
     verifier: AuthorityVerifier,
@@ -287,7 +287,7 @@ where
         pre_session: PreValidatorSession,
         result_for_user: Option<oneshot::Sender<mpsc::UnboundedReceiver<D>>>,
     ) -> Result<ServiceActions<M, NI::AddressingInformation>, SessionHandlerError> {
-        self.update_validator_session(pre_session.clone())
+        self.update_validator_session(pre_session)
             .await
             .map(|(actions, data_from_network)| {
                 if let Some(result_for_user) = result_for_user {
@@ -343,7 +343,7 @@ where
         &mut self,
         pre_session: PreNonvalidatorSession,
     ) -> Result<(), SessionHandlerError> {
-        self.update_nonvalidator_session(pre_session.clone()).await
+        self.update_nonvalidator_session(pre_session).await
     }
 
     /// Handle a session command.

--- a/finality-aleph/src/network/manager/service.rs
+++ b/finality-aleph/src/network/manager/service.rs
@@ -47,6 +47,7 @@ struct Session<D: Data, M: Data, A: AddressingInformation + TryFrom<Vec<M>> + In
 }
 
 #[derive(Clone)]
+/// Stores all data needed for starting validator session
 struct PreValidatorSession {
     session_id: SessionId,
     verifier: AuthorityVerifier,
@@ -55,24 +56,10 @@ struct PreValidatorSession {
 }
 
 #[derive(Clone)]
+/// Stores all data needed for starting non validator session
 struct PreNonvalidatorSession {
     session_id: SessionId,
     verifier: AuthorityVerifier,
-}
-
-#[derive(Clone)]
-enum PreSession {
-    Validator(PreValidatorSession),
-    Nonvalidator(PreNonvalidatorSession),
-}
-
-impl PreSession {
-    fn session_id(&self) -> SessionId {
-        match self {
-            Self::Validator(pre_session) => pre_session.session_id,
-            Self::Nonvalidator(pre_session) => pre_session.session_id,
-        }
-    }
 }
 
 /// Configuration for the session manager service. Controls how often the maintenance and
@@ -145,10 +132,6 @@ where
     network_identity: NI,
     connections: Connections<NI::PeerId>,
     sessions: HashMap<SessionId, Session<D, M, NI::AddressingInformation>>,
-    to_retry: Vec<(
-        PreSession,
-        Option<oneshot::Sender<mpsc::UnboundedReceiver<D>>>,
-    )>,
     discovery_cooldown: Duration,
     maintenance_period: Duration,
     initial_delay: Duration,
@@ -169,7 +152,6 @@ where
             network_identity,
             connections: Connections::new(),
             sessions: HashMap::new(),
-            to_retry: Vec::new(),
             discovery_cooldown,
             maintenance_period,
             initial_delay,
@@ -190,8 +172,6 @@ where
         session_id: SessionId,
     ) -> Option<ConnectionCommand<NI::AddressingInformation>> {
         self.sessions.remove(&session_id);
-        self.to_retry
-            .retain(|(pre_session, _)| pre_session.session_id() != session_id);
         Self::delete_reserved(self.connections.remove_session(session_id))
     }
 
@@ -307,21 +287,16 @@ where
         pre_session: PreValidatorSession,
         result_for_user: Option<oneshot::Sender<mpsc::UnboundedReceiver<D>>>,
     ) -> Result<ServiceActions<M, NI::AddressingInformation>, SessionHandlerError> {
-        match self.update_validator_session(pre_session.clone()).await {
-            Ok((actions, data_from_network)) => {
+        self.update_validator_session(pre_session.clone())
+            .await
+            .map(|(actions, data_from_network)| {
                 if let Some(result_for_user) = result_for_user {
                     if result_for_user.send(data_from_network).is_err() {
                         warn!(target: "aleph-network", "Failed to send started session.")
                     }
                 }
-                Ok(actions)
-            }
-            Err(e) => {
-                self.to_retry
-                    .push((PreSession::Validator(pre_session), result_for_user));
-                Err(e)
-            }
-        }
+                actions
+            })
     }
 
     async fn start_nonvalidator_session(
@@ -368,13 +343,7 @@ where
         &mut self,
         pre_session: PreNonvalidatorSession,
     ) -> Result<(), SessionHandlerError> {
-        self.update_nonvalidator_session(pre_session.clone())
-            .await
-            .map_err(|e| {
-                self.to_retry
-                    .push((PreSession::Nonvalidator(pre_session), None));
-                e
-            })
+        self.update_nonvalidator_session(pre_session.clone()).await
     }
 
     /// Handle a session command.
@@ -492,28 +461,6 @@ where
                 .unbounded_send(data)
                 .map_err(|_| Error::UserSend),
             None => Err(Error::NoSession),
-        }
-    }
-
-    /// Retries starting a validator session the user requested, but which failed to start
-    /// initially. Mostly useful when the network was not yet aware of its own address at time of
-    /// the request.
-    pub async fn retry_session_start(
-        &mut self,
-    ) -> Result<ServiceActions<M, NI::AddressingInformation>, SessionHandlerError> {
-        let (pre_session, result_for_user) = match self.to_retry.pop() {
-            Some(to_retry) => to_retry,
-            None => return Ok(ServiceActions::noop()),
-        };
-        match pre_session {
-            PreSession::Validator(pre_session) => {
-                self.handle_validator_presession(pre_session, result_for_user)
-                    .await
-            }
-            PreSession::Nonvalidator(pre_session) => {
-                self.handle_nonvalidator_presession(pre_session).await?;
-                Ok(ServiceActions::noop())
-            }
         }
     }
 
@@ -759,10 +706,6 @@ where
                 },
                 _ = maintenance.tick() => {
                     debug!(target: "aleph-network", "Manager starts maintenence");
-                    match service.retry_session_start().await {
-                        Ok(to_send) => self.handle_service_actions(to_send)?,
-                        Err(e) => warn!(target: "aleph-network", "Retry failed to update handler: {:?}", e),
-                    }
                     for to_send in service.discovery() {
                         self.send_authentications(to_send.into())?;
                     }


### PR DESCRIPTION
# Description
`to_retry` was kept before, to retry session start in case we did not know our own identity. Now we know it from the start and the only way session start can fail is if we changed session handler type. In this case we do not want to retry session start.