### PR TITLE
Benchmark configuration cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,6 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal",
  "pallet-aleph",
  "pallet-aura",
  "pallet-authorship",

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -59,7 +59,6 @@ sp-io = { default-features = false, git = "https://github.com/Cardinal-Cryptogra
 
 # Benchmarking stuff
 frame-benchmarking = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "liminal-v0.9.32", optional = true }
-hex-literal = { version = "0.3.4", optional = true }
 
 primitives = { path = "../../primitives", default-features = false }
 pallet-aleph = { path = "../../pallets/aleph", default-features = false }
@@ -145,7 +144,6 @@ try-runtime = [
 ]
 enable_treasury_proposals = []
 runtime-benchmarks = [
-    "hex-literal",
     "frame-system/runtime-benchmarks",
     "frame-benchmarking/runtime-benchmarks",
     "pallet-snarcos/runtime-benchmarks",

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -791,12 +791,8 @@ pub type Executive = frame_executive::Executive<
 >;
 
 #[cfg(feature = "runtime-benchmarks")]
-#[macro_use]
-extern crate frame_benchmarking;
-
-#[cfg(feature = "runtime-benchmarks")]
 mod benches {
-    define_benchmarks!([pallet_snarcos, Snarcos]);
+    frame_benchmarking::define_benchmarks!([pallet_snarcos, Snarcos]);
 }
 
 impl_runtime_apis! {
@@ -1033,7 +1029,7 @@ impl_runtime_apis! {
             Vec<frame_benchmarking::BenchmarkList>,
             Vec<frame_support::traits::StorageInfo>,
         ) {
-            use frame_benchmarking::{Benchmarking, BenchmarkList};
+            use frame_benchmarking::{Benchmarking, BenchmarkList, cb_list_benchmarks, list_benchmark};
             use frame_support::traits::StorageInfoTrait;
 
             let mut list = Vec::<BenchmarkList>::new();
@@ -1047,22 +1043,11 @@ impl_runtime_apis! {
         fn dispatch_benchmark(
             config: frame_benchmarking::BenchmarkConfig
         ) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
-            use frame_benchmarking::{Benchmarking, BenchmarkBatch, TrackedStorageKey};
+            use frame_benchmarking::{
+                Benchmarking, BenchmarkBatch, TrackedStorageKey, cb_add_benchmarks, add_benchmark};
+            use frame_support::traits::WhitelistedStorageKeys;
 
-            // After updating Substrate use:
-            // let whitelist: Vec<TrackedStorageKey> = AllPalletsWithSystem::whitelisted_storage_keys();
-            let whitelist: Vec<TrackedStorageKey> = vec![
-                // Block Number
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec().into(),
-                // Total Issuance
-                hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec().into(),
-                // Execution Phase
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec().into(),
-                // Event Count
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec().into(),
-                // System Events
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec().into(),
-            ];
+            let whitelist: Vec<TrackedStorageKey> = AllPalletsWithSystem::whitelisted_storage_keys();
 
             let params = (&config, &whitelist);
             let mut batches = Vec::<BenchmarkBatch>::new();


### PR DESCRIPTION
 - use `AllPalletsWithSystem::whitelisted_storage_keys`
 - drop `extern crate`