### PR TITLE
A0-1696: `cliain` - support Liminal (2/2)

### DIFF
--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -124,6 +124,8 @@ checksum = "ff773c0ef8c655c98071d3026a63950798a66b2f45baef22d8334c1756f1bd18"
 dependencies = [
  "ark-ec",
  "ark-ff",
+ "ark-nonnative-field",
+ "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
  "ark-snark",
@@ -131,6 +133,7 @@ dependencies = [
  "blake2 0.9.2",
  "derivative",
  "digest 0.9.0",
+ "tracing",
 ]
 
 [[package]]
@@ -145,6 +148,19 @@ dependencies = [
  "derivative",
  "num-traits",
  "zeroize",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-381"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b7ada17db3854f5994e74e60b18e10e818594935ee7e1d329800c117b32970"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-r1cs-std",
+ "ark-std",
 ]
 
 [[package]]
@@ -669,6 +685,7 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "primitives",
+ "relations",
  "serde",
  "serde_json",
  "sp-core 6.0.0",
@@ -2950,6 +2967,28 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "relations"
+version = "0.1.0"
+dependencies = [
+ "ark-bls12-381",
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ed-on-bls12-381",
+ "ark-ff",
+ "ark-gm17",
+ "ark-groth16",
+ "ark-marlin",
+ "ark-poly",
+ "ark-poly-commit",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
+ "blake2 0.9.2",
+]
 
 [[package]]
 name = "remove_dir_all"

--- a/bin/cliain/Cargo.toml
+++ b/bin/cliain/Cargo.toml
@@ -25,6 +25,7 @@ sp-core = { git = "https://github.com/Cardinal-Cryptography/substrate.git", bran
 
 aleph_client = { path = "../../aleph-client" }
 primitives = { path = "../../primitives" }
+relations = { path = "../../relations" }
 
 [features]
 default = ["std"]

--- a/bin/cliain/src/commands.rs
+++ b/bin/cliain/src/commands.rs
@@ -250,6 +250,7 @@ pub enum SnarkRelation {
         /// Relation to work with.
         #[clap(subcommand)]
         relation: RelationArgs,
+
         /// Proving system to use.
         ///
         /// Accepts either `NonUniversalProvingSystem` or `UniversalProvingSystem`.
@@ -259,6 +260,27 @@ pub enum SnarkRelation {
         /// Path to a file containing proving key.
         #[clap(long, short)]
         proving_key_file: PathBuf,
+    },
+
+    /// Verify proof.
+    Verify {
+        /// Path to a file containing verifying key.
+        #[clap(long, short)]
+        verifying_key_file: PathBuf,
+
+        /// Path to a file containing proof.
+        #[clap(long, short)]
+        proof_file: PathBuf,
+
+        /// Path to a file containing public input.
+        #[clap(long, short)]
+        public_input_file: PathBuf,
+
+        /// Proving system to use.
+        ///
+        /// Accepts either `NonUniversalProvingSystem` or `UniversalProvingSystem`.
+        #[clap(long, short, value_enum, default_value = "groth16", value_parser = parse_some_system)]
+        system: SomeProvingSystem,
     },
 }
 

--- a/bin/cliain/src/commands.rs
+++ b/bin/cliain/src/commands.rs
@@ -12,7 +12,7 @@ use primitives::{Balance, BlockNumber, CommitteeSeats, SessionIndex};
 use serde::{Deserialize, Serialize};
 use sp_core::H256;
 
-use crate::UniversalProvingSystem;
+use crate::{snark_relations::RelationArgs, UniversalProvingSystem};
 
 #[derive(Debug, Clone, Args)]
 pub struct ContractOptions {
@@ -218,9 +218,10 @@ pub enum SnarkRelation {
 
     /// Generate verifying and proving key from SRS and save them to separate binary files.
     GenerateKeysFromSrs {
-        // Relation to work with.
-        // #[clap(subcommand)]
-        // relation: Relation,
+        ///Relation to work with.
+        #[clap(subcommand)]
+        relation: RelationArgs,
+
         /// Proving system to use.
         #[clap(long, short, value_enum, default_value = "marlin")]
         system: UniversalProvingSystem,

--- a/bin/cliain/src/commands.rs
+++ b/bin/cliain/src/commands.rs
@@ -12,7 +12,10 @@ use primitives::{Balance, BlockNumber, CommitteeSeats, SessionIndex};
 use serde::{Deserialize, Serialize};
 use sp_core::H256;
 
-use crate::{snark_relations::RelationArgs, UniversalProvingSystem};
+use crate::{
+    snark_relations::{parsing::parse_some_system, RelationArgs, SomeProvingSystem},
+    NonUniversalProvingSystem, UniversalProvingSystem,
+};
 
 #[derive(Debug, Clone, Args)]
 pub struct ContractOptions {
@@ -229,6 +232,33 @@ pub enum SnarkRelation {
         /// Path to a file containing SRS.
         #[clap(long)]
         srs_file: PathBuf,
+    },
+
+    /// Generate verifying and proving key and save them to separate binary files.
+    GenerateKeys {
+        /// Relation to work with.
+        #[clap(subcommand)]
+        relation: RelationArgs,
+
+        /// Proving system to use.
+        #[clap(long, short, value_enum, default_value = "groth16")]
+        system: NonUniversalProvingSystem,
+    },
+
+    /// Generate proof and public input and save them to separate binary files.
+    GenerateProof {
+        /// Relation to work with.
+        #[clap(subcommand)]
+        relation: RelationArgs,
+        /// Proving system to use.
+        ///
+        /// Accepts either `NonUniversalProvingSystem` or `UniversalProvingSystem`.
+        #[clap(long, short, value_enum, default_value = "groth16", value_parser = parse_some_system)]
+        system: SomeProvingSystem,
+
+        /// Path to a file containing proving key.
+        #[clap(long, short)]
+        proving_key_file: PathBuf,
     },
 }
 

--- a/bin/cliain/src/commands.rs
+++ b/bin/cliain/src/commands.rs
@@ -204,15 +204,15 @@ pub enum SnarkRelation {
         system: UniversalProvingSystem,
 
         /// Maximum supported number of constraints.
-        #[clap(long, default_value = "1000")]
+        #[clap(long, default_value = "10000")]
         num_constraints: usize,
 
         /// Maximum supported number of variables.
-        #[clap(long, default_value = "1000")]
+        #[clap(long, default_value = "10000")]
         num_variables: usize,
 
         /// Maximum supported polynomial degree.
-        #[clap(long, default_value = "1000")]
+        #[clap(long, default_value = "10000")]
         degree: usize,
     },
 

--- a/bin/cliain/src/commands.rs
+++ b/bin/cliain/src/commands.rs
@@ -12,6 +12,8 @@ use primitives::{Balance, BlockNumber, CommitteeSeats, SessionIndex};
 use serde::{Deserialize, Serialize};
 use sp_core::H256;
 
+use crate::UniversalProvingSystem;
+
 #[derive(Debug, Clone, Args)]
 pub struct ContractOptions {
     /// balance to transfer from the call origin to the contract
@@ -191,6 +193,27 @@ pub enum Snarcos {
         /// The proving system to be used.
         #[clap(long, value_parser(parsing::parse_system))]
         system: ProvingSystem,
+    },
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum SnarkRelation {
+    GenerateSrs {
+        /// Proving system to use.
+        #[clap(long, short, value_enum, default_value = "marlin")]
+        system: UniversalProvingSystem,
+
+        /// Maximum supported number of constraints.
+        #[clap(long, default_value = "1000")]
+        num_constraints: usize,
+
+        /// Maximum supported number of variables.
+        #[clap(long, default_value = "1000")]
+        num_variables: usize,
+
+        /// Maximum supported polynomial degree.
+        #[clap(long, default_value = "1000")]
+        degree: usize,
     },
 }
 
@@ -419,6 +442,10 @@ pub enum Command {
     /// Interact with `pallet_snarcos`.
     #[clap(subcommand)]
     Snarcos(Snarcos),
+
+    /// Interact with `relations` crate.
+    #[clap(subcommand)]
+    SnarkRelation(SnarkRelation),
 }
 
 mod parsing {

--- a/bin/cliain/src/commands.rs
+++ b/bin/cliain/src/commands.rs
@@ -215,6 +215,20 @@ pub enum SnarkRelation {
         #[clap(long, default_value = "1000")]
         degree: usize,
     },
+
+    /// Generate verifying and proving key from SRS and save them to separate binary files.
+    GenerateKeysFromSrs {
+        // Relation to work with.
+        // #[clap(subcommand)]
+        // relation: Relation,
+        /// Proving system to use.
+        #[clap(long, short, value_enum, default_value = "marlin")]
+        system: UniversalProvingSystem,
+
+        /// Path to a file containing SRS.
+        #[clap(long)]
+        srs_file: PathBuf,
+    },
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/bin/cliain/src/lib.rs
+++ b/bin/cliain/src/lib.rs
@@ -7,6 +7,7 @@ mod keys;
 mod runtime;
 mod secret;
 mod snarcos;
+mod snark_relations;
 mod staking;
 mod transfer;
 mod treasury;
@@ -15,7 +16,7 @@ mod version_upgrade;
 mod vesting;
 
 use aleph_client::{keypair_from_string, Connection, RootConnection, SignedConnection};
-pub use commands::{Command, Snarcos};
+pub use commands::{Command, Snarcos, SnarkRelation};
 pub use contracts::{
     call, instantiate, instantiate_with_code, owner_info, remove_code, upload_code,
 };
@@ -24,6 +25,7 @@ pub use keys::{next_session_keys, prepare_keys, rotate_keys, set_keys};
 pub use runtime::update_runtime;
 pub use secret::prompt_password_hidden;
 pub use snarcos::{delete_key, overwrite_key, store_key, verify};
+pub use snark_relations::{generate_srs, NonUniversalProvingSystem, UniversalProvingSystem};
 pub use staking::{bond, force_new_era, nominate, set_staking_limits, validate};
 pub use transfer::transfer;
 pub use treasury::{

--- a/bin/cliain/src/lib.rs
+++ b/bin/cliain/src/lib.rs
@@ -25,7 +25,9 @@ pub use keys::{next_session_keys, prepare_keys, rotate_keys, set_keys};
 pub use runtime::update_runtime;
 pub use secret::prompt_password_hidden;
 pub use snarcos::{delete_key, overwrite_key, store_key, verify};
-pub use snark_relations::{generate_srs, NonUniversalProvingSystem, UniversalProvingSystem};
+pub use snark_relations::{
+    generate_keys_from_srs, generate_srs, NonUniversalProvingSystem, UniversalProvingSystem,
+};
 pub use staking::{bond, force_new_era, nominate, set_staking_limits, validate};
 pub use transfer::transfer;
 pub use treasury::{

--- a/bin/cliain/src/lib.rs
+++ b/bin/cliain/src/lib.rs
@@ -15,7 +15,7 @@ mod version_upgrade;
 mod vesting;
 
 use aleph_client::{keypair_from_string, Connection, RootConnection, SignedConnection};
-pub use commands::Command;
+pub use commands::{Command, Snarcos};
 pub use contracts::{
     call, instantiate, instantiate_with_code, owner_info, remove_code, upload_code,
 };

--- a/bin/cliain/src/lib.rs
+++ b/bin/cliain/src/lib.rs
@@ -26,8 +26,8 @@ pub use runtime::update_runtime;
 pub use secret::prompt_password_hidden;
 pub use snarcos::{delete_key, overwrite_key, store_key, verify};
 pub use snark_relations::{
-    generate_keys, generate_keys_from_srs, generate_proof, generate_srs, NonUniversalProvingSystem,
-    UniversalProvingSystem,
+    generate_keys, generate_keys_from_srs, generate_proof, generate_srs, verify as verify_proof,
+    NonUniversalProvingSystem, UniversalProvingSystem,
 };
 pub use staking::{bond, force_new_era, nominate, set_staking_limits, validate};
 pub use transfer::transfer;

--- a/bin/cliain/src/lib.rs
+++ b/bin/cliain/src/lib.rs
@@ -26,7 +26,8 @@ pub use runtime::update_runtime;
 pub use secret::prompt_password_hidden;
 pub use snarcos::{delete_key, overwrite_key, store_key, verify};
 pub use snark_relations::{
-    generate_keys_from_srs, generate_srs, NonUniversalProvingSystem, UniversalProvingSystem,
+    generate_keys, generate_keys_from_srs, generate_proof, generate_srs, NonUniversalProvingSystem,
+    UniversalProvingSystem,
 };
 pub use staking::{bond, force_new_era, nominate, set_staking_limits, validate};
 pub use transfer::transfer;

--- a/bin/cliain/src/main.rs
+++ b/bin/cliain/src/main.rs
@@ -300,6 +300,7 @@ async fn main() {
                 num_variables,
                 degree,
             } => generate_srs(system, num_constraints, num_variables, degree),
+            SnarkRelation::GenerateKeysFromSrs { .. } => {}
         },
     }
 }

--- a/bin/cliain/src/main.rs
+++ b/bin/cliain/src/main.rs
@@ -8,7 +8,7 @@ use cliain::{
     prompt_password_hidden, remove_code, rotate_keys, schedule_upgrade, set_emergency_finalizer,
     set_keys, set_staking_limits, store_key, transfer, treasury_approve, treasury_propose,
     treasury_reject, update_runtime, upload_code, validate, verify, vest, vest_other,
-    vested_transfer, Command, ConnectionConfig,
+    vested_transfer, Command, ConnectionConfig, Snarcos,
 };
 use log::{error, info};
 
@@ -245,49 +245,51 @@ async fn main() {
             Ok(_) => {}
             Err(why) => error!("Unable to schedule an upgrade {:?}", why),
         },
-        Command::SnarcosStoreKey {
-            identifier,
-            vk_file,
-        } => {
-            if let Err(why) =
-                store_key(cfg.get_signed_connection().await, identifier, vk_file).await
-            {
-                error!("Unable to store key: {why:?}")
+        Command::Snarcos(cmd) => match cmd {
+            Snarcos::StoreKey {
+                identifier,
+                vk_file,
+            } => {
+                if let Err(why) =
+                    store_key(cfg.get_signed_connection().await, identifier, vk_file).await
+                {
+                    error!("Unable to store key: {why:?}")
+                }
             }
-        }
-        Command::SnarcosDeleteKey { identifier } => {
-            if let Err(why) = delete_key(cfg.get_root_connection().await, identifier).await {
-                error!("Unable to delete key: {why:?}")
+            Snarcos::DeleteKey { identifier } => {
+                if let Err(why) = delete_key(cfg.get_root_connection().await, identifier).await {
+                    error!("Unable to delete key: {why:?}")
+                }
             }
-        }
-        Command::SnarcosOverwriteKey {
-            identifier,
-            vk_file,
-        } => {
-            if let Err(why) =
-                overwrite_key(cfg.get_root_connection().await, identifier, vk_file).await
-            {
-                error!("Unable to overwrite key: {why:?}")
+            Snarcos::OverwriteKey {
+                identifier,
+                vk_file,
+            } => {
+                if let Err(why) =
+                    overwrite_key(cfg.get_root_connection().await, identifier, vk_file).await
+                {
+                    error!("Unable to overwrite key: {why:?}")
+                }
             }
-        }
-        Command::SnarcosVerify {
-            identifier,
-            proof_file,
-            input_file,
-            system,
-        } => {
-            if let Err(why) = verify(
-                cfg.get_signed_connection().await,
+            Snarcos::Verify {
                 identifier,
                 proof_file,
                 input_file,
                 system,
-            )
-            .await
-            {
-                error!("Unable to verify proof: {why:?}")
+            } => {
+                if let Err(why) = verify(
+                    cfg.get_signed_connection().await,
+                    identifier,
+                    proof_file,
+                    input_file,
+                    system,
+                )
+                .await
+                {
+                    error!("Unable to verify proof: {why:?}")
+                }
             }
-        }
+        },
     }
 }
 

--- a/bin/cliain/src/main.rs
+++ b/bin/cliain/src/main.rs
@@ -3,12 +3,12 @@ use std::env;
 use aleph_client::{account_from_keypair, aleph_keypair_from_string, keypair_from_string, Pair};
 use clap::Parser;
 use cliain::{
-    bond, call, change_validators, delete_key, finalize, force_new_era, instantiate,
+    bond, call, change_validators, delete_key, finalize, force_new_era, generate_srs, instantiate,
     instantiate_with_code, next_session_keys, nominate, overwrite_key, owner_info, prepare_keys,
     prompt_password_hidden, remove_code, rotate_keys, schedule_upgrade, set_emergency_finalizer,
     set_keys, set_staking_limits, store_key, transfer, treasury_approve, treasury_propose,
     treasury_reject, update_runtime, upload_code, validate, verify, vest, vest_other,
-    vested_transfer, Command, ConnectionConfig, Snarcos,
+    vested_transfer, Command, ConnectionConfig, Snarcos, SnarkRelation,
 };
 use log::{error, info};
 
@@ -37,9 +37,10 @@ fn read_seed(command: &Command, seed: Option<String>) -> String {
             hash: _,
             finalizer_seed: _,
         }
-        | Command::NextSessionKeys { account_id: _ }
+        | Command::NextSessionKeys { .. }
         | Command::RotateKeys
-        | Command::SeedToSS58 { input: _ }
+        | Command::SeedToSS58 { .. }
+        | Command::SnarkRelation { .. }
         | Command::ContractOwnerInfo { .. } => String::new(),
         _ => read_secret(seed, "Provide seed for the signer account:"),
     }
@@ -245,6 +246,7 @@ async fn main() {
             Ok(_) => {}
             Err(why) => error!("Unable to schedule an upgrade {:?}", why),
         },
+
         Command::Snarcos(cmd) => match cmd {
             Snarcos::StoreKey {
                 identifier,
@@ -289,6 +291,15 @@ async fn main() {
                     error!("Unable to verify proof: {why:?}")
                 }
             }
+        },
+
+        Command::SnarkRelation(cmd) => match cmd {
+            SnarkRelation::GenerateSrs {
+                system,
+                num_constraints,
+                num_variables,
+                degree,
+            } => generate_srs(system, num_constraints, num_variables, degree),
         },
     }
 }

--- a/bin/cliain/src/main.rs
+++ b/bin/cliain/src/main.rs
@@ -3,12 +3,12 @@ use std::env;
 use aleph_client::{account_from_keypair, aleph_keypair_from_string, keypair_from_string, Pair};
 use clap::Parser;
 use cliain::{
-    bond, call, change_validators, delete_key, finalize, force_new_era, generate_srs, instantiate,
-    instantiate_with_code, next_session_keys, nominate, overwrite_key, owner_info, prepare_keys,
-    prompt_password_hidden, remove_code, rotate_keys, schedule_upgrade, set_emergency_finalizer,
-    set_keys, set_staking_limits, store_key, transfer, treasury_approve, treasury_propose,
-    treasury_reject, update_runtime, upload_code, validate, verify, vest, vest_other,
-    vested_transfer, Command, ConnectionConfig, Snarcos, SnarkRelation,
+    bond, call, change_validators, delete_key, finalize, force_new_era, generate_keys_from_srs,
+    generate_srs, instantiate, instantiate_with_code, next_session_keys, nominate, overwrite_key,
+    owner_info, prepare_keys, prompt_password_hidden, remove_code, rotate_keys, schedule_upgrade,
+    set_emergency_finalizer, set_keys, set_staking_limits, store_key, transfer, treasury_approve,
+    treasury_propose, treasury_reject, update_runtime, upload_code, validate, verify, vest,
+    vest_other, vested_transfer, Command, ConnectionConfig, Snarcos, SnarkRelation,
 };
 use log::{error, info};
 
@@ -300,7 +300,11 @@ async fn main() {
                 num_variables,
                 degree,
             } => generate_srs(system, num_constraints, num_variables, degree),
-            SnarkRelation::GenerateKeysFromSrs { .. } => {}
+            SnarkRelation::GenerateKeysFromSrs {
+                relation,
+                system,
+                srs_file,
+            } => generate_keys_from_srs(relation, system, srs_file),
         },
     }
 }

--- a/bin/cliain/src/main.rs
+++ b/bin/cliain/src/main.rs
@@ -3,12 +3,13 @@ use std::env;
 use aleph_client::{account_from_keypair, aleph_keypair_from_string, keypair_from_string, Pair};
 use clap::Parser;
 use cliain::{
-    bond, call, change_validators, delete_key, finalize, force_new_era, generate_keys_from_srs,
-    generate_srs, instantiate, instantiate_with_code, next_session_keys, nominate, overwrite_key,
-    owner_info, prepare_keys, prompt_password_hidden, remove_code, rotate_keys, schedule_upgrade,
-    set_emergency_finalizer, set_keys, set_staking_limits, store_key, transfer, treasury_approve,
-    treasury_propose, treasury_reject, update_runtime, upload_code, validate, verify, vest,
-    vest_other, vested_transfer, Command, ConnectionConfig, Snarcos, SnarkRelation,
+    bond, call, change_validators, delete_key, finalize, force_new_era, generate_keys,
+    generate_keys_from_srs, generate_proof, generate_srs, instantiate, instantiate_with_code,
+    next_session_keys, nominate, overwrite_key, owner_info, prepare_keys, prompt_password_hidden,
+    remove_code, rotate_keys, schedule_upgrade, set_emergency_finalizer, set_keys,
+    set_staking_limits, store_key, transfer, treasury_approve, treasury_propose, treasury_reject,
+    update_runtime, upload_code, validate, verify, vest, vest_other, vested_transfer, Command,
+    ConnectionConfig, Snarcos, SnarkRelation,
 };
 use log::{error, info};
 
@@ -305,6 +306,12 @@ async fn main() {
                 system,
                 srs_file,
             } => generate_keys_from_srs(relation, system, srs_file),
+            SnarkRelation::GenerateKeys { relation, system } => generate_keys(relation, system),
+            SnarkRelation::GenerateProof {
+                relation,
+                system,
+                proving_key_file,
+            } => generate_proof(relation, system, proving_key_file),
         },
     }
 }

--- a/bin/cliain/src/main.rs
+++ b/bin/cliain/src/main.rs
@@ -8,8 +8,8 @@ use cliain::{
     next_session_keys, nominate, overwrite_key, owner_info, prepare_keys, prompt_password_hidden,
     remove_code, rotate_keys, schedule_upgrade, set_emergency_finalizer, set_keys,
     set_staking_limits, store_key, transfer, treasury_approve, treasury_propose, treasury_reject,
-    update_runtime, upload_code, validate, verify, vest, vest_other, vested_transfer, Command,
-    ConnectionConfig, Snarcos, SnarkRelation,
+    update_runtime, upload_code, validate, verify, verify_proof, vest, vest_other, vested_transfer,
+    Command, ConnectionConfig, Snarcos, SnarkRelation,
 };
 use log::{error, info};
 
@@ -312,6 +312,18 @@ async fn main() {
                 system,
                 proving_key_file,
             } => generate_proof(relation, system, proving_key_file),
+            SnarkRelation::Verify {
+                verifying_key_file,
+                proof_file,
+                public_input_file,
+                system,
+            } => {
+                if verify_proof(verifying_key_file, proof_file, public_input_file, system) {
+                    println!("Proof is correct")
+                } else {
+                    error!("Incorrect proof!")
+                }
+            }
         },
     }
 }

--- a/bin/cliain/src/snark_relations.rs
+++ b/bin/cliain/src/snark_relations.rs
@@ -1,0 +1,117 @@
+use clap::ValueEnum;
+use relations::{
+    serialize, CanonicalDeserialize, CircuitField, ConstraintSynthesizer, Marlin, RawKeys,
+    UniversalSystem,
+};
+
+use crate::snark_relations::io::save_srs;
+
+/// All available non universal proving systems.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, ValueEnum)]
+pub enum NonUniversalProvingSystem {
+    Groth16,
+    Gm17,
+}
+
+/// All available universal proving systems.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, ValueEnum)]
+pub enum UniversalProvingSystem {
+    Marlin,
+}
+
+/// API available only for universal proving systems.
+impl UniversalProvingSystem {
+    pub fn id(&self) -> String {
+        format!("{:?}", self).to_lowercase()
+    }
+
+    /// Generates SRS. Returns in serialized version.
+    pub fn generate_srs(
+        &self,
+        num_constraints: usize,
+        num_variables: usize,
+        degree: usize,
+    ) -> Vec<u8> {
+        match self {
+            UniversalProvingSystem::Marlin => {
+                Self::_generate_srs::<Marlin>(num_constraints, num_variables, degree)
+            }
+        }
+    }
+
+    fn _generate_srs<S: UniversalSystem>(
+        num_constraints: usize,
+        num_variables: usize,
+        degree: usize,
+    ) -> Vec<u8> {
+        let srs = S::generate_srs(num_constraints, num_variables, degree);
+        serialize(&srs)
+    }
+
+    /// Generates proving and verifying key for `circuit` using `srs`. Returns serialized keys.
+    pub fn generate_keys<C: ConstraintSynthesizer<CircuitField>>(
+        &self,
+        circuit: C,
+        srs: Vec<u8>,
+    ) -> RawKeys {
+        match self {
+            UniversalProvingSystem::Marlin => Self::_generate_keys::<_, Marlin>(circuit, srs),
+        }
+    }
+
+    fn _generate_keys<C: ConstraintSynthesizer<CircuitField>, S: UniversalSystem>(
+        circuit: C,
+        srs: Vec<u8>,
+    ) -> RawKeys {
+        let srs =
+            <<S as UniversalSystem>::Srs>::deserialize(&*srs).expect("Failed to deserialize srs");
+        let (pk, vk) = S::generate_keys(circuit, &srs);
+        RawKeys {
+            pk: serialize(&pk),
+            vk: serialize(&vk),
+        }
+    }
+}
+
+pub fn generate_srs(
+    system: UniversalProvingSystem,
+    num_constraints: usize,
+    num_variables: usize,
+    degree: usize,
+) {
+    let srs = system.generate_srs(num_constraints, num_variables, degree);
+    save_srs(&srs, &system.id());
+}
+
+mod io {
+    use std::{fs, path::PathBuf};
+
+    fn save_bytes(bytes: &[u8], prefix: &str, identifier: &str) {
+        let path = format!("{}.{}.bytes", prefix, identifier);
+        fs::write(path, bytes).unwrap_or_else(|_| panic!("Failed to save {}", identifier));
+    }
+
+    pub fn save_srs(srs: &[u8], env_id: &str) {
+        save_bytes(srs, env_id, "srs");
+    }
+
+    pub fn save_keys(rel_name: &str, env_id: &str, pk: &[u8], vk: &[u8]) {
+        let prefix = format!("{}.{}", rel_name, env_id);
+        save_bytes(pk, &prefix, "pk");
+        save_bytes(vk, &prefix, "vk");
+    }
+
+    pub fn save_proving_artifacts(rel_name: &str, env_id: &str, proof: &[u8], input: &[u8]) {
+        let prefix = format!("{}.{}", rel_name, env_id);
+        save_bytes(proof, &prefix, "proof");
+        save_bytes(input, &prefix, "public_input");
+    }
+
+    pub fn read_srs(srs_file: PathBuf) -> Vec<u8> {
+        fs::read(srs_file).expect("Failed to read SRS from the provided path")
+    }
+
+    pub fn read_proving_key(proving_key_file: PathBuf) -> Vec<u8> {
+        fs::read(proving_key_file).expect("Failed to read proving key from the provided path")
+    }
+}

--- a/bin/cliain/src/snark_relations/io.rs
+++ b/bin/cliain/src/snark_relations/io.rs
@@ -25,6 +25,14 @@ pub fn read_srs(srs_file: PathBuf) -> Vec<u8> {
     fs::read(srs_file).expect("Failed to read SRS from the provided path")
 }
 
-pub fn read_proving_key(proving_key_file: PathBuf) -> Vec<u8> {
-    fs::read(proving_key_file).expect("Failed to read proving key from the provided path")
+pub fn read_key(key_file: PathBuf) -> Vec<u8> {
+    fs::read(key_file).expect("Failed to read key from the provided path")
+}
+
+pub fn read_proof(proof_file: PathBuf) -> Vec<u8> {
+    fs::read(proof_file).expect("Failed to read proof from the provided path")
+}
+
+pub fn read_public_input(public_input_file: PathBuf) -> Vec<u8> {
+    fs::read(public_input_file).expect("Failed to read public key from the provided path")
 }

--- a/bin/cliain/src/snark_relations/io.rs
+++ b/bin/cliain/src/snark_relations/io.rs
@@ -1,0 +1,30 @@
+use std::{fs, path::PathBuf};
+
+fn save_bytes(bytes: &[u8], prefix: &str, identifier: &str) {
+    let path = format!("{}.{}.bytes", prefix, identifier);
+    fs::write(path, bytes).unwrap_or_else(|_| panic!("Failed to save {}", identifier));
+}
+
+pub fn save_srs(srs: &[u8], env_id: &str) {
+    save_bytes(srs, env_id, "srs");
+}
+
+pub fn save_keys(rel_name: &str, env_id: &str, pk: &[u8], vk: &[u8]) {
+    let prefix = format!("{}.{}", rel_name, env_id);
+    save_bytes(pk, &prefix, "pk");
+    save_bytes(vk, &prefix, "vk");
+}
+
+pub fn save_proving_artifacts(rel_name: &str, env_id: &str, proof: &[u8], input: &[u8]) {
+    let prefix = format!("{}.{}", rel_name, env_id);
+    save_bytes(proof, &prefix, "proof");
+    save_bytes(input, &prefix, "public_input");
+}
+
+pub fn read_srs(srs_file: PathBuf) -> Vec<u8> {
+    fs::read(srs_file).expect("Failed to read SRS from the provided path")
+}
+
+pub fn read_proving_key(proving_key_file: PathBuf) -> Vec<u8> {
+    fs::read(proving_key_file).expect("Failed to read proving key from the provided path")
+}

--- a/bin/cliain/src/snark_relations/mod.rs
+++ b/bin/cliain/src/snark_relations/mod.rs
@@ -1,8 +1,12 @@
+use std::path::PathBuf;
+
 pub use systems::{NonUniversalProvingSystem, UniversalProvingSystem};
 
-use crate::snark_relations::io::save_srs;
+pub use self::relations::RelationArgs;
+use crate::snark_relations::io::{read_srs, save_keys, save_srs};
 
 mod io;
+mod relations;
 mod systems;
 
 pub fn generate_srs(
@@ -13,4 +17,14 @@ pub fn generate_srs(
 ) {
     let srs = system.generate_srs(num_constraints, num_variables, degree);
     save_srs(&srs, &system.id());
+}
+
+pub fn generate_keys_from_srs(
+    relation: RelationArgs,
+    system: UniversalProvingSystem,
+    srs_file: PathBuf,
+) {
+    let srs = read_srs(srs_file);
+    let keys = system.generate_keys(relation.clone(), srs);
+    save_keys(&relation.id(), &system.id(), &keys.pk, &keys.vk);
 }

--- a/bin/cliain/src/snark_relations/mod.rs
+++ b/bin/cliain/src/snark_relations/mod.rs
@@ -1,0 +1,16 @@
+pub use systems::{NonUniversalProvingSystem, UniversalProvingSystem};
+
+use crate::snark_relations::io::save_srs;
+
+mod io;
+mod systems;
+
+pub fn generate_srs(
+    system: UniversalProvingSystem,
+    num_constraints: usize,
+    num_variables: usize,
+    degree: usize,
+) {
+    let srs = system.generate_srs(num_constraints, num_variables, degree);
+    save_srs(&srs, &system.id());
+}

--- a/bin/cliain/src/snark_relations/mod.rs
+++ b/bin/cliain/src/snark_relations/mod.rs
@@ -6,6 +6,7 @@ pub use self::relations::RelationArgs;
 use crate::snark_relations::io::{read_srs, save_keys, save_srs};
 
 mod io;
+mod parsing;
 mod relations;
 mod systems;
 

--- a/bin/cliain/src/snark_relations/mod.rs
+++ b/bin/cliain/src/snark_relations/mod.rs
@@ -5,7 +5,7 @@ pub use systems::{NonUniversalProvingSystem, SomeProvingSystem, UniversalProving
 
 pub use self::relations::RelationArgs;
 use crate::snark_relations::io::{
-    read_proving_key, read_srs, save_keys, save_proving_artifacts, save_srs,
+    read_key, read_proof, read_public_input, read_srs, save_keys, save_proving_artifacts, save_srs,
 };
 
 mod io;
@@ -43,8 +43,20 @@ pub fn generate_proof(
     system: SomeProvingSystem,
     proving_key_file: PathBuf,
 ) {
-    let proving_key = read_proving_key(proving_key_file);
+    let proving_key = read_key(proving_key_file);
     let proof = system.prove(relation.clone(), proving_key);
     let public_input = serialize(&relation.public_input());
     save_proving_artifacts(&relation.id(), &system.id(), &proof, &public_input);
+}
+
+pub fn verify(
+    verifying_key_file: PathBuf,
+    proof_file: PathBuf,
+    public_input_file: PathBuf,
+    system: SomeProvingSystem,
+) -> bool {
+    let verifying_key = read_key(verifying_key_file);
+    let proof = read_proof(proof_file);
+    let public_input = read_public_input(public_input_file);
+    system.verify(verifying_key, proof, public_input)
 }

--- a/bin/cliain/src/snark_relations/parsing.rs
+++ b/bin/cliain/src/snark_relations/parsing.rs
@@ -1,6 +1,11 @@
-use anyhow::Result;
+use anyhow::{Error, Result};
+use clap::ValueEnum;
 use relations::{
     note_from_bytes, FrontendAccount, FrontendMerklePathNode, FrontendMerkleRoot, FrontendNote,
+};
+
+use crate::{
+    snark_relations::systems::SomeProvingSystem, NonUniversalProvingSystem, UniversalProvingSystem,
 };
 
 pub fn parse_frontend_note(frontend_note: &str) -> Result<FrontendNote> {
@@ -19,4 +24,12 @@ pub fn parse_frontend_merkle_path_single(
     frontend_merkle_path_single: &str,
 ) -> Result<FrontendMerklePathNode> {
     Ok(note_from_bytes(frontend_merkle_path_single.as_bytes()))
+}
+
+pub fn parse_some_system(system: &str) -> Result<SomeProvingSystem> {
+    let maybe_universal =
+        UniversalProvingSystem::from_str(system, true).map(SomeProvingSystem::Universal);
+    let maybe_non_universal =
+        NonUniversalProvingSystem::from_str(system, true).map(SomeProvingSystem::NonUniversal);
+    maybe_universal.or(maybe_non_universal).map_err(Error::msg)
 }

--- a/bin/cliain/src/snark_relations/parsing.rs
+++ b/bin/cliain/src/snark_relations/parsing.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use relations::{
+    note_from_bytes, FrontendAccount, FrontendMerklePathNode, FrontendMerkleRoot, FrontendNote,
+};
+
+pub fn parse_frontend_note(frontend_note: &str) -> Result<FrontendNote> {
+    Ok(note_from_bytes(frontend_note.as_bytes()))
+}
+
+pub fn parse_frontend_merkle_root(frontend_merkle_root: &str) -> Result<FrontendMerkleRoot> {
+    Ok(note_from_bytes(frontend_merkle_root.as_bytes()))
+}
+
+pub fn parse_frontend_account(frontend_account: &str) -> Result<FrontendAccount> {
+    Ok(frontend_account.as_bytes().try_into().unwrap())
+}
+
+pub fn parse_frontend_merkle_path_single(
+    frontend_merkle_path_single: &str,
+) -> Result<FrontendMerklePathNode> {
+    Ok(note_from_bytes(frontend_merkle_path_single.as_bytes()))
+}

--- a/bin/cliain/src/snark_relations/relations.rs
+++ b/bin/cliain/src/snark_relations/relations.rs
@@ -1,0 +1,61 @@
+use clap::Subcommand;
+use relations::{
+    CircuitField, ConstraintSynthesizer, ConstraintSystemRef, Result as R1CsResult, XorRelation,
+};
+
+/// All available relations from `relations` crate.
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Subcommand)]
+pub enum RelationArgs {
+    Xor {
+        #[clap(long, short = 'a', default_value = "2")]
+        public_xoree: u8,
+        #[clap(long, short = 'b', default_value = "3")]
+        private_xoree: u8,
+        #[clap(long, short = 'c', default_value = "1")]
+        result: u8,
+    },
+    // LinearEquation(LinearEqRelationArgs),
+    // MerkleTree(MerkleTreeRelationArgs),
+    // Deposit(DepositRelationArgs),
+    // Withdraw(WithdrawRelationArgs),
+}
+
+impl RelationArgs {
+    /// Relation identifier.
+    #[allow(dead_code)]
+    pub fn id(&self) -> String {
+        match &self {
+            RelationArgs::Xor { .. } => String::from("xor"),
+            // Relation::LinearEquation(_) => String::from("linear_equation"),
+            // Relation::MerkleTree(_) => String::from("merkle_tree"),
+            // Relation::Deposit(_) => String::from("deposit"),
+            // Relation::Withdraw(_) => String::from("withdraw"),
+        }
+    }
+}
+
+impl ConstraintSynthesizer<CircuitField> for RelationArgs {
+    fn generate_constraints(self, cs: ConstraintSystemRef<CircuitField>) -> R1CsResult<()> {
+        match self {
+            RelationArgs::Xor {
+                public_xoree,
+                private_xoree,
+                result,
+            } => XorRelation::new(public_xoree, private_xoree, result).generate_constraints(cs),
+            // Relation::LinearEquation(relation @ LinearEqRelation { .. }) => {
+            //     relation.generate_constraints(cs)
+            // }
+            // Relation::MerkleTree(args @ MerkleTreeRelationArgs { .. }) => {
+            //     <MerkleTreeRelationArgs as Into<MerkleTreeRelation>>::into(args)
+            //         .generate_constraints(cs)
+            // }
+            // Relation::Deposit(args @ DepositRelationArgs { .. }) => {
+            //     <DepositRelationArgs as Into<DepositRelation>>::into(args).generate_constraints(cs)
+            // }
+            // Relation::Withdraw(args @ WithdrawRelationArgs { .. }) => {
+            //     <WithdrawRelationArgs as Into<WithdrawRelation>>::into(args)
+            //         .generate_constraints(cs)
+            // }
+        }
+    }
+}

--- a/bin/cliain/src/snark_relations/systems.rs
+++ b/bin/cliain/src/snark_relations/systems.rs
@@ -4,8 +4,6 @@ use relations::{
     UniversalSystem,
 };
 
-use crate::snark_relations::io::save_srs;
-
 /// All available non universal proving systems.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, ValueEnum)]
 pub enum NonUniversalProvingSystem {
@@ -70,48 +68,5 @@ impl UniversalProvingSystem {
             pk: serialize(&pk),
             vk: serialize(&vk),
         }
-    }
-}
-
-pub fn generate_srs(
-    system: UniversalProvingSystem,
-    num_constraints: usize,
-    num_variables: usize,
-    degree: usize,
-) {
-    let srs = system.generate_srs(num_constraints, num_variables, degree);
-    save_srs(&srs, &system.id());
-}
-
-mod io {
-    use std::{fs, path::PathBuf};
-
-    fn save_bytes(bytes: &[u8], prefix: &str, identifier: &str) {
-        let path = format!("{}.{}.bytes", prefix, identifier);
-        fs::write(path, bytes).unwrap_or_else(|_| panic!("Failed to save {}", identifier));
-    }
-
-    pub fn save_srs(srs: &[u8], env_id: &str) {
-        save_bytes(srs, env_id, "srs");
-    }
-
-    pub fn save_keys(rel_name: &str, env_id: &str, pk: &[u8], vk: &[u8]) {
-        let prefix = format!("{}.{}", rel_name, env_id);
-        save_bytes(pk, &prefix, "pk");
-        save_bytes(vk, &prefix, "vk");
-    }
-
-    pub fn save_proving_artifacts(rel_name: &str, env_id: &str, proof: &[u8], input: &[u8]) {
-        let prefix = format!("{}.{}", rel_name, env_id);
-        save_bytes(proof, &prefix, "proof");
-        save_bytes(input, &prefix, "public_input");
-    }
-
-    pub fn read_srs(srs_file: PathBuf) -> Vec<u8> {
-        fs::read(srs_file).expect("Failed to read SRS from the provided path")
-    }
-
-    pub fn read_proving_key(proving_key_file: PathBuf) -> Vec<u8> {
-        fs::read(proving_key_file).expect("Failed to read proving key from the provided path")
     }
 }

--- a/relations/src/lib.rs
+++ b/relations/src/lib.rs
@@ -7,7 +7,7 @@ mod shielder;
 mod utils;
 mod xor;
 
-pub use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
+pub use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, Result, SynthesisError};
 pub use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 pub use environment::{
     CircuitField, Groth16, Marlin, MarlinPolynomialCommitment, NonUniversalSystem, ProvingSystem,


### PR DESCRIPTION
This PR moves the whole functionality of `house-snark` tool to `cliain`. Moreover, we add another command for off-chain proof verification.