### PR TITLE
A0-1609 Removed unwrap()'s in aleph-client

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "aleph_client"
-version = "2.4.0"
+# TODO bump major version when API stablize
+version = "2.5.0"
 edition = "2021"
 license = "Apache 2.0"
 

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -3,7 +3,6 @@ use std::{thread::sleep, time::Duration};
 use anyhow::anyhow;
 use codec::Decode;
 use log::info;
-use primitives::BlockNumber;
 use subxt::{
     ext::sp_core::Bytes,
     metadata::DecodeWithMetadata,
@@ -113,18 +112,6 @@ impl Connection {
         let bytes: Bytes = self.client.rpc().request(&func_name, params).await?;
 
         Ok(R::decode(&mut bytes.as_ref())?)
-    }
-
-    pub async fn get_block_number_inner(
-        &self,
-        block: Option<BlockHash>,
-    ) -> anyhow::Result<Option<BlockNumber>> {
-        self.client
-            .rpc()
-            .header(block)
-            .await
-            .map(|maybe_header| maybe_header.map(|header| header.number))
-            .map_err(|e| e.into())
     }
 }
 

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -3,6 +3,7 @@ use std::{thread::sleep, time::Duration};
 use anyhow::anyhow;
 use codec::Decode;
 use log::info;
+use primitives::BlockNumber;
 use subxt::{
     ext::sp_core::Bytes,
     metadata::DecodeWithMetadata,
@@ -112,6 +113,18 @@ impl Connection {
         let bytes: Bytes = self.client.rpc().request(&func_name, params).await?;
 
         Ok(R::decode(&mut bytes.as_ref())?)
+    }
+
+    pub async fn get_block_number_inner(
+        &self,
+        block: Option<BlockHash>,
+    ) -> anyhow::Result<Option<BlockNumber>> {
+        self.client
+            .rpc()
+            .header(block)
+            .await
+            .map(|maybe_header| maybe_header.map(|header| header.number))
+            .map_err(|e| e.into())
     }
 }
 

--- a/aleph-client/src/pallets/author.rs
+++ b/aleph-client/src/pallets/author.rs
@@ -4,14 +4,14 @@ use crate::{aleph_runtime::SessionKeys, Connection};
 
 #[async_trait::async_trait]
 pub trait AuthorRpc {
-    async fn author_rotate_keys(&self) -> SessionKeys;
+    async fn author_rotate_keys(&self) -> anyhow::Result<SessionKeys>;
 }
 
 #[async_trait::async_trait]
 impl AuthorRpc for Connection {
-    async fn author_rotate_keys(&self) -> SessionKeys {
-        let bytes = self.client.rpc().rotate_keys().await.unwrap();
+    async fn author_rotate_keys(&self) -> anyhow::Result<SessionKeys> {
+        let bytes = self.client.rpc().rotate_keys().await?;
 
-        SessionKeys::decode(&mut bytes.0.as_slice()).unwrap()
+        SessionKeys::decode(&mut bytes.0.as_slice()).map_err(|e| e.into())
     }
 }

--- a/aleph-client/src/pallets/contract.rs
+++ b/aleph-client/src/pallets/contract.rs
@@ -188,7 +188,13 @@ impl ContractRpc for Connection {
 
         let res: ContractExecResult<Balance> =
             self.rpc_call("state_call".to_string(), params).await?;
-        let res = T::decode(&mut (res.result.unwrap().data.as_slice()))?;
+        let res = T::decode(
+            &mut (res
+                .result
+                .expect("Failed to decode execution result of the wasm code!")
+                .data
+                .as_slice()),
+        )?;
 
         Ok(res)
     }

--- a/aleph-client/src/pallets/elections.rs
+++ b/aleph-client/src/pallets/elections.rs
@@ -43,7 +43,7 @@ pub trait ElectionsApi {
         validator: AccountId,
         at: Option<BlockHash>,
     ) -> Option<BanInfo>;
-    async fn get_session_period(&self) -> u32;
+    async fn get_session_period(&self) -> anyhow::Result<u32>;
 }
 
 #[async_trait::async_trait]
@@ -164,10 +164,10 @@ impl ElectionsApi for Connection {
         self.get_storage_entry_maybe(&addrs, at).await
     }
 
-    async fn get_session_period(&self) -> u32 {
+    async fn get_session_period(&self) -> anyhow::Result<u32> {
         let addrs = api::constants().elections().session_period();
 
-        self.client.constants().at(&addrs).unwrap()
+        self.client.constants().at(&addrs).map_err(|e| e.into())
     }
 }
 

--- a/aleph-client/src/pallets/treasury.rs
+++ b/aleph-client/src/pallets/treasury.rs
@@ -33,7 +33,7 @@ pub trait TreasuryUserApi {
 
 #[async_trait::async_trait]
 pub trait TreasureApiExt {
-    async fn possible_treasury_payout(&self) -> Balance;
+    async fn possible_treasury_payout(&self) -> anyhow::Result<Balance>;
 }
 
 #[async_trait::async_trait]
@@ -106,12 +106,12 @@ impl TreasurySudoApi for RootConnection {
 
 #[async_trait::async_trait]
 impl TreasureApiExt for Connection {
-    async fn possible_treasury_payout(&self) -> Balance {
-        let session_period = self.get_session_period().await;
-        let sessions_per_era = self.get_session_per_era().await;
+    async fn possible_treasury_payout(&self) -> anyhow::Result<Balance> {
+        let session_period = self.get_session_period().await?;
+        let sessions_per_era = self.get_session_per_era().await?;
 
         let millisecs_per_era =
             MILLISECS_PER_BLOCK * session_period as u64 * sessions_per_era as u64;
-        primitives::staking::era_payout(millisecs_per_era).1
+        Ok(primitives::staking::era_payout(millisecs_per_era).1)
     }
 }

--- a/aleph-client/src/runtime_types.rs
+++ b/aleph-client/src/runtime_types.rs
@@ -24,8 +24,16 @@ impl From<Vec<u8>> for SessionKeys {
     fn from(bytes: Vec<u8>) -> Self {
         assert_eq!(bytes.len(), 64);
         Self {
-            aura: AuraPublic(SrPublic(bytes[..32].try_into().unwrap())),
-            aleph: AlephPublic(EdPublic(bytes[32..64].try_into().unwrap())),
+            aura: AuraPublic(SrPublic(
+                bytes[..32]
+                    .try_into()
+                    .expect("Failed to convert bytes slice to an Aura key!"),
+            )),
+            aleph: AlephPublic(EdPublic(
+                bytes[32..64]
+                    .try_into()
+                    .expect("Failed to convert bytes slice to an Aleph key!"),
+            )),
         }
     }
 }

--- a/aleph-client/src/utility.rs
+++ b/aleph-client/src/utility.rs
@@ -8,64 +8,63 @@ use crate::{
 
 #[async_trait::async_trait]
 pub trait BlocksApi {
-    async fn first_block_of_session(&self, session: SessionIndex) -> Option<BlockHash>;
-    async fn get_block_hash(&self, block: BlockNumber) -> Option<BlockHash>;
-    async fn get_best_block(&self) -> BlockNumber;
-    async fn get_finalized_block_hash(&self) -> BlockHash;
-    async fn get_block_number(&self, block: BlockHash) -> Option<BlockNumber>;
+    async fn first_block_of_session(
+        &self,
+        session: SessionIndex,
+    ) -> anyhow::Result<Option<BlockHash>>;
+    async fn get_block_hash(&self, block: BlockNumber) -> anyhow::Result<Option<BlockHash>>;
+    async fn get_best_block(&self) -> anyhow::Result<Option<BlockNumber>>;
+    async fn get_finalized_block_hash(&self) -> anyhow::Result<BlockHash>;
+    async fn get_block_number(&self, block: BlockHash) -> anyhow::Result<Option<BlockNumber>>;
 }
 
 #[async_trait::async_trait]
 pub trait SessionEraApi {
-    async fn get_active_era_for_session(&self, session: SessionIndex) -> EraIndex;
+    async fn get_active_era_for_session(&self, session: SessionIndex) -> anyhow::Result<EraIndex>;
 }
 
 #[async_trait::async_trait]
 impl BlocksApi for Connection {
-    async fn first_block_of_session(&self, session: SessionIndex) -> Option<BlockHash> {
-        let period = self.get_session_period().await;
+    async fn first_block_of_session(
+        &self,
+        session: SessionIndex,
+    ) -> anyhow::Result<Option<BlockHash>> {
+        let period = self.get_session_period().await?;
         let block_num = period * session;
 
         self.get_block_hash(block_num).await
     }
 
-    async fn get_block_hash(&self, block: BlockNumber) -> Option<BlockHash> {
+    async fn get_block_hash(&self, block: BlockNumber) -> anyhow::Result<Option<BlockHash>> {
         info!(target: "aleph-client", "querying block hash for number #{}", block);
         self.client
             .rpc()
             .block_hash(Some(block.into()))
             .await
-            .unwrap()
+            .map_err(|e| e.into())
     }
 
-    async fn get_best_block(&self) -> BlockNumber {
+    async fn get_best_block(&self) -> anyhow::Result<Option<BlockNumber>> {
+        self.get_block_number_inner(None).await
+    }
+
+    async fn get_finalized_block_hash(&self) -> anyhow::Result<BlockHash> {
         self.client
             .rpc()
-            .header(None)
+            .finalized_head()
             .await
-            .unwrap()
-            .unwrap()
-            .number
+            .map_err(|e| e.into())
     }
 
-    async fn get_finalized_block_hash(&self) -> BlockHash {
-        self.client.rpc().finalized_head().await.unwrap()
-    }
-
-    async fn get_block_number(&self, block: BlockHash) -> Option<BlockNumber> {
-        self.client
-            .rpc()
-            .header(Some(block))
-            .await
-            .unwrap()
-            .map(|h| h.number)
+    async fn get_block_number(&self, block: BlockHash) -> anyhow::Result<Option<BlockNumber>> {
+        self.get_block_number_inner(Some(block)).await
     }
 }
 
 #[async_trait::async_trait]
 impl SessionEraApi for Connection {
-    async fn get_active_era_for_session(&self, session: SessionIndex) -> EraIndex {
-        let block = self.first_block_of_session(session).await;
-        self.get_active_era(block).await
+    async fn get_active_era_for_session(&self, session: SessionIndex) -> anyhow::Result<EraIndex> {
+        let block = self.first_block_of_session(session).await?;
+        Ok(self.get_active_era(block).await)
     }
 }

--- a/aleph-client/src/utility.rs
+++ b/aleph-client/src/utility.rs
@@ -23,6 +23,20 @@ pub trait SessionEraApi {
     async fn get_active_era_for_session(&self, session: SessionIndex) -> anyhow::Result<EraIndex>;
 }
 
+impl Connection {
+    async fn get_block_number_inner(
+        &self,
+        block: Option<BlockHash>,
+    ) -> anyhow::Result<Option<BlockNumber>> {
+        self.client
+            .rpc()
+            .header(block)
+            .await
+            .map(|maybe_header| maybe_header.map(|header| header.number))
+            .map_err(|e| e.into())
+    }
+}
+
 #[async_trait::async_trait]
 impl BlocksApi for Connection {
     async fn first_block_of_session(

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "cliain"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aleph_client",
  "anyhow",

--- a/bin/cliain/Cargo.toml
+++ b/bin/cliain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliain"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "GPL-3.0-or-later"
 

--- a/bin/cliain/src/keys.rs
+++ b/bin/cliain/src/keys.rs
@@ -13,7 +13,10 @@ use primitives::staking::MIN_VALIDATOR_BOND;
 use serde_json::json;
 use subxt::ext::sp_core::crypto::Ss58Codec;
 
-pub async fn prepare_keys(connection: RootConnection, controller_account_id: AccountId) {
+pub async fn prepare_keys(
+    connection: RootConnection,
+    controller_account_id: AccountId,
+) -> anyhow::Result<()> {
     connection
         .as_signed()
         .bond(
@@ -23,12 +26,12 @@ pub async fn prepare_keys(connection: RootConnection, controller_account_id: Acc
         )
         .await
         .unwrap();
-    let new_keys = connection.connection.author_rotate_keys().await;
-    connection
+    let new_keys = connection.connection.author_rotate_keys().await?;
+    let _ = connection
         .as_signed()
         .set_keys(new_keys, TxStatus::Finalized)
-        .await
-        .unwrap();
+        .await?;
+    Ok(())
 }
 
 pub async fn set_keys(connection: SignedConnection, new_keys: String) {

--- a/bin/cliain/src/main.rs
+++ b/bin/cliain/src/main.rs
@@ -58,7 +58,7 @@ fn read_secret(secret: Option<String>, message: &str) -> String {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     init_env();
 
     let Config {
@@ -76,7 +76,7 @@ async fn main() {
         Command::PrepareKeys => {
             let key = keypair_from_string(&seed);
             let controller_account_id = account_from_keypair(key.signer());
-            prepare_keys(cfg.get_root_connection().await, controller_account_id).await;
+            prepare_keys(cfg.get_root_connection().await, controller_account_id).await?
         }
         Command::Bond {
             controller_account,
@@ -245,6 +245,7 @@ async fn main() {
             Err(why) => error!("Unable to schedule an upgrade {:?}", why),
         },
     }
+    Ok(())
 }
 
 fn init_env() {

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-e2e-client"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "aleph_client",
  "anyhow",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-e2e-client"
-version = "0.9.4"
+version = "0.10.0"
 edition = "2021"
 license = "Apache 2.0"
 

--- a/e2e-tests/src/ban.rs
+++ b/e2e-tests/src/ban.rs
@@ -186,7 +186,7 @@ pub async fn check_underperformed_count_for_sessions(
     end_session: SessionIndex,
     ban_session_threshold: SessionCount,
 ) -> anyhow::Result<()> {
-    let session_period = connection.get_session_period().await;
+    let session_period = connection.get_session_period().await?;
 
     let validators: Vec<_> = reserved_validators
         .iter()
@@ -195,11 +195,12 @@ pub async fn check_underperformed_count_for_sessions(
 
     for session in start_session..end_session {
         let session_end_block = (session + 1) * session_period;
-        let session_end_block_hash = connection.get_block_hash(session_end_block).await;
+        let session_end_block_hash = connection.get_block_hash(session_end_block).await?;
 
         let previous_session_end_block = session_end_block - session_period;
-        let previous_session_end_block_hash =
-            connection.get_block_hash(previous_session_end_block).await;
+        let previous_session_end_block_hash = connection
+            .get_block_hash(previous_session_end_block)
+            .await?;
 
         let members =
             get_members_for_session(reserved_validators, non_reserved_validators, seats, session);

--- a/e2e-tests/src/config.rs
+++ b/e2e-tests/src/config.rs
@@ -8,7 +8,7 @@ use crate::accounts::{get_sudo_key, get_validators_keys, get_validators_seeds, N
 
 static GLOBAL_CONFIG: Lazy<Config> = Lazy::new(|| {
     let node = get_env("NODE_URL").unwrap_or_else(|| "ws://127.0.0.1:9943".to_string());
-    let validator_count = get_env("VALIDATOR_COUNT").unwrap_or_else(|| 5);
+    let validator_count = get_env("VALIDATOR_COUNT").unwrap_or(5);
     let validators_seeds = env::var("VALIDATORS_SEEDS")
         .ok()
         .map(|s| s.split(',').map(|s| s.to_string()).collect());
@@ -41,7 +41,7 @@ where
 {
     env::var(name).ok().map(|v| {
         v.parse()
-            .expect(&format!("Failed to parse env var {}", name))
+            .unwrap_or_else(|_| panic!("Failed to parse env var {}", name))
     })
 }
 

--- a/e2e-tests/src/elections.rs
+++ b/e2e-tests/src/elections.rs
@@ -14,7 +14,7 @@ pub async fn get_and_test_members_for_session(
     seats: CommitteeSeats,
     era_validators: &EraValidators<AccountId>,
     session: SessionIndex,
-) -> (Vec<AccountId>, Vec<AccountId>) {
+) -> anyhow::Result<(Vec<AccountId>, Vec<AccountId>)> {
     let reserved_members_for_session =
         get_members_subset_for_session(seats.reserved_seats, &era_validators.reserved, session);
     let non_reserved_members_for_session = get_members_subset_for_session(
@@ -40,7 +40,7 @@ pub async fn get_and_test_members_for_session(
         .collect();
 
     let members_active_set: HashSet<_> = members_active.iter().cloned().collect();
-    let block = connection.first_block_of_session(session).await;
+    let block = connection.first_block_of_session(session).await?;
     let network_members: HashSet<_> = connection.get_validators(block).await.into_iter().collect();
 
     debug!(
@@ -55,7 +55,7 @@ pub async fn get_and_test_members_for_session(
 
     assert_eq!(members_active_set, network_members);
 
-    (members_active, members_bench)
+    Ok((members_active, members_bench))
 }
 
 /// Computes a list of validators that should be elected for a given session, based on description in our elections pallet.

--- a/e2e-tests/src/test/electing_validators.rs
+++ b/e2e-tests/src/test/electing_validators.rs
@@ -25,10 +25,10 @@ async fn assert_validators_are_elected_stakers(
     connection: &Connection,
     current_era: EraIndex,
     expected_validators_as_keys: Vec<Vec<u8>>,
-) {
+) -> anyhow::Result<()> {
     let stakers = connection
         .get_stakers_storage_keys(current_era, None)
-        .await
+        .await?
         .into_iter()
         .map(|key| key.0);
     let stakers_tree = BTreeSet::from_iter(stakers);
@@ -39,6 +39,8 @@ async fn assert_validators_are_elected_stakers(
         "Expected another set of staking validators.\n\tExpected: {:?}\n\tActual: {:?}",
         expected_validators_as_keys, stakers_tree
     );
+
+    Ok(())
 }
 
 // There are v non-reserved validators and s non-reserved seats. We will have seen all
@@ -180,7 +182,7 @@ pub async fn authorities_are_staking() -> anyhow::Result<()> {
 
     let desired_validator_count = reserved_seats + non_reserved_seats;
     let accounts = setup_accounts(desired_validator_count);
-    prepare_validators(&root_connection.as_signed(), node, &accounts).await;
+    prepare_validators(&root_connection.as_signed(), node, &accounts).await?;
     info!("New validators are set up");
 
     let reserved_validators = accounts.get_stash_accounts()[..reserved_seats as usize].to_vec();
@@ -249,7 +251,7 @@ pub async fn authorities_are_staking() -> anyhow::Result<()> {
             .map(|k| k.0)
             .collect(),
     )
-    .await;
+    .await?;
 
     let min_num_sessions =
         min_num_sessions_to_see_all_non_reserved_validators(non_reserved_count, non_reserved_seats);
@@ -288,7 +290,7 @@ pub async fn authorities_are_staking() -> anyhow::Result<()> {
             .map(|k| k.0)
             .collect(),
     )
-    .await;
+    .await?;
     assert_validators_are_used_as_authorities(
         &connection.connection,
         &BTreeSet::from_iter(left_stashes.into_iter()),

--- a/e2e-tests/src/test/era_validators.rs
+++ b/e2e-tests/src/test/era_validators.rs
@@ -5,6 +5,7 @@ use aleph_client::{
     waiting::{AlephWaiting, BlockStatus, WaitingExt},
     AccountId, Connection, KeyPair, TxStatus,
 };
+use anyhow::anyhow;
 
 use crate::{
     accounts::{account_ids_from_keys, get_validators_raw_keys},
@@ -160,7 +161,11 @@ pub async fn era_validators() -> anyhow::Result<()> {
         "Non-reserved validators set is not properly updated in the next era."
     );
 
-    let block_number = connection.connection.get_best_block().await;
+    let block_number = connection
+        .connection
+        .get_best_block()
+        .await?
+        .ok_or(anyhow!("Failed to retrieve best block number!"))?;
     connection
         .connection
         .wait_for_block(|n| n >= block_number, BlockStatus::Finalized)

--- a/e2e-tests/src/test/finalization.rs
+++ b/e2e-tests/src/test/finalization.rs
@@ -2,6 +2,7 @@ use aleph_client::{
     utility::BlocksApi,
     waiting::{AlephWaiting, BlockStatus},
 };
+use anyhow::anyhow;
 
 use crate::config::setup_test;
 
@@ -10,12 +11,15 @@ pub async fn finalization() -> anyhow::Result<()> {
     let config = setup_test();
     let connection = config.create_root_connection().await;
 
-    let finalized = connection.connection.get_finalized_block_hash().await;
+    let finalized = connection.connection.get_finalized_block_hash().await?;
     let finalized_number = connection
         .connection
         .get_block_number(finalized)
-        .await
-        .unwrap();
+        .await?
+        .ok_or(anyhow!(
+            "Failed to retrieve block number for hash {:?}",
+            finalized
+        ))?;
     connection
         .connection
         .wait_for_block(|n| n > finalized_number, BlockStatus::Finalized)

--- a/e2e-tests/src/test/finalization.rs
+++ b/e2e-tests/src/test/finalization.rs
@@ -17,8 +17,7 @@ pub async fn finalization() -> anyhow::Result<()> {
         .get_block_number(finalized)
         .await?
         .ok_or(anyhow!(
-            "Failed to retrieve block number for hash {:?}",
-            finalized
+            "Failed to retrieve block number for hash {finalized:?}"
         ))?;
     connection
         .connection

--- a/e2e-tests/src/test/rewards.rs
+++ b/e2e-tests/src/test/rewards.rs
@@ -48,14 +48,14 @@ pub async fn points_basic() -> anyhow::Result<()> {
         let era = connection
             .connection
             .get_active_era_for_session(session)
-            .await;
+            .await?;
         let (members_active, members_bench) = get_and_test_members_for_session(
             &connection.connection,
             committee_size.clone(),
             &era_validators,
             session,
         )
-        .await;
+        .await?;
 
         check_points(
             &connection,
@@ -109,14 +109,14 @@ pub async fn points_stake_change() -> anyhow::Result<()> {
         let era = connection
             .connection
             .get_active_era_for_session(session)
-            .await;
+            .await?;
         let (members_active, members_bench) = get_and_test_members_for_session(
             &connection.connection,
             committee_size.clone(),
             &era_validators,
             session,
         )
-        .await;
+        .await?;
 
         check_points(
             &connection,
@@ -165,14 +165,14 @@ pub async fn disable_node() -> anyhow::Result<()> {
         let era = root_connection
             .connection
             .get_active_era_for_session(session)
-            .await;
+            .await?;
         let (members_active, members_bench) = get_and_test_members_for_session(
             &controller_connection.connection,
             committee_size.clone(),
             &era_validators,
             session,
         )
-        .await;
+        .await?;
 
         check_points(
             &controller_connection,
@@ -203,7 +203,7 @@ pub async fn force_new_era() -> anyhow::Result<()> {
     let start_era = connection
         .connection
         .get_active_era_for_session(start_session)
-        .await;
+        .await?;
 
     info!("Start | era: {}, session: {}", start_era, start_session);
 
@@ -248,7 +248,7 @@ pub async fn change_stake_and_force_new_era() -> anyhow::Result<()> {
     let start_era = connection
         .connection
         .get_active_era_for_session(start_session)
-        .await;
+        .await?;
     info!("Start | era: {}, session: {}", start_era, start_session);
 
     validators_bond_extra_stakes(
@@ -316,7 +316,7 @@ async fn check_points_after_force_new_era(
             era_validators,
             session_to_check,
         )
-        .await;
+        .await?;
 
         check_points(
             connection,

--- a/e2e-tests/src/test/staking.rs
+++ b/e2e-tests/src/test/staking.rs
@@ -178,7 +178,7 @@ pub async fn staking_new_validator() -> anyhow::Result<()> {
         &stash_account, &controller_account, &bonded_controller_account
     );
 
-    let validator_keys = root_connection.connection.author_rotate_keys().await;
+    let validator_keys = root_connection.connection.author_rotate_keys().await?;
     let controller_connection =
         SignedConnection::new(node.to_string(), KeyPair::new(controller.signer().clone())).await;
     controller_connection

--- a/e2e-tests/src/test/treasury.rs
+++ b/e2e-tests/src/test/treasury.rs
@@ -41,7 +41,7 @@ pub async fn channeling_fee_and_tip() -> anyhow::Result<()> {
 
     let (treasury_balance_before, issuance_before) = balance_info(&connection.connection).await;
     let possible_treasury_gain_from_staking =
-        connection.connection.possible_treasury_payout().await;
+        connection.connection.possible_treasury_payout().await?;
     let (fee, _) = current_fees(&connection, to, Some(tip), transfer_amount).await;
     let (treasury_balance_after, issuance_after) = balance_info(&connection.connection).await;
 

--- a/e2e-tests/src/test/validators_change.rs
+++ b/e2e-tests/src/test/validators_change.rs
@@ -6,6 +6,7 @@ use aleph_client::{
     waiting::{AlephWaiting, BlockStatus},
     AccountId, Pair, TxStatus,
 };
+use anyhow::anyhow;
 use log::info;
 
 use crate::{accounts::get_validators_keys, config::setup_test};
@@ -90,7 +91,11 @@ pub async fn change_validators() -> anyhow::Result<()> {
         },
         committee_size_after
     );
-    let block_number = connection.connection.get_best_block().await;
+    let block_number = connection
+        .connection
+        .get_best_block()
+        .await?
+        .ok_or(anyhow!("Failed to retrieve best block!"))?;
     connection
         .connection
         .wait_for_block(|n| n >= block_number, BlockStatus::Finalized)

--- a/e2e-tests/src/test/version_upgrade.rs
+++ b/e2e-tests/src/test/version_upgrade.rs
@@ -4,6 +4,7 @@ use aleph_client::{
     waiting::{AlephWaiting, BlockStatus},
     TxStatus,
 };
+use anyhow::anyhow;
 use primitives::SessionIndex;
 
 use crate::config::setup_test;
@@ -44,7 +45,11 @@ pub async fn schedule_version_change() -> anyhow::Result<()> {
         .wait_for_session(session_after_upgrade + 1, BlockStatus::Finalized)
         .await;
 
-    let block_number = connection.connection.get_best_block().await;
+    let block_number = connection
+        .connection
+        .get_best_block()
+        .await?
+        .ok_or(anyhow!("Failed to retrieve best block number!"))?;
     connection
         .connection
         .wait_for_block(|n| n >= block_number, BlockStatus::Finalized)
@@ -86,11 +91,11 @@ pub async fn schedule_doomed_version_change_and_verify_finalization_stopped() ->
         .await;
 
     let last_finalized_block =
-        session_for_upgrade * connection.connection.get_session_period().await - 1;
+        session_for_upgrade * connection.connection.get_session_period().await? - 1;
 
     let connection = connection.connection;
-    let finalized_block_head = connection.get_finalized_block_hash().await;
-    let finalized_block = connection.get_block_number(finalized_block_head).await;
+    let finalized_block_head = connection.get_finalized_block_hash().await?;
+    let finalized_block = connection.get_block_number(finalized_block_head).await?;
 
     let finalized_block = match finalized_block {
         Some(block) => block,

--- a/e2e-tests/src/validators.rs
+++ b/e2e-tests/src/validators.rs
@@ -103,7 +103,11 @@ pub fn setup_accounts(desired_validator_count: u32) -> Accounts {
 /// Endow validators (stashes and controllers), bond and rotate keys.
 ///
 /// Signer of `connection` should have enough balance to endow new accounts.
-pub async fn prepare_validators(connection: &SignedConnection, node: &str, accounts: &Accounts) {
+pub async fn prepare_validators(
+    connection: &SignedConnection,
+    node: &str,
+    accounts: &Accounts,
+) -> anyhow::Result<()> {
     connection
         .batch_transfer(
             &accounts.stash_accounts,
@@ -134,7 +138,7 @@ pub async fn prepare_validators(connection: &SignedConnection, node: &str, accou
     }
 
     for controller in accounts.controller_raw_keys.iter() {
-        let keys = connection.connection.author_rotate_keys().await;
+        let keys = connection.connection.author_rotate_keys().await?;
         let connection =
             SignedConnection::new(node.to_string(), KeyPair::new(controller.clone())).await;
         handles.push(tokio::spawn(async move {
@@ -147,4 +151,5 @@ pub async fn prepare_validators(connection: &SignedConnection, node: &str, accou
     }
 
     join_all(handles).await;
+    Ok(())
 }

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/fork-off/Cargo.lock
+++ b/fork-off/Cargo.lock
@@ -839,7 +839,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-off"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-channel",


### PR DESCRIPTION
# Description

Motivation: get rid of bare `unwrap()` in `aleph-client`. One can just transform them to `expect(msg)`, but we can do better. We can benefit from leveraging `subxt::Error`, ie passing `Result<T, subxt::Error> to the client of `aleph-client`. This can be simple done as `.map_err(|e: subxt::Error| e.into())`, where the return type is `anyhow::Result` that is used already in `aleph-client`. Not all public API of `aleph-client` was modified in order not to bloat this PR. 

Deliberately only minor version of `aleph-client` was bumped to not bump major version twice. This is fine since we don't publish `aleph-client` to crates.io.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

