### PR TITLE
Relations crate: `no_std`

### DIFF
--- a/relations/Cargo.lock
+++ b/relations/Cargo.lock
@@ -197,7 +197,9 @@ checksum = "a71ddfa72bad1446cab7bbecb6018dbbdc9abcbc3a0065483ae5186ad2a64dcd"
 dependencies = [
  "ark-ec",
  "ark-ff",
+ "ark-nonnative-field",
  "ark-poly",
+ "ark-relations",
  "ark-serialize",
  "ark-std",
  "derivative",

--- a/relations/Cargo.toml
+++ b/relations/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Cardinal Cryptography"]
 
 [dependencies]
 ark-bls12-381 = { version = "^0.3.0" }
-ark-crypto-primitives = { version = "^0.3.0", default-features = true, features = [ "r1cs" ] }
+ark-crypto-primitives = { version = "^0.3.0", default-features = false, features = [ "r1cs" ] }
 ark-ec = { version = "^0.3.0", default-features = false }
 ark-ed-on-bls12-381 = { version = "^0.3.0", features = ["r1cs"] }
 ark-ff = { version = "^0.3.0", default-features = false }
@@ -25,4 +25,19 @@ blake2 = { version = "0.9.2", default-features = false }
 
 [features]
 default = ["std"]
-std = []
+std = [
+    "ark-bls12-381/std",
+    "ark-crypto-primitives/std",
+    "ark-ec/std",
+    "ark-ed-on-bls12-381/std",
+    "ark-ff/std",
+    "ark-gm17/std",
+    "ark-groth16/std",
+    "ark-marlin/std",
+    "ark-poly/std",
+    "ark-poly-commit/std",
+    "ark-r1cs-std/std",
+    "ark-relations/std",
+    "ark-serialize/std",
+    "blake2/std",
+]

--- a/relations/src/environment.rs
+++ b/relations/src/environment.rs
@@ -3,7 +3,10 @@ use ark_poly_commit::marlin_pc::MarlinKZG10;
 use ark_relations::r1cs::ConstraintSynthesizer;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
-use ark_std::rand::{rngs::StdRng, SeedableRng};
+use ark_std::{
+    rand::{rngs::StdRng, SeedableRng},
+    vec::Vec,
+};
 use blake2::Blake2s;
 
 // For now, we can settle with these types.

--- a/relations/src/lib.rs
+++ b/relations/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 mod environment;
 mod linear;
 mod merkle_tree;

--- a/relations/src/linear.rs
+++ b/relations/src/linear.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use ark_ff::PrimeField;
 use ark_r1cs_std::{
     prelude::{AllocVar, EqGadget},
@@ -8,6 +6,7 @@ use ark_r1cs_std::{
 use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystemRef, SynthesisError, SynthesisError::AssignmentMissing,
 };
+use ark_std::{marker::PhantomData, vec::Vec};
 
 use crate::{
     relation::{
@@ -70,7 +69,7 @@ impl<Field: PrimeField, S: State> ConstraintSynthesizer<Field> for LinearEquatio
         let b = UInt32::new_constant(ark_relations::ns!(cs, "b"), self.b)?;
         let y = UInt32::new_constant(ark_relations::ns!(cs, "y"), self.y)?;
 
-        let mut left = std::iter::repeat(x)
+        let mut left = ark_std::iter::repeat(x)
             .take(self.a as usize)
             .collect::<Vec<UInt32<Field>>>();
 

--- a/relations/src/merkle_tree/relation.rs
+++ b/relations/src/merkle_tree/relation.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use ark_crypto_primitives::{
     crh::{TwoToOneCRH, TwoToOneCRHGadget},
     PathVar, CRH,
@@ -8,6 +6,7 @@ use ark_r1cs_std::{boolean::Boolean, eq::EqGadget, prelude::AllocVar, uint8::UIn
 use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystemRef, SynthesisError, SynthesisError::AssignmentMissing,
 };
+use ark_std::{marker::PhantomData, string::String, vec, vec::Vec};
 
 use crate::{
     byte_to_bits,
@@ -112,6 +111,7 @@ impl<S: State> ConstraintSynthesizer<CircuitField> for MerkleTreeRelation<S> {
     ) -> Result<(), SynthesisError> {
         let path = SimplePathVar::new_witness(ark_relations::ns!(cs, "path"), || {
             self.merkle_path.ok_or_else(|| {
+            #[cfg(feature = "std")]
             if cs.is_in_setup_mode() {
                 eprintln!("Unfortunately, `MerkleTreeRelation` requires path even for keys generation. Blame `arkworks`.");
             }

--- a/relations/src/merkle_tree/tree.rs
+++ b/relations/src/merkle_tree/tree.rs
@@ -4,7 +4,10 @@ use ark_crypto_primitives::{
     MerkleTree, Path, CRH,
 };
 use ark_ed_on_bls12_381::EdwardsProjective;
-use ark_std::rand::{prelude::StdRng, SeedableRng};
+use ark_std::{
+    rand::{prelude::StdRng, SeedableRng},
+    vec::Vec,
+};
 
 use crate::merkle_tree::hash_functions::{LeafHash, TwoToOneHash};
 

--- a/relations/src/relation.rs
+++ b/relations/src/relation.rs
@@ -1,5 +1,6 @@
 use ark_ff::PrimeField;
 use ark_serialize::CanonicalSerialize;
+use ark_std::{vec, vec::Vec};
 
 pub trait GetPublicInput<CircuitField: PrimeField + CanonicalSerialize> {
     fn public_input(&self) -> Vec<CircuitField> {

--- a/relations/src/serialization.rs
+++ b/relations/src/serialization.rs
@@ -1,4 +1,5 @@
 use ark_serialize::CanonicalSerialize;
+use ark_std::{vec, vec::Vec};
 
 pub fn serialize<T: CanonicalSerialize>(t: &T) -> Vec<u8> {
     let mut bytes = vec![0; t.serialized_size()];

--- a/relations/src/shielder/deposit.rs
+++ b/relations/src/shielder/deposit.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use ark_ff::BigInteger256;
 use ark_r1cs_std::alloc::AllocVar;
 use ark_relations::{
@@ -9,6 +7,7 @@ use ark_relations::{
         SynthesisError::AssignmentMissing,
     },
 };
+use ark_std::{marker::PhantomData, vec, vec::Vec};
 
 use super::{
     note::check_note,

--- a/relations/src/shielder/note.rs
+++ b/relations/src/shielder/note.rs
@@ -3,6 +3,7 @@
 use ark_ff::{BigInteger, BigInteger256};
 use ark_r1cs_std::{eq::EqGadget, ToBytesGadget};
 use ark_relations::r1cs::SynthesisError;
+use ark_std::{vec, vec::Vec};
 
 use super::{
     tangle::{tangle, tangle_in_field},

--- a/relations/src/shielder/tangle.rs
+++ b/relations/src/shielder/tangle.rs
@@ -21,6 +21,7 @@
 
 use ark_r1cs_std::R1CSVar;
 use ark_relations::r1cs::SynthesisError;
+use ark_std::vec::Vec;
 
 use super::types::ByteVar;
 

--- a/relations/src/shielder/types.rs
+++ b/relations/src/shielder/types.rs
@@ -1,5 +1,7 @@
 // use super::CircuitField;
 
+use ark_std::vec::Vec;
+
 use crate::environment::CircuitField;
 
 /// The circuit lifting for `CircuitField`.

--- a/relations/src/shielder/withdraw.rs
+++ b/relations/src/shielder/withdraw.rs
@@ -1,7 +1,4 @@
-use std::{
-    marker::PhantomData,
-    ops::{Add, Div},
-};
+use core::ops::{Add, Div};
 
 use ark_ff::{BigInteger, BigInteger256, Zero};
 use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::FieldVar, R1CSVar, ToBytesGadget};
@@ -12,6 +9,7 @@ use ark_relations::{
         SynthesisError::{AssignmentMissing, UnconstrainedVariable},
     },
 };
+use ark_std::{marker::PhantomData, vec, vec::Vec};
 
 use super::{
     note::check_note,

--- a/relations/src/utils.rs
+++ b/relations/src/utils.rs
@@ -1,4 +1,5 @@
 use ark_ff::{One, Zero};
+use ark_std::{string::String, vec::Vec};
 
 /// Convert `u8` into an 8-tuple of bits over `F` (little endian).
 pub fn byte_to_bits<F: Zero + One + Copy>(byte: u8) -> [F; 8] {

--- a/relations/src/xor.rs
+++ b/relations/src/xor.rs
@@ -1,10 +1,9 @@
-use std::marker::PhantomData;
-
 use ark_ff::PrimeField;
 use ark_r1cs_std::prelude::{AllocVar, EqGadget, UInt8};
 use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystemRef, SynthesisError, SynthesisError::AssignmentMissing,
 };
+use ark_std::{marker::PhantomData, vec::Vec};
 
 use crate::{
     byte_to_bits,


### PR DESCRIPTION
Enable using `relations` crate in `no-std` environment (like contract).

These two commands should succeed now:
```sh
cargo build
cargo build --no-default-features
```