### PR TITLE
Remove `pub(crate)` from `aleph-client`

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aleph_client"
 # TODO bump major version when API stablize
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 license = "Apache 2.0"
 

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -34,11 +34,13 @@ pub struct RootConnection {
     connection: SignedConnection,
 }
 
-pub(crate) trait AsConnection {
+/// Castability to a plain connection.
+pub trait AsConnection {
     fn as_connection(&self) -> &Connection;
 }
 
-pub(crate) trait AsSigned {
+/// Castability to a signed connection.
+pub trait AsSigned {
     fn as_signed(&self) -> &SignedConnection;
 }
 
@@ -337,7 +339,8 @@ impl Connection {
         }
     }
 
-    pub(crate) fn as_client(&self) -> &SubxtClient {
+    /// Casts self to the underlying RPC client.
+    pub fn as_client(&self) -> &SubxtClient {
         &self.client
     }
 }

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -339,7 +339,8 @@ impl Connection {
         }
     }
 
-    pub(super) fn as_client(&self) -> &SubxtClient {
+    /// Casts self to the underlying RPC client.
+    pub fn as_client(&self) -> &SubxtClient {
         &self.client
     }
 }

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -339,8 +339,7 @@ impl Connection {
         }
     }
 
-    /// Casts self to the underlying RPC client.
-    pub fn as_client(&self) -> &SubxtClient {
+    pub(super) fn as_client(&self) -> &SubxtClient {
         &self.client
     }
 }

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -52,8 +52,7 @@ pub type Client = OnlineClient<AlephConfig>;
 /// An alias for a hash type.
 pub type BlockHash = H256;
 
-/// An alias for an RPC client type.
-pub type SubxtClient = OnlineClient<AlephConfig>;
+type SubxtClient = OnlineClient<AlephConfig>;
 
 pub use connections::{
     Connection, ConnectionApi, RootConnection, SignedConnection, SignedConnectionApi, SudoCall,

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -52,7 +52,8 @@ pub type Client = OnlineClient<AlephConfig>;
 /// An alias for a hash type.
 pub type BlockHash = H256;
 
-pub(crate) type SubxtClient = OnlineClient<AlephConfig>;
+/// An alias for an RPC client type.
+pub type SubxtClient = OnlineClient<AlephConfig>;
 
 pub use connections::{
     Connection, ConnectionApi, RootConnection, SignedConnection, SignedConnectionApi, SudoCall,

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -52,7 +52,8 @@ pub type Client = OnlineClient<AlephConfig>;
 /// An alias for a hash type.
 pub type BlockHash = H256;
 
-type SubxtClient = OnlineClient<AlephConfig>;
+/// An alias for an RPC client type.
+pub type SubxtClient = OnlineClient<AlephConfig>;
 
 pub use connections::{
     Connection, ConnectionApi, RootConnection, SignedConnection, SignedConnectionApi, SudoCall,

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Adhere to the ADR (https://www.notion.so/cardinalcryptography/Module-based-access-in-our-codebase-2f0f0d6421c841ed889858b971850cb6). Moreover, enables downcasting connections outside (e.g. in `traffic-maker`)