### PR TITLE
A0-1540: Verification error

### DIFF
--- a/bin/runtime/src/chain_extension/mod.rs
+++ b/bin/runtime/src/chain_extension/mod.rs
@@ -193,7 +193,7 @@ impl SnarcosChainExtension {
                 DeserializingPublicInputFailed => SNARCOS_VERIFY_DESERIALIZING_INPUT_FAIL,
                 UnknownVerificationKeyIdentifier => SNARCOS_VERIFY_UNKNOWN_IDENTIFIER,
                 DeserializingVerificationKeyFailed => SNARCOS_VERIFY_DESERIALIZING_KEY_FAIL,
-                VerificationFailed => SNARCOS_VERIFY_VERIFICATION_FAIL,
+                VerificationFailed(_) => SNARCOS_VERIFY_VERIFICATION_FAIL,
                 IncorrectProof => SNARCOS_VERIFY_INCORRECT_PROOF,
                 _ => SNARCOS_VERIFY_ERROR_UNKNOWN,
             },

--- a/bin/runtime/src/chain_extension/tests/mod.rs
+++ b/bin/runtime/src/chain_extension/tests/mod.rs
@@ -2,6 +2,7 @@ use core::iter::Sum;
 use std::{ops::Neg, sync::mpsc::Receiver};
 
 use environment::{CorruptedMode, MockedEnvironment, StandardMode, StoreKeyMode, VerifyMode};
+use pallet_snarcos::VerificationError;
 
 use super::*;
 use crate::chain_extension::tests::executor::{
@@ -214,7 +215,7 @@ fn verify__pallet_says_vk_deserialization_failed() {
 #[allow(non_snake_case)]
 fn verify__pallet_says_verification_failed() {
     simulate_verify::<
-        VerifyErrorer<{ VerificationFailed }, { None }>,
+        VerifyErrorer<{ VerificationFailed(VerificationError::MalformedVerifyingKey) }, { None }>,
         { None },
         SNARCOS_VERIFY_VERIFICATION_FAIL,
     >()

--- a/pallets/snarcos/src/lib.rs
+++ b/pallets/snarcos/src/lib.rs
@@ -10,7 +10,7 @@ mod weights;
 use frame_support::pallet_prelude::StorageVersion;
 use frame_system::ensure_root;
 pub use pallet::*;
-pub use systems::ProvingSystem;
+pub use systems::{ProvingSystem, VerificationError};
 pub use weights::{AlephWeight, WeightInfo};
 
 /// The current storage version.

--- a/pallets/snarcos/src/lib.rs
+++ b/pallets/snarcos/src/lib.rs
@@ -29,7 +29,7 @@ pub mod pallet {
     use sp_std::prelude::Vec;
 
     use super::*;
-    use crate::systems::{Gm17, Groth16, Marlin, VerifyingSystem};
+    use crate::systems::{Gm17, Groth16, Marlin, VerificationError, VerifyingSystem};
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -67,7 +67,7 @@ pub mod pallet {
         /// Couldn't deserialize verification key from storage.
         DeserializingVerificationKeyFailed,
         /// Verification procedure has failed. Proof still can be correct.
-        VerificationFailed,
+        VerificationFailed(VerificationError),
         /// Proof has been found as incorrect.
         IncorrectProof,
     }
@@ -303,9 +303,8 @@ pub mod pallet {
                     )
                 })?;
 
-            // At some point we should enhance error type from `S::verify` and be more verbose here.
             let valid_proof = S::verify(&verification_key, &public_input, &proof)
-                .map_err(|_| (Error::<T>::VerificationFailed, None))?;
+                .map_err(|err| (Error::<T>::VerificationFailed(err), None))?;
 
             ensure!(valid_proof, (Error::<T>::IncorrectProof, None));
 

--- a/pallets/snarcos/src/systems.rs
+++ b/pallets/snarcos/src/systems.rs
@@ -1,11 +1,63 @@
 use ark_poly::polynomial::univariate::DensePolynomial;
 use ark_poly_commit::marlin_pc::MarlinKZG10;
+use ark_relations::r1cs::SynthesisError;
 use ark_serialize::CanonicalDeserialize;
 use ark_snark::SNARK;
 use ark_std::rand::{prelude::StdRng, SeedableRng};
 use blake2::Blake2s;
 use codec::{Decode, Encode};
+use frame_support::log::{error, info};
 use scale_info::TypeInfo;
+
+/// Possible errors from the verification process.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Decode, Encode, TypeInfo)]
+pub enum VerificationError {
+    /// The verifying key was malformed.
+    ///
+    /// May occur only for some non-universal system.
+    MalformedVerifyingKey,
+    /// There was an error in the underlying holographic IOP. For details, consult your logs.
+    ///
+    /// May occur only for some universal system.
+    AHPError,
+    /// There was an error in the underlying polynomial commitment. For details, consult your logs.
+    ///
+    /// May occur only for some universal system.
+    PolynomialCommitmentError,
+    /// Unexpected error has occurred. Check your logs.
+    UnexpectedError,
+}
+
+impl From<SynthesisError> for VerificationError {
+    fn from(syn_err: SynthesisError) -> Self {
+        match syn_err {
+            SynthesisError::MalformedVerifyingKey => VerificationError::MalformedVerifyingKey,
+            _ => {
+                error!("Unexpected SynthesisError variant: {syn_err}");
+                VerificationError::UnexpectedError
+            }
+        }
+    }
+}
+
+impl From<ark_marlin::Error<ark_poly_commit::Error>> for VerificationError {
+    fn from(err: ark_marlin::Error<ark_poly_commit::Error>) -> Self {
+        match err {
+            ark_marlin::Error::AHPError(err) => {
+                info!("Encountered AHP error: {err:?}");
+                VerificationError::AHPError
+            }
+            ark_marlin::Error::PolynomialCommitmentError(err) => {
+                info!("Encountered polynomial commitment error: {err:?}");
+                VerificationError::PolynomialCommitmentError
+            }
+            _ => {
+                error!("Unexpected Marlin error variant: {err:?}");
+                VerificationError::UnexpectedError
+            }
+        }
+    }
+}
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Decode, Encode, TypeInfo)]
 pub enum ProvingSystem {
@@ -23,7 +75,7 @@ pub(super) trait VerifyingSystem {
         key: &Self::VerifyingKey,
         input: &[Self::CircuitField],
         proof: &Self::Proof,
-    ) -> Result<bool, ()>;
+    ) -> Result<bool, VerificationError>;
 }
 
 /// Common pairing engine.
@@ -41,8 +93,8 @@ impl VerifyingSystem for Groth16 {
         key: &Self::VerifyingKey,
         input: &[Self::CircuitField],
         proof: &Self::Proof,
-    ) -> Result<bool, ()> {
-        ark_groth16::Groth16::verify(key, input, proof).map_err(|_| ())
+    ) -> Result<bool, VerificationError> {
+        ark_groth16::Groth16::verify(key, input, proof).map_err(Into::into)
     }
 }
 
@@ -56,8 +108,8 @@ impl VerifyingSystem for Gm17 {
         key: &Self::VerifyingKey,
         input: &[Self::CircuitField],
         proof: &Self::Proof,
-    ) -> Result<bool, ()> {
-        ark_gm17::GM17::verify(key, input, proof).map_err(|_| ())
+    ) -> Result<bool, VerificationError> {
+        ark_gm17::GM17::verify(key, input, proof).map_err(Into::into)
     }
 }
 
@@ -75,8 +127,8 @@ impl VerifyingSystem for Marlin {
         key: &Self::VerifyingKey,
         input: &[Self::CircuitField],
         proof: &Self::Proof,
-    ) -> Result<bool, ()> {
+    ) -> Result<bool, VerificationError> {
         let mut rng = StdRng::from_seed([0u8; 32]);
-        ark_marlin::Marlin::<_, _, Blake2s>::verify(key, input, proof, &mut rng).map_err(|_| ())
+        ark_marlin::Marlin::<_, _, Blake2s>::verify(key, input, proof, &mut rng).map_err(Into::into)
     }
 }

--- a/pallets/snarcos/src/systems.rs
+++ b/pallets/snarcos/src/systems.rs
@@ -6,11 +6,14 @@ use ark_snark::SNARK;
 use ark_std::rand::{prelude::StdRng, SeedableRng};
 use blake2::Blake2s;
 use codec::{Decode, Encode};
-use frame_support::log::{error, info};
+use frame_support::{
+    log::{error, info},
+    PalletError,
+};
 use scale_info::TypeInfo;
 
 /// Possible errors from the verification process.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Decode, Encode, TypeInfo)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Decode, Encode, TypeInfo, PalletError)]
 pub enum VerificationError {
     /// The verifying key was malformed.
     ///

--- a/pallets/snarcos/src/tests/suite.rs
+++ b/pallets/snarcos/src/tests/suite.rs
@@ -3,7 +3,7 @@ use frame_system::{pallet_prelude::OriginFor, Config};
 use sp_runtime::traits::Get;
 
 use super::setup::*;
-use crate::{Error, ProvingSystem, VerificationKeyIdentifier, VerificationKeys};
+use crate::{Error, ProvingSystem, VerificationError, VerificationKeyIdentifier, VerificationKeys};
 
 type Snarcos = crate::Pallet<TestRuntime>;
 
@@ -221,7 +221,10 @@ fn verify_shouts_when_verification_fails() {
 
         let result = Snarcos::verify(caller(), IDENTIFIER, proof(), other_input.to_vec(), SYSTEM);
 
-        assert_err!(result, Error::<TestRuntime>::VerificationFailed);
+        assert_err!(
+            result,
+            Error::<TestRuntime>::VerificationFailed(VerificationError::MalformedVerifyingKey)
+        );
         assert!(result.unwrap_err().post_info.actual_weight.is_none());
     });
 }


### PR DESCRIPTION
This PR introduces error enum for the verification process in pallet `snarcos`. It covers possible errors from `verify(..)` methods in `Groth16`, `GM17` and `Marlin` implementations from `arkworks`, i.e. 
 - `SynthesisError` (for the former two) - here we have only two variants: `MalformedVerifyingKey` and `UnexpectedError`. The first one is just extraction of its counterpart in `SynthesisError`. The second one covers all other variants - they are dedicated for constraint synthesis or proof generation phases.
 - `ark_marlin::Error<ark_poly_commit::Error>` (for the latter one) - here we unpack the `ark_marlin::Error` enum to either `AHPError` or `PolynomialCommitmentError`. In case `IndexTooLarge` happened, we fall back to `UnexpectedError` (this should never happen during verification process)

All the new variants are flat, i.e. they do not contain inner errors. This is because arkworks' errors don't implement basic traits and thus cannot be used in the runtime.