### PR TITLE
A0-1821: add substrate specific finalizer for sync protocol

### DIFF
--- a/finality-aleph/src/sync/substrate/finalizer.rs
+++ b/finality-aleph/src/sync/substrate/finalizer.rs
@@ -1,0 +1,31 @@
+use aleph_primitives::{BlockNumber, ALEPH_ENGINE_ID};
+use sc_client_api::{Backend, Finalizer as SubstrateFinalizer, HeaderBackend, LockImportRun};
+use sp_blockchain::Error as ClientError;
+use sp_runtime::traits::{Block as BlockT, Header as SubstrateHeader};
+
+use crate::{
+    finalization::{AlephFinalizer, BlockFinalizer},
+    justification::versioned_encode,
+    sync::{substrate::Justification, Finalizer},
+};
+
+impl<B, BE, C> Finalizer<Justification<B::Header>> for AlephFinalizer<B, BE, C>
+where
+    B: BlockT,
+    B::Header: SubstrateHeader<Number = BlockNumber>,
+    BE: Backend<B>,
+    C: HeaderBackend<B> + LockImportRun<B, BE> + SubstrateFinalizer<B, BE>,
+{
+    type Error = ClientError;
+
+    fn finalize(&self, justification: Justification<B::Header>) -> Result<(), Self::Error> {
+        self.finalize_block(
+            justification.header.hash(),
+            *justification.header.number(),
+            Some((
+                ALEPH_ENGINE_ID,
+                versioned_encode(justification.raw_justification),
+            )),
+        )
+    }
+}

--- a/finality-aleph/src/sync/substrate/mod.rs
+++ b/finality-aleph/src/sync/substrate/mod.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 mod chain_status;
+mod finalizer;
 mod status_notifier;
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
# Description
Implement substrate specific finalizer for sync protocol. Original `BlockFinalizer` trait and logic for JustificationHandler will most likely be removed in the future and replaced by new Justification Sync protocol.

## Type of change
- New feature (not yet used)