### PR TITLE
`aleph-client`: Get tx events

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aleph_client"
 # TODO bump major version when API stablize
-version = "2.7.0"
+version = "2.8.0"
 edition = "2021"
 license = "Apache 2.0"
 

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -109,7 +109,7 @@ pub trait ConnectionApi: Sync {
 }
 
 /// Data regarding submitted transaction.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct TxInfo {
     pub block_hash: BlockHash,
     pub tx_hash: TxHash,
@@ -313,8 +313,13 @@ impl<S: AsSigned + Sync> SignedConnectionApi for S {
                 .await?
                 .into(),
             TxStatus::Finalized => progress.wait_for_finalized_success().await?.into(),
-            // In case of Submitted coords do not mean anything
-            TxStatus::Submitted => return Ok(Default::default()),
+            // In case of Submitted block hash do not mean anything
+            TxStatus::Submitted => {
+                return Ok(TxInfo {
+                    block_hash: Default::default(),
+                    tx_hash: progress.extrinsic_hash(),
+                })
+            }
         };
         info!(target: "aleph-client", "tx with hash {} included in block {}", info.tx_hash, info.block_hash);
 

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -313,7 +313,7 @@ impl<S: AsSigned + Sync> SignedConnectionApi for S {
                 .await?
                 .into(),
             TxStatus::Finalized => progress.wait_for_finalized_success().await?.into(),
-            // In case of Submitted block hash do not mean anything
+            // In case of Submitted block hash does not mean anything
             TxStatus::Submitted => {
                 return Ok(TxInfo {
                     block_hash: Default::default(),

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -3,9 +3,7 @@ use std::{thread::sleep, time::Duration};
 use anyhow::anyhow;
 use codec::Decode;
 use log::info;
-use serde::{Deserialize, Serialize};
 use subxt::{
-    blocks::ExtrinsicEvents,
     ext::sp_core::Bytes,
     metadata::DecodeWithMetadata,
     rpc::RpcParams,
@@ -15,8 +13,8 @@ use subxt::{
 };
 
 use crate::{
-    api, sp_weights::weight_v2::Weight, AccountId, AlephConfig, BlockHash, Call, KeyPair,
-    SubxtClient, TxHash, TxStatus,
+    api, sp_weights::weight_v2::Weight, AccountId, BlockHash, Call, KeyPair, SubxtClient, TxInfo,
+    TxStatus,
 };
 
 /// Capable of communicating with a live Aleph chain.
@@ -106,22 +104,6 @@ pub trait ConnectionApi: Sync {
     /// rpc_call("state_call".to_string(), params).await;
     /// ```
     async fn rpc_call<R: Decode>(&self, func_name: String, params: RpcParams) -> anyhow::Result<R>;
-}
-
-/// Data regarding submitted transaction.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct TxInfo {
-    pub block_hash: BlockHash,
-    pub tx_hash: TxHash,
-}
-
-impl From<ExtrinsicEvents<AlephConfig>> for TxInfo {
-    fn from(ee: ExtrinsicEvents<AlephConfig>) -> Self {
-        Self {
-            block_hash: ee.extrinsic_hash(),
-            tx_hash: ee.block_hash(),
-        }
-    }
 }
 
 /// Signed connection should be able to sends transactions to chain

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -118,8 +118,8 @@ pub struct TxInfo {
 impl From<ExtrinsicEvents<AlephConfig>> for TxInfo {
     fn from(ee: ExtrinsicEvents<AlephConfig>) -> Self {
         Self {
-            block_hash: ee.extrinsic_hash(),
-            tx_hash: ee.block_hash(),
+            block_hash: ee.block_hash(),
+            tx_hash: ee.extrinsic_hash(),
         }
     }
 }
@@ -321,7 +321,7 @@ impl<S: AsSigned + Sync> SignedConnectionApi for S {
                 })
             }
         };
-        info!(target: "aleph-client", "tx with hash {} included in block {}", info.tx_hash, info.block_hash);
+        info!(target: "aleph-client", "tx with hash {:?} included in block {:?}", info.tx_hash, info.block_hash);
 
         Ok(info)
     }

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -305,7 +305,7 @@ impl<S: AsSigned + Sync> SignedConnectionApi for S {
             .await
             .map_err(|e| anyhow!("Failed to submit transaction: {:?}", e))?;
 
-        let coords: TxInfo = match status {
+        let info: TxInfo = match status {
             TxStatus::InBlock => progress
                 .wait_for_in_block()
                 .await?
@@ -316,9 +316,9 @@ impl<S: AsSigned + Sync> SignedConnectionApi for S {
             // In case of Submitted coords do not mean anything
             TxStatus::Submitted => return Ok(Default::default()),
         };
-        info!(target: "aleph-client", "tx with hash {} included in block {}", coords.tx_hash, coords.block_hash);
+        info!(target: "aleph-client", "tx with hash {} included in block {}", info.tx_hash, info.block_hash);
 
-        Ok(coords)
+        Ok(info)
     }
 
     fn account_id(&self) -> &AccountId {

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -3,7 +3,9 @@ use std::{thread::sleep, time::Duration};
 use anyhow::anyhow;
 use codec::Decode;
 use log::info;
+use serde::{Deserialize, Serialize};
 use subxt::{
+    blocks::ExtrinsicEvents,
     ext::sp_core::Bytes,
     metadata::DecodeWithMetadata,
     rpc::RpcParams,
@@ -13,8 +15,8 @@ use subxt::{
 };
 
 use crate::{
-    api, sp_weights::weight_v2::Weight, AccountId, BlockHash, Call, KeyPair, SubxtClient, TxInfo,
-    TxStatus,
+    api, sp_weights::weight_v2::Weight, AccountId, AlephConfig, BlockHash, Call, KeyPair,
+    SubxtClient, TxHash, TxStatus,
 };
 
 /// Capable of communicating with a live Aleph chain.
@@ -104,6 +106,22 @@ pub trait ConnectionApi: Sync {
     /// rpc_call("state_call".to_string(), params).await;
     /// ```
     async fn rpc_call<R: Decode>(&self, func_name: String, params: RpcParams) -> anyhow::Result<R>;
+}
+
+/// Data regarding submitted transaction.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct TxInfo {
+    pub block_hash: BlockHash,
+    pub tx_hash: TxHash,
+}
+
+impl From<ExtrinsicEvents<AlephConfig>> for TxInfo {
+    fn from(ee: ExtrinsicEvents<AlephConfig>) -> Self {
+        Self {
+            block_hash: ee.extrinsic_hash(),
+            tx_hash: ee.block_hash(),
+        }
+    }
 }
 
 /// Signed connection should be able to sends transactions to chain

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -13,7 +13,7 @@
 extern crate core;
 
 pub use contract_transcode;
-pub use subxt::ext::sp_core::Pair;
+pub use subxt::{blocks::ExtrinsicEvents, ext::sp_core::Pair};
 use subxt::{
     ext::sp_core::{ed25519, sr25519, H256},
     tx::PairSigner,

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -49,8 +49,10 @@ pub type KeyPair = PairSigner<AlephConfig, sr25519::Pair>;
 pub type AccountId = subxt::ext::sp_core::crypto::AccountId32;
 /// An alias for a client type.
 pub type Client = OnlineClient<AlephConfig>;
-/// An alias for a hash type.
+/// An alias for a block hash type.
 pub type BlockHash = H256;
+/// An alias for a transaction hash type.
+pub type TxHash = H256;
 
 /// An alias for an RPC client type.
 pub type SubxtClient = OnlineClient<AlephConfig>;

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -13,8 +13,10 @@
 extern crate core;
 
 pub use contract_transcode;
+use serde::{Deserialize, Serialize};
 pub use subxt::ext::sp_core::Pair;
 use subxt::{
+    blocks::ExtrinsicEvents,
     ext::sp_core::{ed25519, sr25519, H256},
     tx::PairSigner,
     OnlineClient, PolkadotConfig,
@@ -99,4 +101,22 @@ where
     AccountId: From<<P as Pair>::Public>,
 {
     AccountId::from(keypair.public())
+}
+
+/// Data regarding submitted transaction.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Deserialize, Serialize)]
+pub struct TxInfo {
+    /// Hash of the block that contains the transaction.
+    pub block_hash: BlockHash,
+    /// The hash of the transaction.
+    pub tx_hash: TxHash,
+}
+
+impl From<ExtrinsicEvents<AlephConfig>> for TxInfo {
+    fn from(ee: ExtrinsicEvents<AlephConfig>) -> Self {
+        Self {
+            block_hash: ee.extrinsic_hash(),
+            tx_hash: ee.block_hash(),
+        }
+    }
 }

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -13,10 +13,8 @@
 extern crate core;
 
 pub use contract_transcode;
-use serde::{Deserialize, Serialize};
 pub use subxt::ext::sp_core::Pair;
 use subxt::{
-    blocks::ExtrinsicEvents,
     ext::sp_core::{ed25519, sr25519, H256},
     tx::PairSigner,
     OnlineClient, PolkadotConfig,
@@ -101,22 +99,4 @@ where
     AccountId: From<<P as Pair>::Public>,
 {
     AccountId::from(keypair.public())
-}
-
-/// Data regarding submitted transaction.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Deserialize, Serialize)]
-pub struct TxInfo {
-    /// Hash of the block that contains the transaction.
-    pub block_hash: BlockHash,
-    /// The hash of the transaction.
-    pub tx_hash: TxHash,
-}
-
-impl From<ExtrinsicEvents<AlephConfig>> for TxInfo {
-    fn from(ee: ExtrinsicEvents<AlephConfig>) -> Self {
-        Self {
-            block_hash: ee.extrinsic_hash(),
-            tx_hash: ee.block_hash(),
-        }
-    }
 }

--- a/aleph-client/src/pallets/aleph.rs
+++ b/aleph-client/src/pallets/aleph.rs
@@ -7,11 +7,10 @@ use crate::{
         pallet_aleph::pallet::Call::set_emergency_finalizer, primitives::app::Public,
         sp_core::ed25519::Public as EdPublic,
     },
-    connections::TxInfo,
     pallet_aleph::pallet::Call::schedule_finality_version_change,
     AccountId, AlephKeyPair, BlockHash,
     Call::Aleph,
-    ConnectionApi, Pair, RootConnection, SudoCall, TxStatus,
+    ConnectionApi, Pair, RootConnection, SudoCall, TxInfo, TxStatus,
 };
 
 // TODO replace docs with link to pallet aleph docs, once they are published

--- a/aleph-client/src/pallets/aleph.rs
+++ b/aleph-client/src/pallets/aleph.rs
@@ -7,10 +7,11 @@ use crate::{
         pallet_aleph::pallet::Call::set_emergency_finalizer, primitives::app::Public,
         sp_core::ed25519::Public as EdPublic,
     },
+    connections::TxInfo,
     pallet_aleph::pallet::Call::schedule_finality_version_change,
     AccountId, AlephKeyPair, BlockHash,
     Call::Aleph,
-    ConnectionApi, Pair, RootConnection, SudoCall, TxInfo, TxStatus,
+    ConnectionApi, Pair, RootConnection, SudoCall, TxStatus,
 };
 
 // TODO replace docs with link to pallet aleph docs, once they are published

--- a/aleph-client/src/pallets/aleph.rs
+++ b/aleph-client/src/pallets/aleph.rs
@@ -7,7 +7,7 @@ use crate::{
         pallet_aleph::pallet::Call::set_emergency_finalizer, primitives::app::Public,
         sp_core::ed25519::Public as EdPublic,
     },
-    connections::TxCoords,
+    connections::TxInfo,
     pallet_aleph::pallet::Call::schedule_finality_version_change,
     AccountId, AlephKeyPair, BlockHash,
     Call::Aleph,
@@ -27,7 +27,7 @@ pub trait AlephSudoApi {
         &self,
         finalizer: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// Schedules a finality version change for a future session.
     /// * `version` - next version of the finalizer
@@ -40,7 +40,7 @@ pub trait AlephSudoApi {
         version: u32,
         session: SessionIndex,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 }
 
 /// Pallet aleph RPC api.
@@ -63,7 +63,7 @@ impl AlephSudoApi for RootConnection {
         &self,
         finalizer: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let call = Aleph(set_emergency_finalizer {
             emergency_finalizer: Public(EdPublic(finalizer.into())),
         });
@@ -75,7 +75,7 @@ impl AlephSudoApi for RootConnection {
         version: u32,
         session: SessionIndex,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let call = Aleph(schedule_finality_version_change {
             version_incoming: version,
             session,

--- a/aleph-client/src/pallets/aleph.rs
+++ b/aleph-client/src/pallets/aleph.rs
@@ -7,6 +7,7 @@ use crate::{
         pallet_aleph::pallet::Call::set_emergency_finalizer, primitives::app::Public,
         sp_core::ed25519::Public as EdPublic,
     },
+    connections::TxCoords,
     pallet_aleph::pallet::Call::schedule_finality_version_change,
     AccountId, AlephKeyPair, BlockHash,
     Call::Aleph,
@@ -26,7 +27,7 @@ pub trait AlephSudoApi {
         &self,
         finalizer: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// Schedules a finality version change for a future session.
     /// * `version` - next version of the finalizer
@@ -39,7 +40,7 @@ pub trait AlephSudoApi {
         version: u32,
         session: SessionIndex,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 }
 
 /// Pallet aleph RPC api.
@@ -62,7 +63,7 @@ impl AlephSudoApi for RootConnection {
         &self,
         finalizer: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let call = Aleph(set_emergency_finalizer {
             emergency_finalizer: Public(EdPublic(finalizer.into())),
         });
@@ -74,7 +75,7 @@ impl AlephSudoApi for RootConnection {
         version: u32,
         session: SessionIndex,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let call = Aleph(schedule_finality_version_change {
             version_incoming: version,
             session,

--- a/aleph-client/src/pallets/balances.rs
+++ b/aleph-client/src/pallets/balances.rs
@@ -3,7 +3,7 @@ use subxt::{ext::sp_runtime::MultiAddress, tx::PolkadotExtrinsicParamsBuilder};
 
 use crate::{
     aleph_zero::{self, api, api::runtime_types::pallet_balances::BalanceLock},
-    connections::TxCoords,
+    connections::TxInfo,
     pallet_balances::pallet::Call::transfer,
     pallets::utility::UtilityApi,
     AccountId, BlockHash,
@@ -45,7 +45,7 @@ pub trait BalanceUserApi {
         dest: AccountId,
         amount: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`transfer`](https://paritytech.github.io/substrate/master/pallet_balances/pallet/struct.Pallet.html#method.transfer) call.
     /// Include tip in the tx.
@@ -55,7 +55,7 @@ pub trait BalanceUserApi {
         amount: Balance,
         tip: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 }
 
 /// Pallet balances logic not directly related to any pallet call.
@@ -80,7 +80,7 @@ pub trait BalanceUserBatchExtApi {
         dest: &[AccountId],
         amount: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 }
 
 #[async_trait::async_trait]
@@ -123,7 +123,7 @@ impl<S: SignedConnectionApi> BalanceUserApi for S {
         dest: AccountId,
         amount: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx()
             .balances()
             .transfer(MultiAddress::Id(dest), amount);
@@ -136,7 +136,7 @@ impl<S: SignedConnectionApi> BalanceUserApi for S {
         amount: Balance,
         tip: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx()
             .balances()
             .transfer(MultiAddress::Id(dest), amount);
@@ -153,7 +153,7 @@ impl<S: SignedConnectionApi> BalanceUserBatchExtApi for S {
         dests: &[AccountId],
         amount: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let calls = dests
             .iter()
             .map(|dest| {

--- a/aleph-client/src/pallets/balances.rs
+++ b/aleph-client/src/pallets/balances.rs
@@ -3,12 +3,11 @@ use subxt::{ext::sp_runtime::MultiAddress, tx::PolkadotExtrinsicParamsBuilder};
 
 use crate::{
     aleph_zero::{self, api, api::runtime_types::pallet_balances::BalanceLock},
-    connections::TxInfo,
     pallet_balances::pallet::Call::transfer,
     pallets::utility::UtilityApi,
     AccountId, BlockHash,
     Call::Balances,
-    ConnectionApi, SignedConnectionApi, TxStatus,
+    ConnectionApi, SignedConnectionApi, TxInfo, TxStatus,
 };
 
 /// Pallet balances read-only API.

--- a/aleph-client/src/pallets/balances.rs
+++ b/aleph-client/src/pallets/balances.rs
@@ -3,11 +3,12 @@ use subxt::{ext::sp_runtime::MultiAddress, tx::PolkadotExtrinsicParamsBuilder};
 
 use crate::{
     aleph_zero::{self, api, api::runtime_types::pallet_balances::BalanceLock},
+    connections::TxInfo,
     pallet_balances::pallet::Call::transfer,
     pallets::utility::UtilityApi,
     AccountId, BlockHash,
     Call::Balances,
-    ConnectionApi, SignedConnectionApi, TxInfo, TxStatus,
+    ConnectionApi, SignedConnectionApi, TxStatus,
 };
 
 /// Pallet balances read-only API.

--- a/aleph-client/src/pallets/balances.rs
+++ b/aleph-client/src/pallets/balances.rs
@@ -3,6 +3,7 @@ use subxt::{ext::sp_runtime::MultiAddress, tx::PolkadotExtrinsicParamsBuilder};
 
 use crate::{
     aleph_zero::{self, api, api::runtime_types::pallet_balances::BalanceLock},
+    connections::TxCoords,
     pallet_balances::pallet::Call::transfer,
     pallets::utility::UtilityApi,
     AccountId, BlockHash,
@@ -44,7 +45,7 @@ pub trait BalanceUserApi {
         dest: AccountId,
         amount: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`transfer`](https://paritytech.github.io/substrate/master/pallet_balances/pallet/struct.Pallet.html#method.transfer) call.
     /// Include tip in the tx.
@@ -54,7 +55,7 @@ pub trait BalanceUserApi {
         amount: Balance,
         tip: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 }
 
 /// Pallet balances logic not directly related to any pallet call.
@@ -79,7 +80,7 @@ pub trait BalanceUserBatchExtApi {
         dest: &[AccountId],
         amount: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 }
 
 #[async_trait::async_trait]
@@ -122,7 +123,7 @@ impl<S: SignedConnectionApi> BalanceUserApi for S {
         dest: AccountId,
         amount: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx()
             .balances()
             .transfer(MultiAddress::Id(dest), amount);
@@ -135,7 +136,7 @@ impl<S: SignedConnectionApi> BalanceUserApi for S {
         amount: Balance,
         tip: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx()
             .balances()
             .transfer(MultiAddress::Id(dest), amount);
@@ -152,7 +153,7 @@ impl<S: SignedConnectionApi> BalanceUserBatchExtApi for S {
         dests: &[AccountId],
         amount: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let calls = dests
             .iter()
             .map(|dest| {

--- a/aleph-client/src/pallets/contract.rs
+++ b/aleph-client/src/pallets/contract.rs
@@ -4,8 +4,8 @@ use primitives::Balance;
 use subxt::{ext::sp_core::Bytes, rpc_params};
 
 use crate::{
-    api, pallet_contracts::wasm::OwnerInfo, sp_weights::weight_v2::Weight, AccountId, BlockHash,
-    ConnectionApi, SignedConnectionApi, TxStatus,
+    api, connections::TxCoords, pallet_contracts::wasm::OwnerInfo, sp_weights::weight_v2::Weight,
+    AccountId, BlockHash, ConnectionApi, SignedConnectionApi, TxStatus,
 };
 
 /// Arguments to [`ContractRpc::call_and_get`].
@@ -47,7 +47,7 @@ pub trait ContractsUserApi {
         code: Vec<u8>,
         storage_limit: Option<Compact<u128>>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`instantiate`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.instantiate) call.
     #[allow(clippy::too_many_arguments)]
@@ -60,7 +60,7 @@ pub trait ContractsUserApi {
         data: Vec<u8>,
         salt: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`instantiate_with_code`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.instantiate_with_code) call.
     #[allow(clippy::too_many_arguments)]
@@ -73,7 +73,7 @@ pub trait ContractsUserApi {
         data: Vec<u8>,
         salt: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`call`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.call) call.
     async fn call(
@@ -84,14 +84,11 @@ pub trait ContractsUserApi {
         storage_limit: Option<Compact<u128>>,
         data: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`remove_code`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.remove_code) call.
-    async fn remove_code(
-        &self,
-        code_hash: BlockHash,
-        status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    async fn remove_code(&self, code_hash: BlockHash, status: TxStatus)
+        -> anyhow::Result<TxCoords>;
 }
 
 /// RPC for runtime ContractsApi
@@ -124,7 +121,7 @@ impl<S: SignedConnectionApi> ContractsUserApi for S {
         code: Vec<u8>,
         storage_limit: Option<Compact<u128>>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().contracts().upload_code(code, storage_limit);
 
         self.send_tx(tx, status).await
@@ -139,7 +136,7 @@ impl<S: SignedConnectionApi> ContractsUserApi for S {
         data: Vec<u8>,
         salt: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().contracts().instantiate(
             balance,
             gas_limit,
@@ -161,7 +158,7 @@ impl<S: SignedConnectionApi> ContractsUserApi for S {
         data: Vec<u8>,
         salt: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().contracts().instantiate_with_code(
             balance,
             gas_limit,
@@ -182,7 +179,7 @@ impl<S: SignedConnectionApi> ContractsUserApi for S {
         storage_limit: Option<Compact<u128>>,
         data: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx =
             api::tx()
                 .contracts()
@@ -194,7 +191,7 @@ impl<S: SignedConnectionApi> ContractsUserApi for S {
         &self,
         code_hash: BlockHash,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().contracts().remove_code(code_hash);
 
         self.send_tx(tx, status).await

--- a/aleph-client/src/pallets/contract.rs
+++ b/aleph-client/src/pallets/contract.rs
@@ -4,8 +4,8 @@ use primitives::Balance;
 use subxt::{ext::sp_core::Bytes, rpc_params};
 
 use crate::{
-    api, pallet_contracts::wasm::OwnerInfo, sp_weights::weight_v2::Weight, AccountId, BlockHash,
-    ConnectionApi, SignedConnectionApi, TxInfo, TxStatus,
+    api, connections::TxInfo, pallet_contracts::wasm::OwnerInfo, sp_weights::weight_v2::Weight,
+    AccountId, BlockHash, ConnectionApi, SignedConnectionApi, TxStatus,
 };
 
 /// Arguments to [`ContractRpc::call_and_get`].

--- a/aleph-client/src/pallets/contract.rs
+++ b/aleph-client/src/pallets/contract.rs
@@ -4,7 +4,7 @@ use primitives::Balance;
 use subxt::{ext::sp_core::Bytes, rpc_params};
 
 use crate::{
-    api, connections::TxCoords, pallet_contracts::wasm::OwnerInfo, sp_weights::weight_v2::Weight,
+    api, connections::TxInfo, pallet_contracts::wasm::OwnerInfo, sp_weights::weight_v2::Weight,
     AccountId, BlockHash, ConnectionApi, SignedConnectionApi, TxStatus,
 };
 
@@ -47,7 +47,7 @@ pub trait ContractsUserApi {
         code: Vec<u8>,
         storage_limit: Option<Compact<u128>>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`instantiate`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.instantiate) call.
     #[allow(clippy::too_many_arguments)]
@@ -60,7 +60,7 @@ pub trait ContractsUserApi {
         data: Vec<u8>,
         salt: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`instantiate_with_code`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.instantiate_with_code) call.
     #[allow(clippy::too_many_arguments)]
@@ -73,7 +73,7 @@ pub trait ContractsUserApi {
         data: Vec<u8>,
         salt: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`call`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.call) call.
     async fn call(
@@ -84,11 +84,10 @@ pub trait ContractsUserApi {
         storage_limit: Option<Compact<u128>>,
         data: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`remove_code`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.remove_code) call.
-    async fn remove_code(&self, code_hash: BlockHash, status: TxStatus)
-        -> anyhow::Result<TxCoords>;
+    async fn remove_code(&self, code_hash: BlockHash, status: TxStatus) -> anyhow::Result<TxInfo>;
 }
 
 /// RPC for runtime ContractsApi
@@ -121,7 +120,7 @@ impl<S: SignedConnectionApi> ContractsUserApi for S {
         code: Vec<u8>,
         storage_limit: Option<Compact<u128>>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx().contracts().upload_code(code, storage_limit);
 
         self.send_tx(tx, status).await
@@ -136,7 +135,7 @@ impl<S: SignedConnectionApi> ContractsUserApi for S {
         data: Vec<u8>,
         salt: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx().contracts().instantiate(
             balance,
             gas_limit,
@@ -158,7 +157,7 @@ impl<S: SignedConnectionApi> ContractsUserApi for S {
         data: Vec<u8>,
         salt: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx().contracts().instantiate_with_code(
             balance,
             gas_limit,
@@ -179,7 +178,7 @@ impl<S: SignedConnectionApi> ContractsUserApi for S {
         storage_limit: Option<Compact<u128>>,
         data: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx =
             api::tx()
                 .contracts()
@@ -187,11 +186,7 @@ impl<S: SignedConnectionApi> ContractsUserApi for S {
         self.send_tx(tx, status).await
     }
 
-    async fn remove_code(
-        &self,
-        code_hash: BlockHash,
-        status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    async fn remove_code(&self, code_hash: BlockHash, status: TxStatus) -> anyhow::Result<TxInfo> {
         let tx = api::tx().contracts().remove_code(code_hash);
 
         self.send_tx(tx, status).await

--- a/aleph-client/src/pallets/contract.rs
+++ b/aleph-client/src/pallets/contract.rs
@@ -4,8 +4,8 @@ use primitives::Balance;
 use subxt::{ext::sp_core::Bytes, rpc_params};
 
 use crate::{
-    api, connections::TxInfo, pallet_contracts::wasm::OwnerInfo, sp_weights::weight_v2::Weight,
-    AccountId, BlockHash, ConnectionApi, SignedConnectionApi, TxStatus,
+    api, pallet_contracts::wasm::OwnerInfo, sp_weights::weight_v2::Weight, AccountId, BlockHash,
+    ConnectionApi, SignedConnectionApi, TxInfo, TxStatus,
 };
 
 /// Arguments to [`ContractRpc::call_and_get`].

--- a/aleph-client/src/pallets/elections.rs
+++ b/aleph-client/src/pallets/elections.rs
@@ -6,14 +6,14 @@ use crate::{
         pallet_elections::pallet::Call::set_ban_config,
         primitives::{BanReason, CommitteeSeats, EraValidators},
     },
-    connections::AsConnection,
+    connections::{AsConnection, TxInfo},
     pallet_elections::pallet::Call::{
         ban_from_committee, change_validators, set_elections_openness,
     },
     primitives::{BanConfig, BanInfo, ElectionOpenness},
     AccountId, BlockHash,
     Call::Elections,
-    ConnectionApi, RootConnection, SudoCall, TxInfo, TxStatus,
+    ConnectionApi, RootConnection, SudoCall, TxStatus,
 };
 
 // TODO once pallet elections docs are published, replace api docs with links to public docs

--- a/aleph-client/src/pallets/elections.rs
+++ b/aleph-client/src/pallets/elections.rs
@@ -6,7 +6,7 @@ use crate::{
         pallet_elections::pallet::Call::set_ban_config,
         primitives::{BanReason, CommitteeSeats, EraValidators},
     },
-    connections::{AsConnection, TxCoords},
+    connections::{AsConnection, TxInfo},
     pallet_elections::pallet::Call::{
         ban_from_committee, change_validators, set_elections_openness,
     },
@@ -99,7 +99,7 @@ pub trait ElectionsSudoApi {
         clean_session_counter_delay: Option<u32>,
         ban_period: Option<EraIndex>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// Issues `elections.change_validators` that sets the committee for the next era.
     /// * `new_reserved_validators` - reserved validators to be in place in the next era; optional
@@ -112,7 +112,7 @@ pub trait ElectionsSudoApi {
         new_non_reserved_validators: Option<Vec<AccountId>>,
         committee_size: Option<CommitteeSeats>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// Schedule a non-reserved node to be banned out from the committee at the end of the era.
     /// * `account` - account to be banned,
@@ -123,7 +123,7 @@ pub trait ElectionsSudoApi {
         account: AccountId,
         ban_reason: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// Set openness of the elections.
     /// * `mode` - new elections openness mode
@@ -132,7 +132,7 @@ pub trait ElectionsSudoApi {
         &self,
         mode: ElectionOpenness,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 }
 
 #[async_trait::async_trait]
@@ -241,7 +241,7 @@ impl ElectionsSudoApi for RootConnection {
         clean_session_counter_delay: Option<u32>,
         ban_period: Option<EraIndex>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let call = Elections(set_ban_config {
             minimal_expected_performance,
             underperformed_session_count_threshold,
@@ -258,7 +258,7 @@ impl ElectionsSudoApi for RootConnection {
         new_non_reserved_validators: Option<Vec<AccountId>>,
         committee_size: Option<CommitteeSeats>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let call = Elections(change_validators {
             reserved_validators: new_reserved_validators,
             non_reserved_validators: new_non_reserved_validators,
@@ -273,7 +273,7 @@ impl ElectionsSudoApi for RootConnection {
         account: AccountId,
         ban_reason: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let call = Elections(ban_from_committee {
             banned: account,
             ban_reason,
@@ -285,7 +285,7 @@ impl ElectionsSudoApi for RootConnection {
         &self,
         mode: ElectionOpenness,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let call = Elections(set_elections_openness { openness: mode });
 
         self.sudo_unchecked(call, status).await

--- a/aleph-client/src/pallets/elections.rs
+++ b/aleph-client/src/pallets/elections.rs
@@ -6,7 +6,7 @@ use crate::{
         pallet_elections::pallet::Call::set_ban_config,
         primitives::{BanReason, CommitteeSeats, EraValidators},
     },
-    connections::AsConnection,
+    connections::{AsConnection, TxCoords},
     pallet_elections::pallet::Call::{
         ban_from_committee, change_validators, set_elections_openness,
     },
@@ -99,7 +99,7 @@ pub trait ElectionsSudoApi {
         clean_session_counter_delay: Option<u32>,
         ban_period: Option<EraIndex>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// Issues `elections.change_validators` that sets the committee for the next era.
     /// * `new_reserved_validators` - reserved validators to be in place in the next era; optional
@@ -112,7 +112,7 @@ pub trait ElectionsSudoApi {
         new_non_reserved_validators: Option<Vec<AccountId>>,
         committee_size: Option<CommitteeSeats>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// Schedule a non-reserved node to be banned out from the committee at the end of the era.
     /// * `account` - account to be banned,
@@ -123,7 +123,7 @@ pub trait ElectionsSudoApi {
         account: AccountId,
         ban_reason: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// Set openness of the elections.
     /// * `mode` - new elections openness mode
@@ -132,7 +132,7 @@ pub trait ElectionsSudoApi {
         &self,
         mode: ElectionOpenness,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 }
 
 #[async_trait::async_trait]
@@ -241,7 +241,7 @@ impl ElectionsSudoApi for RootConnection {
         clean_session_counter_delay: Option<u32>,
         ban_period: Option<EraIndex>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let call = Elections(set_ban_config {
             minimal_expected_performance,
             underperformed_session_count_threshold,
@@ -258,7 +258,7 @@ impl ElectionsSudoApi for RootConnection {
         new_non_reserved_validators: Option<Vec<AccountId>>,
         committee_size: Option<CommitteeSeats>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let call = Elections(change_validators {
             reserved_validators: new_reserved_validators,
             non_reserved_validators: new_non_reserved_validators,
@@ -273,7 +273,7 @@ impl ElectionsSudoApi for RootConnection {
         account: AccountId,
         ban_reason: Vec<u8>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let call = Elections(ban_from_committee {
             banned: account,
             ban_reason,
@@ -285,7 +285,7 @@ impl ElectionsSudoApi for RootConnection {
         &self,
         mode: ElectionOpenness,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let call = Elections(set_elections_openness { openness: mode });
 
         self.sudo_unchecked(call, status).await

--- a/aleph-client/src/pallets/elections.rs
+++ b/aleph-client/src/pallets/elections.rs
@@ -6,14 +6,14 @@ use crate::{
         pallet_elections::pallet::Call::set_ban_config,
         primitives::{BanReason, CommitteeSeats, EraValidators},
     },
-    connections::{AsConnection, TxInfo},
+    connections::AsConnection,
     pallet_elections::pallet::Call::{
         ban_from_committee, change_validators, set_elections_openness,
     },
     primitives::{BanConfig, BanInfo, ElectionOpenness},
     AccountId, BlockHash,
     Call::Elections,
-    ConnectionApi, RootConnection, SudoCall, TxStatus,
+    ConnectionApi, RootConnection, SudoCall, TxInfo, TxStatus,
 };
 
 // TODO once pallet elections docs are published, replace api docs with links to public docs

--- a/aleph-client/src/pallets/multisig.rs
+++ b/aleph-client/src/pallets/multisig.rs
@@ -7,9 +7,9 @@ use sp_core::blake2_256;
 use sp_runtime::traits::TrailingZeroInput;
 
 use crate::{
-    account_from_keypair, aleph_runtime::RuntimeCall, api, api::runtime_types,
+    account_from_keypair, aleph_runtime::RuntimeCall, api, api::runtime_types, connections::TxInfo,
     sp_weights::weight_v2::Weight, AccountId, BlockHash, ConnectionApi, SignedConnectionApi,
-    TxInfo, TxStatus,
+    TxStatus,
 };
 
 /// An alias for a call hash.

--- a/aleph-client/src/pallets/multisig.rs
+++ b/aleph-client/src/pallets/multisig.rs
@@ -8,8 +8,8 @@ use sp_runtime::traits::TrailingZeroInput;
 
 use crate::{
     account_from_keypair, aleph_runtime::RuntimeCall, api, api::runtime_types,
-    sp_weights::weight_v2::Weight, AccountId, BlockHash, ConnectionApi, SignedConnectionApi,
-    TxStatus,
+    connections::TxCoords, sp_weights::weight_v2::Weight, AccountId, BlockHash, ConnectionApi,
+    SignedConnectionApi, TxStatus,
 };
 
 /// An alias for a call hash.
@@ -42,7 +42,7 @@ pub trait MultisigUserApi {
         other_signatories: Vec<AccountId>,
         call: Call,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
     /// API for [`as_multi`](https://paritytech.github.io/substrate/master/pallet_multisig/pallet/struct.Pallet.html#method.as_multi) call.
     async fn as_multi(
         &self,
@@ -52,7 +52,7 @@ pub trait MultisigUserApi {
         max_weight: Weight,
         call: Call,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
     /// API for [`approve_as_multi`](https://paritytech.github.io/substrate/master/pallet_multisig/pallet/struct.Pallet.html#method.approve_as_multi) call.
     async fn approve_as_multi(
         &self,
@@ -62,7 +62,7 @@ pub trait MultisigUserApi {
         max_weight: Weight,
         call_hash: CallHash,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
     /// API for [`cancel_as_multi`](https://paritytech.github.io/substrate/master/pallet_multisig/pallet/struct.Pallet.html#method.cancel_as_multi) call.
     async fn cancel_as_multi(
         &self,
@@ -71,7 +71,7 @@ pub trait MultisigUserApi {
         timepoint: Timepoint,
         call_hash: CallHash,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 }
 
 #[async_trait::async_trait]
@@ -81,7 +81,7 @@ impl<S: SignedConnectionApi> MultisigUserApi for S {
         other_signatories: Vec<AccountId>,
         call: Call,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx()
             .multisig()
             .as_multi_threshold_1(other_signatories, call);
@@ -97,7 +97,7 @@ impl<S: SignedConnectionApi> MultisigUserApi for S {
         max_weight: Weight,
         call: Call,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().multisig().as_multi(
             threshold,
             other_signatories,
@@ -117,7 +117,7 @@ impl<S: SignedConnectionApi> MultisigUserApi for S {
         max_weight: Weight,
         call_hash: CallHash,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().multisig().approve_as_multi(
             threshold,
             other_signatories,
@@ -136,7 +136,7 @@ impl<S: SignedConnectionApi> MultisigUserApi for S {
         timepoint: Timepoint,
         call_hash: CallHash,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().multisig().cancel_as_multi(
             threshold,
             other_signatories,
@@ -385,7 +385,7 @@ impl Context<Closed> {
 #[async_trait::async_trait]
 pub trait MultisigContextualApi {
     /// Start signature aggregation for `party` and `call_hash`. Get `Context` object as a result
-    /// (together with standard block hash).
+    /// (together with standard tx coordinates).
     ///
     /// This is the recommended way of initialization.
     async fn initiate(
@@ -394,9 +394,9 @@ pub trait MultisigContextualApi {
         max_weight: &Weight,
         call_hash: CallHash,
         status: TxStatus,
-    ) -> anyhow::Result<(BlockHash, Context<Ongoing>)>;
+    ) -> anyhow::Result<(TxCoords, Context<Ongoing>)>;
     /// Start signature aggregation for `party` and `call`. Get `Context` object as a result
-    /// (together with standard block hash).
+    /// (together with standard tx coordinates).
     ///
     /// Note: it is usually a better idea to pass `call` only with the final approval (so that it
     /// isn't stored on-chain).
@@ -406,7 +406,7 @@ pub trait MultisigContextualApi {
         max_weight: &Weight,
         call: Call,
         status: TxStatus,
-    ) -> anyhow::Result<(BlockHash, Context<Ongoing>)>;
+    ) -> anyhow::Result<(TxCoords, Context<Ongoing>)>;
     /// Express contextual approval for the call hash.
     ///
     /// This is the recommended way for every intermediate approval.
@@ -414,7 +414,7 @@ pub trait MultisigContextualApi {
         &self,
         context: Context<Ongoing>,
         status: TxStatus,
-    ) -> anyhow::Result<(BlockHash, ContextAfterUse)>;
+    ) -> anyhow::Result<(TxCoords, ContextAfterUse)>;
     /// Express contextual approval for the `call`.
     ///
     /// This is the recommended way only for the final approval.
@@ -423,13 +423,13 @@ pub trait MultisigContextualApi {
         context: Context<Ongoing>,
         call: Option<Call>,
         status: TxStatus,
-    ) -> anyhow::Result<(BlockHash, ContextAfterUse)>;
+    ) -> anyhow::Result<(TxCoords, ContextAfterUse)>;
     /// Cancel signature aggregation.
     async fn cancel(
         &self,
         context: Context<Ongoing>,
         status: TxStatus,
-    ) -> anyhow::Result<(BlockHash, Context<Closed>)>;
+    ) -> anyhow::Result<(TxCoords, Context<Closed>)>;
 }
 
 #[async_trait::async_trait]
@@ -440,10 +440,10 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
         max_weight: &Weight,
         call_hash: CallHash,
         status: TxStatus,
-    ) -> anyhow::Result<(BlockHash, Context<Ongoing>)> {
+    ) -> anyhow::Result<(TxCoords, Context<Ongoing>)> {
         let other_signatories = ensure_signer_in_party(self, party)?;
 
-        let block_hash = self
+        let tx_coords = self
             .approve_as_multi(
                 party.threshold,
                 other_signatories,
@@ -461,11 +461,11 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
         // `connections` module. Secondly, if `Timepoint` struct change, this method (reading raw
         // extrinsic position) might become incorrect.
         let timepoint = self
-            .get_timepoint(&party.account(), &call_hash, Some(block_hash))
+            .get_timepoint(&party.account(), &call_hash, Some(tx_coords.block_hash))
             .await;
 
         Ok((
-            block_hash,
+            tx_coords,
             Context::new(
                 party.clone(),
                 self.account_id().clone(),
@@ -483,10 +483,10 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
         max_weight: &Weight,
         call: Call,
         status: TxStatus,
-    ) -> anyhow::Result<(BlockHash, Context<Ongoing>)> {
+    ) -> anyhow::Result<(TxCoords, Context<Ongoing>)> {
         let other_signatories = ensure_signer_in_party(self, party)?;
 
-        let block_hash = self
+        let tx_coords = self
             .as_multi(
                 party.threshold,
                 other_signatories,
@@ -499,11 +499,11 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
 
         let call_hash = compute_call_hash(&call);
         let timepoint = self
-            .get_timepoint(&party.account(), &call_hash, Some(block_hash))
+            .get_timepoint(&party.account(), &call_hash, Some(tx_coords.block_hash))
             .await;
 
         Ok((
-            block_hash,
+            tx_coords,
             Context::new(
                 party.clone(),
                 self.account_id().clone(),
@@ -519,7 +519,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
         &self,
         context: Context<Ongoing>,
         status: TxStatus,
-    ) -> anyhow::Result<(BlockHash, ContextAfterUse)> {
+    ) -> anyhow::Result<(TxCoords, ContextAfterUse)> {
         let other_signatories = ensure_signer_in_party(self, &context.party)?;
 
         self.approve_as_multi(
@@ -531,7 +531,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
             status,
         )
         .await
-        .map(|block_hash| (block_hash, context.add_approval(self.account_id().clone())))
+        .map(|tx_coords| (tx_coords, context.add_approval(self.account_id().clone())))
     }
 
     async fn approve_with_call(
@@ -539,7 +539,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
         mut context: Context<Ongoing>,
         call: Option<Call>,
         status: TxStatus,
-    ) -> anyhow::Result<(BlockHash, ContextAfterUse)> {
+    ) -> anyhow::Result<(TxCoords, ContextAfterUse)> {
         let other_signatories = ensure_signer_in_party(self, &context.party)?;
 
         let call = match (call.as_ref(), context.call.as_ref()) {
@@ -569,14 +569,14 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
             status,
         )
         .await
-        .map(|block_hash| (block_hash, context.add_approval(self.account_id().clone())))
+        .map(|tx_coords| (tx_coords, context.add_approval(self.account_id().clone())))
     }
 
     async fn cancel(
         &self,
         context: Context<Ongoing>,
         status: TxStatus,
-    ) -> anyhow::Result<(BlockHash, Context<Closed>)> {
+    ) -> anyhow::Result<(TxCoords, Context<Closed>)> {
         let other_signatories = ensure_signer_in_party(self, &context.party)?;
 
         ensure!(
@@ -584,7 +584,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
             "Only the author can cancel multisig aggregation"
         );
 
-        let block_hash = self
+        let tx_coords = self
             .cancel_as_multi(
                 context.party.threshold,
                 other_signatories,
@@ -594,7 +594,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
             )
             .await?;
 
-        Ok((block_hash, context.close()))
+        Ok((tx_coords, context.close()))
     }
 }
 

--- a/aleph-client/src/pallets/multisig.rs
+++ b/aleph-client/src/pallets/multisig.rs
@@ -7,9 +7,9 @@ use sp_core::blake2_256;
 use sp_runtime::traits::TrailingZeroInput;
 
 use crate::{
-    account_from_keypair, aleph_runtime::RuntimeCall, api, api::runtime_types, connections::TxInfo,
+    account_from_keypair, aleph_runtime::RuntimeCall, api, api::runtime_types,
     sp_weights::weight_v2::Weight, AccountId, BlockHash, ConnectionApi, SignedConnectionApi,
-    TxStatus,
+    TxInfo, TxStatus,
 };
 
 /// An alias for a call hash.

--- a/aleph-client/src/pallets/multisig.rs
+++ b/aleph-client/src/pallets/multisig.rs
@@ -443,7 +443,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
     ) -> anyhow::Result<(TxInfo, Context<Ongoing>)> {
         let other_signatories = ensure_signer_in_party(self, party)?;
 
-        let tx_coords = self
+        let tx_info = self
             .approve_as_multi(
                 party.threshold,
                 other_signatories,
@@ -461,11 +461,11 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
         // `connections` module. Secondly, if `Timepoint` struct change, this method (reading raw
         // extrinsic position) might become incorrect.
         let timepoint = self
-            .get_timepoint(&party.account(), &call_hash, Some(tx_coords.block_hash))
+            .get_timepoint(&party.account(), &call_hash, Some(tx_info.block_hash))
             .await;
 
         Ok((
-            tx_coords,
+            tx_info,
             Context::new(
                 party.clone(),
                 self.account_id().clone(),
@@ -486,7 +486,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
     ) -> anyhow::Result<(TxInfo, Context<Ongoing>)> {
         let other_signatories = ensure_signer_in_party(self, party)?;
 
-        let tx_coords = self
+        let tx_info = self
             .as_multi(
                 party.threshold,
                 other_signatories,
@@ -499,11 +499,11 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
 
         let call_hash = compute_call_hash(&call);
         let timepoint = self
-            .get_timepoint(&party.account(), &call_hash, Some(tx_coords.block_hash))
+            .get_timepoint(&party.account(), &call_hash, Some(tx_info.block_hash))
             .await;
 
         Ok((
-            tx_coords,
+            tx_info,
             Context::new(
                 party.clone(),
                 self.account_id().clone(),
@@ -531,7 +531,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
             status,
         )
         .await
-        .map(|tx_coords| (tx_coords, context.add_approval(self.account_id().clone())))
+        .map(|tx_info| (tx_info, context.add_approval(self.account_id().clone())))
     }
 
     async fn approve_with_call(
@@ -569,7 +569,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
             status,
         )
         .await
-        .map(|tx_coords| (tx_coords, context.add_approval(self.account_id().clone())))
+        .map(|tx_info| (tx_info, context.add_approval(self.account_id().clone())))
     }
 
     async fn cancel(
@@ -584,7 +584,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
             "Only the author can cancel multisig aggregation"
         );
 
-        let tx_coords = self
+        let tx_info = self
             .cancel_as_multi(
                 context.party.threshold,
                 other_signatories,
@@ -594,7 +594,7 @@ impl<S: SignedConnectionApi> MultisigContextualApi for S {
             )
             .await?;
 
-        Ok((tx_coords, context.close()))
+        Ok((tx_info, context.close()))
     }
 }
 

--- a/aleph-client/src/pallets/session.rs
+++ b/aleph-client/src/pallets/session.rs
@@ -1,8 +1,8 @@
 use primitives::SessionIndex;
 
 use crate::{
-    api, api::runtime_types::aleph_runtime::SessionKeys, connections::TxInfo, AccountId, BlockHash,
-    ConnectionApi, SignedConnectionApi, TxStatus,
+    api, api::runtime_types::aleph_runtime::SessionKeys, AccountId, BlockHash, ConnectionApi,
+    SignedConnectionApi, TxInfo, TxStatus,
 };
 
 /// Pallet session read-only api.

--- a/aleph-client/src/pallets/session.rs
+++ b/aleph-client/src/pallets/session.rs
@@ -1,8 +1,8 @@
 use primitives::SessionIndex;
 
 use crate::{
-    api, api::runtime_types::aleph_runtime::SessionKeys, connections::TxCoords, AccountId,
-    BlockHash, ConnectionApi, SignedConnectionApi, TxStatus,
+    api, api::runtime_types::aleph_runtime::SessionKeys, connections::TxInfo, AccountId, BlockHash,
+    ConnectionApi, SignedConnectionApi, TxStatus,
 };
 
 /// Pallet session read-only api.
@@ -26,7 +26,7 @@ pub trait SessionApi {
 #[async_trait::async_trait]
 pub trait SessionUserApi {
     /// API for [`set_keys`](https://paritytech.github.io/substrate/master/pallet_session/pallet/struct.Pallet.html#method.set_keys) call.
-    async fn set_keys(&self, new_keys: SessionKeys, status: TxStatus) -> anyhow::Result<TxCoords>;
+    async fn set_keys(&self, new_keys: SessionKeys, status: TxStatus) -> anyhow::Result<TxInfo>;
 }
 
 #[async_trait::async_trait]
@@ -58,7 +58,7 @@ impl<C: ConnectionApi> SessionApi for C {
 
 #[async_trait::async_trait]
 impl<S: SignedConnectionApi> SessionUserApi for S {
-    async fn set_keys(&self, new_keys: SessionKeys, status: TxStatus) -> anyhow::Result<TxCoords> {
+    async fn set_keys(&self, new_keys: SessionKeys, status: TxStatus) -> anyhow::Result<TxInfo> {
         let tx = api::tx().session().set_keys(new_keys, vec![]);
 
         self.send_tx(tx, status).await

--- a/aleph-client/src/pallets/session.rs
+++ b/aleph-client/src/pallets/session.rs
@@ -1,8 +1,8 @@
 use primitives::SessionIndex;
 
 use crate::{
-    api, api::runtime_types::aleph_runtime::SessionKeys, AccountId, BlockHash, ConnectionApi,
-    SignedConnectionApi, TxStatus,
+    api, api::runtime_types::aleph_runtime::SessionKeys, connections::TxCoords, AccountId,
+    BlockHash, ConnectionApi, SignedConnectionApi, TxStatus,
 };
 
 /// Pallet session read-only api.
@@ -26,7 +26,7 @@ pub trait SessionApi {
 #[async_trait::async_trait]
 pub trait SessionUserApi {
     /// API for [`set_keys`](https://paritytech.github.io/substrate/master/pallet_session/pallet/struct.Pallet.html#method.set_keys) call.
-    async fn set_keys(&self, new_keys: SessionKeys, status: TxStatus) -> anyhow::Result<BlockHash>;
+    async fn set_keys(&self, new_keys: SessionKeys, status: TxStatus) -> anyhow::Result<TxCoords>;
 }
 
 #[async_trait::async_trait]
@@ -58,7 +58,7 @@ impl<C: ConnectionApi> SessionApi for C {
 
 #[async_trait::async_trait]
 impl<S: SignedConnectionApi> SessionUserApi for S {
-    async fn set_keys(&self, new_keys: SessionKeys, status: TxStatus) -> anyhow::Result<BlockHash> {
+    async fn set_keys(&self, new_keys: SessionKeys, status: TxStatus) -> anyhow::Result<TxCoords> {
         let tx = api::tx().session().set_keys(new_keys, vec![]);
 
         self.send_tx(tx, status).await

--- a/aleph-client/src/pallets/session.rs
+++ b/aleph-client/src/pallets/session.rs
@@ -1,8 +1,8 @@
 use primitives::SessionIndex;
 
 use crate::{
-    api, api::runtime_types::aleph_runtime::SessionKeys, AccountId, BlockHash, ConnectionApi,
-    SignedConnectionApi, TxInfo, TxStatus,
+    api, api::runtime_types::aleph_runtime::SessionKeys, connections::TxInfo, AccountId, BlockHash,
+    ConnectionApi, SignedConnectionApi, TxStatus,
 };
 
 /// Pallet session read-only api.

--- a/aleph-client/src/pallets/staking.rs
+++ b/aleph-client/src/pallets/staking.rs
@@ -9,7 +9,7 @@ use subxt::{
 
 use crate::{
     api,
-    connections::{AsConnection, TxCoords},
+    connections::{AsConnection, TxInfo},
     pallet_staking::{
         pallet::pallet::{
             Call::{bond, force_new_era, nominate, set_staking_configs},
@@ -88,14 +88,14 @@ pub trait StakingUserApi {
         initial_stake: Balance,
         controller_id: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`validate`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.validate) call.
     async fn validate(
         &self,
         validator_commission_percentage: u8,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`payout_stakers`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.payout_stakers) call.
     async fn payout_stakers(
@@ -103,24 +103,24 @@ pub trait StakingUserApi {
         stash_account: AccountId,
         era: EraIndex,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`nominate`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.nominate) call.
     async fn nominate(
         &self,
         nominee_account_id: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`chill`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.chill) call.
-    async fn chill(&self, status: TxStatus) -> anyhow::Result<TxCoords>;
+    async fn chill(&self, status: TxStatus) -> anyhow::Result<TxInfo>;
 
     /// API for [`bond_extra`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.bond_extra) call.
     async fn bond_extra_stake(
         &self,
         extra_stake: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 }
 
 /// Pallet staking logic, not directly related to any particular pallet call.
@@ -174,7 +174,7 @@ pub trait StakingApiExt {
         accounts: &[(AccountId, AccountId)],
         stake: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// Send batch of [`nominate`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.nominate) calls.
     /// * `nominator_nominee_pairs` - a slice of account ids pairs (nominator, nominee)
@@ -186,14 +186,14 @@ pub trait StakingApiExt {
         &self,
         nominator_nominee_pairs: &[(AccountId, AccountId)],
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 }
 
 /// Pallet staking api that requires sudo.
 #[async_trait::async_trait]
 pub trait StakingSudoApi {
     /// API for [`force_new_era`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.force_new_era) call.
-    async fn force_new_era(&self, status: TxStatus) -> anyhow::Result<TxCoords>;
+    async fn force_new_era(&self, status: TxStatus) -> anyhow::Result<TxInfo>;
 
     /// API for [`set_staking_config`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.set_staking_configs) call.
     async fn set_staking_config(
@@ -203,7 +203,7 @@ pub trait StakingSudoApi {
         max_nominators_count: Option<u32>,
         max_validators_count: Option<u32>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 }
 
 /// Logic for retrieving raw storage keys or values from a pallet staking.
@@ -317,7 +317,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         initial_stake: Balance,
         controller_id: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx().staking().bond(
             MultiAddress::<AccountId, ()>::Id(controller_id),
             initial_stake,
@@ -331,7 +331,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         &self,
         validator_commission_percentage: u8,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx().staking().validate(ValidatorPrefs {
             commission: Perbill(
                 SPerbill::from_percent(validator_commission_percentage as u32).deconstruct(),
@@ -347,7 +347,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         stash_account: AccountId,
         era: EraIndex,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx().staking().payout_stakers(stash_account, era);
 
         self.send_tx(tx, status).await
@@ -357,7 +357,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         &self,
         nominee_account_id: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx()
             .staking()
             .nominate(vec![MultiAddress::Id(nominee_account_id)]);
@@ -365,7 +365,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         self.send_tx(tx, status).await
     }
 
-    async fn chill(&self, status: TxStatus) -> anyhow::Result<TxCoords> {
+    async fn chill(&self, status: TxStatus) -> anyhow::Result<TxInfo> {
         let tx = api::tx().staking().chill();
 
         self.send_tx(tx, status).await
@@ -375,7 +375,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         &self,
         extra_stake: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx().staking().bond_extra(extra_stake);
 
         self.send_tx(tx, status).await
@@ -384,7 +384,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
 
 #[async_trait::async_trait]
 impl StakingSudoApi for RootConnection {
-    async fn force_new_era(&self, status: TxStatus) -> anyhow::Result<TxCoords> {
+    async fn force_new_era(&self, status: TxStatus) -> anyhow::Result<TxInfo> {
         let call = Staking(force_new_era);
 
         self.sudo_unchecked(call, status).await
@@ -397,7 +397,7 @@ impl StakingSudoApi for RootConnection {
         max_nominator_count: Option<u32>,
         max_validator_count: Option<u32>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         fn convert<T>(arg: Option<T>) -> ConfigOp<T> {
             match arg {
                 Some(v) => Set(v),
@@ -462,7 +462,7 @@ impl StakingApiExt for RootConnection {
         accounts: &[(AccountId, AccountId)],
         stake: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let calls = accounts
             .iter()
             .map(|(s, c)| {
@@ -486,7 +486,7 @@ impl StakingApiExt for RootConnection {
         &self,
         nominator_nominee_pairs: &[(AccountId, AccountId)],
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let calls = nominator_nominee_pairs
             .iter()
             .map(|(nominator, nominee)| {

--- a/aleph-client/src/pallets/staking.rs
+++ b/aleph-client/src/pallets/staking.rs
@@ -9,7 +9,7 @@ use subxt::{
 
 use crate::{
     api,
-    connections::{AsConnection, TxInfo},
+    connections::AsConnection,
     pallet_staking::{
         pallet::pallet::{
             Call::{bond, force_new_era, nominate, set_staking_configs},
@@ -23,7 +23,7 @@ use crate::{
     sp_arithmetic::per_things::Perbill,
     AccountId, BlockHash,
     Call::{Staking, Sudo},
-    ConnectionApi, RootConnection, SignedConnectionApi, SudoCall, TxStatus,
+    ConnectionApi, RootConnection, SignedConnectionApi, SudoCall, TxInfo, TxStatus,
 };
 
 /// Any object that implemnts pallet staking read-only api.

--- a/aleph-client/src/pallets/staking.rs
+++ b/aleph-client/src/pallets/staking.rs
@@ -9,7 +9,7 @@ use subxt::{
 
 use crate::{
     api,
-    connections::AsConnection,
+    connections::{AsConnection, TxCoords},
     pallet_staking::{
         pallet::pallet::{
             Call::{bond, force_new_era, nominate, set_staking_configs},
@@ -88,14 +88,14 @@ pub trait StakingUserApi {
         initial_stake: Balance,
         controller_id: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`validate`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.validate) call.
     async fn validate(
         &self,
         validator_commission_percentage: u8,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`payout_stakers`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.payout_stakers) call.
     async fn payout_stakers(
@@ -103,24 +103,24 @@ pub trait StakingUserApi {
         stash_account: AccountId,
         era: EraIndex,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`nominate`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.nominate) call.
     async fn nominate(
         &self,
         nominee_account_id: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`chill`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.chill) call.
-    async fn chill(&self, status: TxStatus) -> anyhow::Result<BlockHash>;
+    async fn chill(&self, status: TxStatus) -> anyhow::Result<TxCoords>;
 
     /// API for [`bond_extra`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.bond_extra) call.
     async fn bond_extra_stake(
         &self,
         extra_stake: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 }
 
 /// Pallet staking logic, not directly related to any particular pallet call.
@@ -174,7 +174,7 @@ pub trait StakingApiExt {
         accounts: &[(AccountId, AccountId)],
         stake: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// Send batch of [`nominate`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.nominate) calls.
     /// * `nominator_nominee_pairs` - a slice of account ids pairs (nominator, nominee)
@@ -186,14 +186,14 @@ pub trait StakingApiExt {
         &self,
         nominator_nominee_pairs: &[(AccountId, AccountId)],
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 }
 
 /// Pallet staking api that requires sudo.
 #[async_trait::async_trait]
 pub trait StakingSudoApi {
     /// API for [`force_new_era`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.force_new_era) call.
-    async fn force_new_era(&self, status: TxStatus) -> anyhow::Result<BlockHash>;
+    async fn force_new_era(&self, status: TxStatus) -> anyhow::Result<TxCoords>;
 
     /// API for [`set_staking_config`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.set_staking_configs) call.
     async fn set_staking_config(
@@ -203,7 +203,7 @@ pub trait StakingSudoApi {
         max_nominators_count: Option<u32>,
         max_validators_count: Option<u32>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 }
 
 /// Logic for retrieving raw storage keys or values from a pallet staking.
@@ -317,7 +317,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         initial_stake: Balance,
         controller_id: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().staking().bond(
             MultiAddress::<AccountId, ()>::Id(controller_id),
             initial_stake,
@@ -331,7 +331,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         &self,
         validator_commission_percentage: u8,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().staking().validate(ValidatorPrefs {
             commission: Perbill(
                 SPerbill::from_percent(validator_commission_percentage as u32).deconstruct(),
@@ -347,7 +347,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         stash_account: AccountId,
         era: EraIndex,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().staking().payout_stakers(stash_account, era);
 
         self.send_tx(tx, status).await
@@ -357,7 +357,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         &self,
         nominee_account_id: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx()
             .staking()
             .nominate(vec![MultiAddress::Id(nominee_account_id)]);
@@ -365,7 +365,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         self.send_tx(tx, status).await
     }
 
-    async fn chill(&self, status: TxStatus) -> anyhow::Result<BlockHash> {
+    async fn chill(&self, status: TxStatus) -> anyhow::Result<TxCoords> {
         let tx = api::tx().staking().chill();
 
         self.send_tx(tx, status).await
@@ -375,7 +375,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
         &self,
         extra_stake: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().staking().bond_extra(extra_stake);
 
         self.send_tx(tx, status).await
@@ -384,7 +384,7 @@ impl<S: SignedConnectionApi> StakingUserApi for S {
 
 #[async_trait::async_trait]
 impl StakingSudoApi for RootConnection {
-    async fn force_new_era(&self, status: TxStatus) -> anyhow::Result<BlockHash> {
+    async fn force_new_era(&self, status: TxStatus) -> anyhow::Result<TxCoords> {
         let call = Staking(force_new_era);
 
         self.sudo_unchecked(call, status).await
@@ -397,7 +397,7 @@ impl StakingSudoApi for RootConnection {
         max_nominator_count: Option<u32>,
         max_validator_count: Option<u32>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         fn convert<T>(arg: Option<T>) -> ConfigOp<T> {
             match arg {
                 Some(v) => Set(v),
@@ -462,7 +462,7 @@ impl StakingApiExt for RootConnection {
         accounts: &[(AccountId, AccountId)],
         stake: Balance,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let calls = accounts
             .iter()
             .map(|(s, c)| {
@@ -486,7 +486,7 @@ impl StakingApiExt for RootConnection {
         &self,
         nominator_nominee_pairs: &[(AccountId, AccountId)],
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let calls = nominator_nominee_pairs
             .iter()
             .map(|(nominator, nominee)| {

--- a/aleph-client/src/pallets/staking.rs
+++ b/aleph-client/src/pallets/staking.rs
@@ -9,7 +9,7 @@ use subxt::{
 
 use crate::{
     api,
-    connections::AsConnection,
+    connections::{AsConnection, TxInfo},
     pallet_staking::{
         pallet::pallet::{
             Call::{bond, force_new_era, nominate, set_staking_configs},
@@ -23,7 +23,7 @@ use crate::{
     sp_arithmetic::per_things::Perbill,
     AccountId, BlockHash,
     Call::{Staking, Sudo},
-    ConnectionApi, RootConnection, SignedConnectionApi, SudoCall, TxInfo, TxStatus,
+    ConnectionApi, RootConnection, SignedConnectionApi, SudoCall, TxStatus,
 };
 
 /// Any object that implemnts pallet staking read-only api.

--- a/aleph-client/src/pallets/system.rs
+++ b/aleph-client/src/pallets/system.rs
@@ -3,11 +3,12 @@ use subxt::ext::sp_runtime::Perbill as SPerbill;
 
 use crate::{
     api,
+    connections::TxInfo,
     frame_system::pallet::Call::{fill_block, set_code},
     sp_arithmetic::per_things::Perbill,
     AccountId, BlockHash,
     Call::System,
-    ConnectionApi, RootConnection, SudoCall, TxInfo, TxStatus,
+    ConnectionApi, RootConnection, SudoCall, TxStatus,
 };
 
 /// Pallet system read-only api.

--- a/aleph-client/src/pallets/system.rs
+++ b/aleph-client/src/pallets/system.rs
@@ -3,12 +3,11 @@ use subxt::ext::sp_runtime::Perbill as SPerbill;
 
 use crate::{
     api,
-    connections::TxInfo,
     frame_system::pallet::Call::{fill_block, set_code},
     sp_arithmetic::per_things::Perbill,
     AccountId, BlockHash,
     Call::System,
-    ConnectionApi, RootConnection, SudoCall, TxStatus,
+    ConnectionApi, RootConnection, SudoCall, TxInfo, TxStatus,
 };
 
 /// Pallet system read-only api.

--- a/aleph-client/src/pallets/system.rs
+++ b/aleph-client/src/pallets/system.rs
@@ -3,6 +3,7 @@ use subxt::ext::sp_runtime::Perbill as SPerbill;
 
 use crate::{
     api,
+    connections::TxCoords,
     frame_system::pallet::Call::{fill_block, set_code},
     sp_arithmetic::per_things::Perbill,
     AccountId, BlockHash,
@@ -25,7 +26,7 @@ pub trait SystemApi {
 #[async_trait::async_trait]
 pub trait SystemSudoApi {
     /// API for [`set_code`](https://paritytech.github.io/substrate/master/frame_system/pallet/struct.Pallet.html#method.set_code) call.
-    async fn set_code(&self, code: Vec<u8>, status: TxStatus) -> anyhow::Result<BlockHash>;
+    async fn set_code(&self, code: Vec<u8>, status: TxStatus) -> anyhow::Result<TxCoords>;
 
     /// A dispatch that will fill the block weight up to the given ratio.
     /// * `target_ratio_percent` - ratio to fill block
@@ -34,12 +35,12 @@ pub trait SystemSudoApi {
         &self,
         target_ratio_percent: u8,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 }
 
 #[async_trait::async_trait]
 impl SystemSudoApi for RootConnection {
-    async fn set_code(&self, code: Vec<u8>, status: TxStatus) -> anyhow::Result<BlockHash> {
+    async fn set_code(&self, code: Vec<u8>, status: TxStatus) -> anyhow::Result<TxCoords> {
         let call = System(set_code { code });
 
         self.sudo_unchecked(call, status).await
@@ -49,7 +50,7 @@ impl SystemSudoApi for RootConnection {
         &self,
         target_ratio_percent: u8,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let call = System(fill_block {
             ratio: Perbill(SPerbill::from_percent(target_ratio_percent as u32).deconstruct()),
         });

--- a/aleph-client/src/pallets/system.rs
+++ b/aleph-client/src/pallets/system.rs
@@ -3,7 +3,7 @@ use subxt::ext::sp_runtime::Perbill as SPerbill;
 
 use crate::{
     api,
-    connections::TxCoords,
+    connections::TxInfo,
     frame_system::pallet::Call::{fill_block, set_code},
     sp_arithmetic::per_things::Perbill,
     AccountId, BlockHash,
@@ -26,7 +26,7 @@ pub trait SystemApi {
 #[async_trait::async_trait]
 pub trait SystemSudoApi {
     /// API for [`set_code`](https://paritytech.github.io/substrate/master/frame_system/pallet/struct.Pallet.html#method.set_code) call.
-    async fn set_code(&self, code: Vec<u8>, status: TxStatus) -> anyhow::Result<TxCoords>;
+    async fn set_code(&self, code: Vec<u8>, status: TxStatus) -> anyhow::Result<TxInfo>;
 
     /// A dispatch that will fill the block weight up to the given ratio.
     /// * `target_ratio_percent` - ratio to fill block
@@ -35,12 +35,12 @@ pub trait SystemSudoApi {
         &self,
         target_ratio_percent: u8,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 }
 
 #[async_trait::async_trait]
 impl SystemSudoApi for RootConnection {
-    async fn set_code(&self, code: Vec<u8>, status: TxStatus) -> anyhow::Result<TxCoords> {
+    async fn set_code(&self, code: Vec<u8>, status: TxStatus) -> anyhow::Result<TxInfo> {
         let call = System(set_code { code });
 
         self.sudo_unchecked(call, status).await
@@ -50,7 +50,7 @@ impl SystemSudoApi for RootConnection {
         &self,
         target_ratio_percent: u8,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let call = System(fill_block {
             ratio: Perbill(SPerbill::from_percent(target_ratio_percent as u32).deconstruct()),
         });

--- a/aleph-client/src/pallets/treasury.rs
+++ b/aleph-client/src/pallets/treasury.rs
@@ -5,12 +5,12 @@ use subxt::ext::sp_runtime::MultiAddress;
 
 use crate::{
     api,
-    connections::{AsConnection, TxInfo},
+    connections::AsConnection,
     pallet_treasury::pallet::Call::{approve_proposal, reject_proposal},
     pallets::{elections::ElectionsApi, staking::StakingApi},
     AccountId, BlockHash,
     Call::Treasury,
-    ConnectionApi, RootConnection, SignedConnectionApi, SudoCall, TxStatus,
+    ConnectionApi, RootConnection, SignedConnectionApi, SudoCall, TxInfo, TxStatus,
 };
 
 /// Pallet treasury read-only api.

--- a/aleph-client/src/pallets/treasury.rs
+++ b/aleph-client/src/pallets/treasury.rs
@@ -5,7 +5,7 @@ use subxt::ext::sp_runtime::MultiAddress;
 
 use crate::{
     api,
-    connections::AsConnection,
+    connections::{AsConnection, TxCoords},
     pallet_treasury::pallet::Call::{approve_proposal, reject_proposal},
     pallets::{elections::ElectionsApi, staking::StakingApi},
     AccountId, BlockHash,
@@ -37,13 +37,13 @@ pub trait TreasuryUserApi {
         amount: Balance,
         beneficiary: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`approve_proposal`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.approve_proposal) call.
-    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<BlockHash>;
+    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords>;
 
     /// API for [`reject_proposal`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.reject_proposal) call.
-    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<BlockHash>;
+    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords>;
 }
 
 /// Pallet treasury funcionality that is not directly related to any pallet call.
@@ -59,11 +59,11 @@ pub trait TreasureApiExt {
 pub trait TreasurySudoApi {
     /// API for [`approve_proposal`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.approve_proposal) call.
     /// wrapped  in [`sudo_unchecked_weight`](https://paritytech.github.io/substrate/master/pallet_sudo/pallet/struct.Pallet.html#method.sudo_unchecked_weight)
-    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<BlockHash>;
+    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords>;
 
     /// API for [`reject_proposal`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.reject_proposal) call.
     /// wrapped [`sudo_unchecked_weight`](https://paritytech.github.io/substrate/master/pallet_sudo/pallet/struct.Pallet.html#method.sudo_unchecked_weight)
-    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<BlockHash>;
+    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords>;
 }
 
 #[async_trait::async_trait]
@@ -92,7 +92,7 @@ impl<S: SignedConnectionApi> TreasuryUserApi for S {
         amount: Balance,
         beneficiary: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx()
             .treasury()
             .propose_spend(amount, MultiAddress::Id(beneficiary));
@@ -100,13 +100,13 @@ impl<S: SignedConnectionApi> TreasuryUserApi for S {
         self.send_tx(tx, status).await
     }
 
-    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<BlockHash> {
+    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords> {
         let tx = api::tx().treasury().approve_proposal(proposal_id);
 
         self.send_tx(tx, status).await
     }
 
-    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<BlockHash> {
+    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords> {
         let tx = api::tx().treasury().reject_proposal(proposal_id);
 
         self.send_tx(tx, status).await
@@ -115,13 +115,13 @@ impl<S: SignedConnectionApi> TreasuryUserApi for S {
 
 #[async_trait::async_trait]
 impl TreasurySudoApi for RootConnection {
-    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<BlockHash> {
+    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords> {
         let call = Treasury(approve_proposal { proposal_id });
 
         self.sudo_unchecked(call, status).await
     }
 
-    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<BlockHash> {
+    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords> {
         let call = Treasury(reject_proposal { proposal_id });
 
         self.sudo_unchecked(call, status).await

--- a/aleph-client/src/pallets/treasury.rs
+++ b/aleph-client/src/pallets/treasury.rs
@@ -5,12 +5,12 @@ use subxt::ext::sp_runtime::MultiAddress;
 
 use crate::{
     api,
-    connections::AsConnection,
+    connections::{AsConnection, TxInfo},
     pallet_treasury::pallet::Call::{approve_proposal, reject_proposal},
     pallets::{elections::ElectionsApi, staking::StakingApi},
     AccountId, BlockHash,
     Call::Treasury,
-    ConnectionApi, RootConnection, SignedConnectionApi, SudoCall, TxInfo, TxStatus,
+    ConnectionApi, RootConnection, SignedConnectionApi, SudoCall, TxStatus,
 };
 
 /// Pallet treasury read-only api.

--- a/aleph-client/src/pallets/treasury.rs
+++ b/aleph-client/src/pallets/treasury.rs
@@ -5,7 +5,7 @@ use subxt::ext::sp_runtime::MultiAddress;
 
 use crate::{
     api,
-    connections::{AsConnection, TxCoords},
+    connections::{AsConnection, TxInfo},
     pallet_treasury::pallet::Call::{approve_proposal, reject_proposal},
     pallets::{elections::ElectionsApi, staking::StakingApi},
     AccountId, BlockHash,
@@ -37,13 +37,13 @@ pub trait TreasuryUserApi {
         amount: Balance,
         beneficiary: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`approve_proposal`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.approve_proposal) call.
-    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords>;
+    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxInfo>;
 
     /// API for [`reject_proposal`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.reject_proposal) call.
-    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords>;
+    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxInfo>;
 }
 
 /// Pallet treasury funcionality that is not directly related to any pallet call.
@@ -59,11 +59,11 @@ pub trait TreasureApiExt {
 pub trait TreasurySudoApi {
     /// API for [`approve_proposal`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.approve_proposal) call.
     /// wrapped  in [`sudo_unchecked_weight`](https://paritytech.github.io/substrate/master/pallet_sudo/pallet/struct.Pallet.html#method.sudo_unchecked_weight)
-    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords>;
+    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxInfo>;
 
     /// API for [`reject_proposal`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.reject_proposal) call.
     /// wrapped [`sudo_unchecked_weight`](https://paritytech.github.io/substrate/master/pallet_sudo/pallet/struct.Pallet.html#method.sudo_unchecked_weight)
-    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords>;
+    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxInfo>;
 }
 
 #[async_trait::async_trait]
@@ -92,7 +92,7 @@ impl<S: SignedConnectionApi> TreasuryUserApi for S {
         amount: Balance,
         beneficiary: AccountId,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx()
             .treasury()
             .propose_spend(amount, MultiAddress::Id(beneficiary));
@@ -100,13 +100,13 @@ impl<S: SignedConnectionApi> TreasuryUserApi for S {
         self.send_tx(tx, status).await
     }
 
-    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords> {
+    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxInfo> {
         let tx = api::tx().treasury().approve_proposal(proposal_id);
 
         self.send_tx(tx, status).await
     }
 
-    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords> {
+    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxInfo> {
         let tx = api::tx().treasury().reject_proposal(proposal_id);
 
         self.send_tx(tx, status).await
@@ -115,13 +115,13 @@ impl<S: SignedConnectionApi> TreasuryUserApi for S {
 
 #[async_trait::async_trait]
 impl TreasurySudoApi for RootConnection {
-    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords> {
+    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxInfo> {
         let call = Treasury(approve_proposal { proposal_id });
 
         self.sudo_unchecked(call, status).await
     }
 
-    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxCoords> {
+    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxInfo> {
         let call = Treasury(reject_proposal { proposal_id });
 
         self.sudo_unchecked(call, status).await

--- a/aleph-client/src/pallets/utility.rs
+++ b/aleph-client/src/pallets/utility.rs
@@ -1,4 +1,4 @@
-use crate::{api, Call, SignedConnectionApi, TxInfo, TxStatus};
+use crate::{api, connections::TxInfo, Call, SignedConnectionApi, TxStatus};
 
 /// Pallet utility api.
 #[async_trait::async_trait]

--- a/aleph-client/src/pallets/utility.rs
+++ b/aleph-client/src/pallets/utility.rs
@@ -1,15 +1,15 @@
-use crate::{api, BlockHash, Call, SignedConnectionApi, TxStatus};
+use crate::{api, connections::TxCoords, Call, SignedConnectionApi, TxStatus};
 
 /// Pallet utility api.
 #[async_trait::async_trait]
 pub trait UtilityApi {
     /// API for [`batch`](https://paritytech.github.io/substrate/master/pallet_utility/pallet/struct.Pallet.html#method.batch) call.
-    async fn batch_call(&self, calls: Vec<Call>, status: TxStatus) -> anyhow::Result<BlockHash>;
+    async fn batch_call(&self, calls: Vec<Call>, status: TxStatus) -> anyhow::Result<TxCoords>;
 }
 
 #[async_trait::async_trait]
 impl<S: SignedConnectionApi> UtilityApi for S {
-    async fn batch_call(&self, calls: Vec<Call>, status: TxStatus) -> anyhow::Result<BlockHash> {
+    async fn batch_call(&self, calls: Vec<Call>, status: TxStatus) -> anyhow::Result<TxCoords> {
         let tx = api::tx().utility().batch(calls);
 
         self.send_tx(tx, status).await

--- a/aleph-client/src/pallets/utility.rs
+++ b/aleph-client/src/pallets/utility.rs
@@ -1,4 +1,4 @@
-use crate::{api, connections::TxInfo, Call, SignedConnectionApi, TxStatus};
+use crate::{api, Call, SignedConnectionApi, TxInfo, TxStatus};
 
 /// Pallet utility api.
 #[async_trait::async_trait]

--- a/aleph-client/src/pallets/utility.rs
+++ b/aleph-client/src/pallets/utility.rs
@@ -1,15 +1,15 @@
-use crate::{api, connections::TxCoords, Call, SignedConnectionApi, TxStatus};
+use crate::{api, connections::TxInfo, Call, SignedConnectionApi, TxStatus};
 
 /// Pallet utility api.
 #[async_trait::async_trait]
 pub trait UtilityApi {
     /// API for [`batch`](https://paritytech.github.io/substrate/master/pallet_utility/pallet/struct.Pallet.html#method.batch) call.
-    async fn batch_call(&self, calls: Vec<Call>, status: TxStatus) -> anyhow::Result<TxCoords>;
+    async fn batch_call(&self, calls: Vec<Call>, status: TxStatus) -> anyhow::Result<TxInfo>;
 }
 
 #[async_trait::async_trait]
 impl<S: SignedConnectionApi> UtilityApi for S {
-    async fn batch_call(&self, calls: Vec<Call>, status: TxStatus) -> anyhow::Result<TxCoords> {
+    async fn batch_call(&self, calls: Vec<Call>, status: TxStatus) -> anyhow::Result<TxInfo> {
         let tx = api::tx().utility().batch(calls);
 
         self.send_tx(tx, status).await

--- a/aleph-client/src/pallets/vesting.rs
+++ b/aleph-client/src/pallets/vesting.rs
@@ -1,8 +1,8 @@
 use subxt::ext::sp_runtime::MultiAddress;
 
 use crate::{
-    api, pallet_vesting::vesting_info::VestingInfo, AccountId, BlockHash, ConnectionApi,
-    SignedConnectionApi, TxInfo, TxStatus,
+    api, connections::TxInfo, pallet_vesting::vesting_info::VestingInfo, AccountId, BlockHash,
+    ConnectionApi, SignedConnectionApi, TxStatus,
 };
 
 /// Read only pallet vesting API.

--- a/aleph-client/src/pallets/vesting.rs
+++ b/aleph-client/src/pallets/vesting.rs
@@ -1,7 +1,7 @@
 use subxt::ext::sp_runtime::MultiAddress;
 
 use crate::{
-    api, connections::TxCoords, pallet_vesting::vesting_info::VestingInfo, AccountId, BlockHash,
+    api, connections::TxInfo, pallet_vesting::vesting_info::VestingInfo, AccountId, BlockHash,
     ConnectionApi, SignedConnectionApi, TxStatus,
 };
 
@@ -22,10 +22,10 @@ pub trait VestingApi {
 #[async_trait::async_trait]
 pub trait VestingUserApi {
     /// API for [`vest`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.vest) call.
-    async fn vest(&self, status: TxStatus) -> anyhow::Result<TxCoords>;
+    async fn vest(&self, status: TxStatus) -> anyhow::Result<TxInfo>;
 
     /// API for [`vest_other`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.vest_other) call.
-    async fn vest_other(&self, status: TxStatus, other: AccountId) -> anyhow::Result<TxCoords>;
+    async fn vest_other(&self, status: TxStatus, other: AccountId) -> anyhow::Result<TxInfo>;
 
     /// API for [`vested_transfer`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.vested_transfer) call.
     async fn vested_transfer(
@@ -33,7 +33,7 @@ pub trait VestingUserApi {
         receiver: AccountId,
         schedule: VestingInfo<u128, u32>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 
     /// API for [`merge_schedules`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.merge_schedules) call.
     async fn merge_schedules(
@@ -41,7 +41,7 @@ pub trait VestingUserApi {
         idx1: u32,
         idx2: u32,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords>;
+    ) -> anyhow::Result<TxInfo>;
 }
 
 #[async_trait::async_trait]
@@ -59,13 +59,13 @@ impl<C: ConnectionApi> VestingApi for C {
 
 #[async_trait::async_trait]
 impl<S: SignedConnectionApi> VestingUserApi for S {
-    async fn vest(&self, status: TxStatus) -> anyhow::Result<TxCoords> {
+    async fn vest(&self, status: TxStatus) -> anyhow::Result<TxInfo> {
         let tx = api::tx().vesting().vest();
 
         self.send_tx(tx, status).await
     }
 
-    async fn vest_other(&self, status: TxStatus, other: AccountId) -> anyhow::Result<TxCoords> {
+    async fn vest_other(&self, status: TxStatus, other: AccountId) -> anyhow::Result<TxInfo> {
         let tx = api::tx().vesting().vest_other(MultiAddress::Id(other));
 
         self.send_tx(tx, status).await
@@ -76,7 +76,7 @@ impl<S: SignedConnectionApi> VestingUserApi for S {
         receiver: AccountId,
         schedule: VestingInfo<u128, u32>,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx()
             .vesting()
             .vested_transfer(MultiAddress::Id(receiver), schedule);
@@ -89,7 +89,7 @@ impl<S: SignedConnectionApi> VestingUserApi for S {
         idx1: u32,
         idx2: u32,
         status: TxStatus,
-    ) -> anyhow::Result<TxCoords> {
+    ) -> anyhow::Result<TxInfo> {
         let tx = api::tx().vesting().merge_schedules(idx1, idx2);
 
         self.send_tx(tx, status).await

--- a/aleph-client/src/pallets/vesting.rs
+++ b/aleph-client/src/pallets/vesting.rs
@@ -1,8 +1,8 @@
 use subxt::ext::sp_runtime::MultiAddress;
 
 use crate::{
-    api, connections::TxInfo, pallet_vesting::vesting_info::VestingInfo, AccountId, BlockHash,
-    ConnectionApi, SignedConnectionApi, TxStatus,
+    api, pallet_vesting::vesting_info::VestingInfo, AccountId, BlockHash, ConnectionApi,
+    SignedConnectionApi, TxInfo, TxStatus,
 };
 
 /// Read only pallet vesting API.

--- a/aleph-client/src/pallets/vesting.rs
+++ b/aleph-client/src/pallets/vesting.rs
@@ -1,8 +1,8 @@
 use subxt::ext::sp_runtime::MultiAddress;
 
 use crate::{
-    api, pallet_vesting::vesting_info::VestingInfo, AccountId, BlockHash, ConnectionApi,
-    SignedConnectionApi, TxStatus,
+    api, connections::TxCoords, pallet_vesting::vesting_info::VestingInfo, AccountId, BlockHash,
+    ConnectionApi, SignedConnectionApi, TxStatus,
 };
 
 /// Read only pallet vesting API.
@@ -22,10 +22,10 @@ pub trait VestingApi {
 #[async_trait::async_trait]
 pub trait VestingUserApi {
     /// API for [`vest`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.vest) call.
-    async fn vest(&self, status: TxStatus) -> anyhow::Result<BlockHash>;
+    async fn vest(&self, status: TxStatus) -> anyhow::Result<TxCoords>;
 
     /// API for [`vest_other`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.vest_other) call.
-    async fn vest_other(&self, status: TxStatus, other: AccountId) -> anyhow::Result<BlockHash>;
+    async fn vest_other(&self, status: TxStatus, other: AccountId) -> anyhow::Result<TxCoords>;
 
     /// API for [`vested_transfer`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.vested_transfer) call.
     async fn vested_transfer(
@@ -33,7 +33,7 @@ pub trait VestingUserApi {
         receiver: AccountId,
         schedule: VestingInfo<u128, u32>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 
     /// API for [`merge_schedules`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.merge_schedules) call.
     async fn merge_schedules(
@@ -41,7 +41,7 @@ pub trait VestingUserApi {
         idx1: u32,
         idx2: u32,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash>;
+    ) -> anyhow::Result<TxCoords>;
 }
 
 #[async_trait::async_trait]
@@ -59,13 +59,13 @@ impl<C: ConnectionApi> VestingApi for C {
 
 #[async_trait::async_trait]
 impl<S: SignedConnectionApi> VestingUserApi for S {
-    async fn vest(&self, status: TxStatus) -> anyhow::Result<BlockHash> {
+    async fn vest(&self, status: TxStatus) -> anyhow::Result<TxCoords> {
         let tx = api::tx().vesting().vest();
 
         self.send_tx(tx, status).await
     }
 
-    async fn vest_other(&self, status: TxStatus, other: AccountId) -> anyhow::Result<BlockHash> {
+    async fn vest_other(&self, status: TxStatus, other: AccountId) -> anyhow::Result<TxCoords> {
         let tx = api::tx().vesting().vest_other(MultiAddress::Id(other));
 
         self.send_tx(tx, status).await
@@ -76,7 +76,7 @@ impl<S: SignedConnectionApi> VestingUserApi for S {
         receiver: AccountId,
         schedule: VestingInfo<u128, u32>,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx()
             .vesting()
             .vested_transfer(MultiAddress::Id(receiver), schedule);
@@ -89,7 +89,7 @@ impl<S: SignedConnectionApi> VestingUserApi for S {
         idx1: u32,
         idx2: u32,
         status: TxStatus,
-    ) -> anyhow::Result<BlockHash> {
+    ) -> anyhow::Result<TxCoords> {
         let tx = api::tx().vesting().merge_schedules(idx1, idx2);
 
         self.send_tx(tx, status).await

--- a/aleph-client/src/utility.rs
+++ b/aleph-client/src/utility.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use log::info;
 use primitives::{BlockNumber, EraIndex, SessionIndex};
-use subxt::{blocks::ExtrinsicEvents, ext::sp_core::Hasher, Config};
+use subxt::{blocks::ExtrinsicEvents, ext::sp_runtime::traits::Hash, Config};
 
 use crate::{
     connections::{AsConnection, TxInfo},
@@ -117,7 +117,7 @@ impl<C: AsConnection + Sync> BlocksApi for C {
 
         let extrinsic_events = block_body
             .extrinsics()
-            .find(|tx| tx_info.tx_hash == <AlephConfig as Config>::Hashing::hash(tx.bytes()))
+            .find(|tx| tx_info.tx_hash == <AlephConfig as Config>::Hashing::hash_of(&tx.bytes()))
             .ok_or(anyhow!("Couldn't find the transaction in the block."))?
             .events()
             .await

--- a/aleph-client/src/utility.rs
+++ b/aleph-client/src/utility.rs
@@ -1,10 +1,12 @@
+use anyhow::anyhow;
 use log::info;
 use primitives::{BlockNumber, EraIndex, SessionIndex};
+use subxt::{blocks::ExtrinsicEvents, ext::sp_core::Hasher, Config};
 
 use crate::{
-    connections::AsConnection,
+    connections::{AsConnection, TxInfo},
     pallets::{elections::ElectionsApi, staking::StakingApi},
-    BlockHash,
+    AlephConfig, BlockHash,
 };
 
 /// Block info API.
@@ -38,6 +40,9 @@ pub trait BlocksApi {
         &self,
         block: Option<BlockHash>,
     ) -> anyhow::Result<Option<BlockNumber>>;
+
+    /// Fetch all events that corresponds to the transaction identified by `tx_info`.
+    async fn get_tx_events(&self, tx_info: TxInfo) -> anyhow::Result<ExtrinsicEvents<AlephConfig>>;
 }
 
 /// Interaction logic between pallet session and pallet staking.
@@ -98,6 +103,27 @@ impl<C: AsConnection + Sync> BlocksApi for C {
 
     async fn get_block_number(&self, block: BlockHash) -> anyhow::Result<Option<BlockNumber>> {
         self.get_block_number_opt(Some(block)).await
+    }
+
+    async fn get_tx_events(&self, tx_info: TxInfo) -> anyhow::Result<ExtrinsicEvents<AlephConfig>> {
+        let block_body = self
+            .as_connection()
+            .as_client()
+            .blocks()
+            .at(Some(tx_info.block_hash))
+            .await?
+            .body()
+            .await?;
+
+        let extrinsic_events = block_body
+            .extrinsics()
+            .find(|tx| tx_info.tx_hash == <AlephConfig as Config>::Hashing::hash(tx.bytes()))
+            .ok_or(anyhow!("Couldn't find the transaction in the block."))?
+            .events()
+            .await
+            .map_err(|e| anyhow!("Couldn't fetch events for the transaction: {e:?}"))?;
+
+        Ok(extrinsic_events)
     }
 }
 

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.6.0"
+version = "2.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.8.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/cliain/src/contracts.rs
+++ b/bin/cliain/src/contracts.rs
@@ -58,7 +58,7 @@ pub async fn upload_code(
             .await
     });
 
-    let _block_hash = signed_connection
+    let _tx_info = signed_connection
         .upload_code(
             wasm,
             storage_deposit(storage_deposit_limit),
@@ -109,7 +109,7 @@ pub async fn instantiate(
             .await
     });
 
-    let _block_hash = signed_connection
+    let _tx_info = signed_connection
         .instantiate(
             code_hash,
             balance,
@@ -182,7 +182,7 @@ pub async fn instantiate_with_code(
             .await
     });
 
-    let _block_hash = signed_connection
+    let _tx_info = signed_connection
         .instantiate_with_code(
             wasm,
             balance,
@@ -227,7 +227,7 @@ pub async fn call(
 
     debug!("Encoded call data {:?}", data);
 
-    let _block_hash = signed_connection
+    let _tx_info = signed_connection
         .call(
             destination,
             balance,
@@ -267,7 +267,7 @@ pub async fn remove_code(
             .await
     });
 
-    let _block_hash = signed_connection
+    let _tx_info = signed_connection
         .remove_code(code_hash, TxStatus::InBlock)
         .await?;
 

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.8.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/src/test/fee.rs
+++ b/e2e-tests/src/test/fee.rs
@@ -2,8 +2,7 @@ use aleph_client::{
     api::transaction_payment::events::TransactionFeePaid,
     pallets::{balances::BalanceUserApi, fee::TransactionPaymentApi, system::SystemSudoApi},
     utility::BlocksApi,
-    waiting::{AlephWaiting, BlockStatus},
-    AccountId, RootConnection, SignedConnection, SignedConnectionApi, TxStatus,
+    AccountId, RootConnection, SignedConnection, TxStatus,
 };
 use log::info;
 use primitives::Balance;
@@ -107,9 +106,6 @@ pub async fn current_fees(
     transfer_value: Balance,
 ) -> (Balance, u128) {
     let actual_multiplier = connection.get_next_fee_multiplier(None).await;
-
-    let waiting_connection = connection.clone();
-    let signer = connection.account_id().clone();
 
     let tx_info = match tip {
         None => connection.transfer(to, transfer_value, TxStatus::Finalized),

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.6.0"
+version = "2.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.8.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
# Description

This PR introduces two things:
 - now all methods like `send_tx` return `TxInfo`, which currently is a simple struct containing `TxHash` and `BlockHash`
 - there's a new method `get_tx_events` that returns `ExtrinsicEvents` struct

There's also an example of usage in e2e test (fee).

Supporting contract events (i.e. merging new utility with decoding) will be done in another, non-breaking 

Reasoning for `ExtrinsicEvents`:
 - it is a `subxt`'s struct that already exposes handy API for filtering/extracting events; so it is ready to use so we don't have to provide our own, similar implementations
 - `ExtrinsicEvents` has `pub(crate)` constructor, which is used in two places in `subxt`: `TxInBlock::fetch_events` and `Extrinsic::events`. The former one is kinda out of external usage, so we have to create `Block`, `BlockBody` and `Extrinsic` intermediate objects. Anyway, works quite well and is still fairly concise

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- I have made corresponding changes to the existing documentation
- I have created new documentation
- I have bumped aleph-client version if relevant
