### PR TITLE
Decode return value as T instead of Result<T>.

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aleph_client"
 # TODO bump major version when API stablize
-version = "2.8.0"
+version = "2.8.1"
 edition = "2021"
 license = "Apache 2.0"
 

--- a/aleph-client/src/contract/mod.rs
+++ b/aleph-client/src/contract/mod.rs
@@ -120,7 +120,7 @@ impl ContractInstance {
             .result
             .map_err(|e| anyhow!("Contract exec failed {:?}", e))?;
         let decoded = self.decode(message, result.data)?;
-        ConvertibleValue(decoded).try_into()?
+        Ok(ConvertibleValue(decoded).try_into()?)
     }
 
     /// Executes a 0-argument contract call.

--- a/aleph-client/src/contract/mod.rs
+++ b/aleph-client/src/contract/mod.rs
@@ -120,7 +120,7 @@ impl ContractInstance {
             .result
             .map_err(|e| anyhow!("Contract exec failed {:?}", e))?;
         let decoded = self.decode(message, result.data)?;
-        Ok(ConvertibleValue(decoded).try_into()?)
+        ConvertibleValue(decoded).try_into()
     }
 
     /// Executes a 0-argument contract call.


### PR DESCRIPTION
# Description

Fix a bug where compiler would infer that the type of the decoded value is `Result<T>` rather than `T`. This resulted in errors when parsing the data, like:
```
Error: Expected ConvertibleValue(UInt(1000000)) to be an Ok(_) or Err(_) tuple.
```
b/c the used `ConvertibleValue` instance was for `Result<T>` but the value being decoded was just `T`.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have bumped aleph-client version if relevant
