### PR TITLE
`aleph-client`: Fetch contract events

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aleph_client"
 # TODO bump major version when API stablize
-version = "2.9.1"
+version = "2.10.0"
 edition = "2021"
 license = "Apache 2.0"
 

--- a/aleph-client/src/connections.rs
+++ b/aleph-client/src/connections.rs
@@ -113,7 +113,9 @@ pub trait ConnectionApi: Sync {
 /// Data regarding submitted transaction.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct TxInfo {
+    /// Hash of the block containing tx.
     pub block_hash: BlockHash,
+    /// Hash of the transaction itself.
     pub tx_hash: TxHash,
 }
 

--- a/aleph-client/src/contract/mod.rs
+++ b/aleph-client/src/contract/mod.rs
@@ -6,7 +6,7 @@
 //! ```no_run
 //! # use anyhow::{Result, Context};
 //! # use aleph_client::{AccountId, Balance};
-//! # use aleph_client::{Connection, SignedConnection};
+//! # use aleph_client::{Connection, SignedConnection, TxInfo};
 //! # use aleph_client::contract::ContractInstance;
 //! #
 //! #[derive(Debug)]
@@ -24,7 +24,7 @@
 //!         })
 //!     }
 //!
-//!     async fn transfer(&self, conn: &SignedConnection, to: AccountId, amount: Balance) -> Result<()> {
+//!     async fn transfer(&self, conn: &SignedConnection, to: AccountId, amount: Balance) -> Result<TxInfo> {
 //!         self.contract.contract_exec(
 //!             conn,
 //!             "PSP22::transfer",
@@ -52,6 +52,7 @@ use contract_transcode::ContractMessageTranscoder;
 pub use convertible_value::ConvertibleValue;
 
 use crate::{
+    connections::TxInfo,
     contract_transcode::Value,
     pallets::contract::{ContractCallArgs, ContractRpc, ContractsUserApi},
     sp_weights::weight_v2::Weight,
@@ -128,7 +129,7 @@ impl ContractInstance {
         &self,
         conn: &C,
         message: &str,
-    ) -> Result<()> {
+    ) -> Result<TxInfo> {
         self.contract_exec::<C, String>(conn, message, &[]).await
     }
 
@@ -138,7 +139,7 @@ impl ContractInstance {
         conn: &C,
         message: &str,
         args: &[S],
-    ) -> Result<()> {
+    ) -> Result<TxInfo> {
         self.contract_exec_value::<C, S>(conn, message, args, 0)
             .await
     }
@@ -149,7 +150,7 @@ impl ContractInstance {
         conn: &C,
         message: &str,
         value: Balance,
-    ) -> Result<()> {
+    ) -> Result<TxInfo> {
         self.contract_exec_value::<C, String>(conn, message, &[], value)
             .await
     }
@@ -161,7 +162,7 @@ impl ContractInstance {
         message: &str,
         args: &[S],
         value: Balance,
-    ) -> Result<()> {
+    ) -> Result<TxInfo> {
         let data = self.encode(message, args)?;
         conn.call(
             self.address.clone(),
@@ -175,7 +176,6 @@ impl ContractInstance {
             TxStatus::InBlock,
         )
         .await
-        .map(|_| ())
     }
 
     fn encode<S: AsRef<str> + Debug>(&self, message: &str, args: &[S]) -> Result<Vec<u8>> {

--- a/aleph-client/src/lib.rs
+++ b/aleph-client/src/lib.rs
@@ -61,7 +61,7 @@ pub type SubxtClient = OnlineClient<AlephConfig>;
 
 pub use connections::{
     AsConnection, AsSigned, Connection, ConnectionApi, RootConnection, SignedConnection,
-    SignedConnectionApi, SudoCall,
+    SignedConnectionApi, SudoCall, TxInfo,
 };
 
 /// When submitting a transaction, wait for given status before proceeding.

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/src/test/adder.rs
+++ b/e2e-tests/src/test/adder.rs
@@ -1,19 +1,74 @@
-use std::{fmt::Debug, str::FromStr};
+use std::{fmt::Debug, str::FromStr, sync::Arc};
 
 use aleph_client::{
-    contract::{event::get_contract_events, ContractInstance},
+    contract::{
+        event::{get_contract_events, listen_contract_events},
+        ContractInstance,
+    },
     contract_transcode::Value,
     AccountId, ConnectionApi, SignedConnectionApi, TxInfo,
 };
 use anyhow::{anyhow, Context, Result};
 use assert2::assert;
+use futures::{channel::mpsc::unbounded, StreamExt};
 
 use crate::{config::setup_test, test::helpers::basic_test_context};
 
-/// This test exercises the aleph-client code for interacting with contracts by testing a simple contract that maintains
-/// some state and publishes some events.
+/// This test exercises the aleph-client code for interacting with contracts by testing a simple
+/// contract that maintains some state and publishes some events. The events are obtained by
+/// listening mechanism.
 #[tokio::test]
-pub async fn adder() -> Result<()> {
+pub async fn adder_events_listening() -> Result<()> {
+    let config = setup_test();
+
+    let (conn, _authority, account) = basic_test_context(config).await?;
+
+    let contract = Arc::new(AdderInstance::new(
+        &config.test_case_params.adder,
+        &config.test_case_params.adder_metadata,
+    )?);
+
+    let listen_conn = conn.clone();
+    let listen_contract = contract.clone();
+    let (tx, mut rx) = unbounded();
+    let listen = || async move {
+        listen_contract_events(&listen_conn, &[listen_contract.as_ref().into()], tx).await?;
+        <Result<(), anyhow::Error>>::Ok(())
+    };
+    let join = tokio::spawn(listen());
+
+    let increment = 10;
+    let before = contract.get(&conn).await?;
+
+    contract.add(&account.sign(&conn), increment).await?;
+
+    let event = rx.next().await.context("No event received")??;
+    assert!(event.name == Some("ValueChanged".to_string()));
+    assert!(event.contract == *contract.contract.address());
+    assert!(event.data["new_value"] == Value::UInt(before as u128 + 10));
+
+    let after = contract.get(&conn).await?;
+    assert!(after == before + increment);
+
+    let new_name = "test";
+    contract.set_name(&account.sign(&conn), None).await?;
+    assert!(contract.get_name(&conn).await?.is_none());
+    contract
+        .set_name(&account.sign(&conn), Some(new_name))
+        .await?;
+    assert!(contract.get_name(&conn).await? == Some(new_name.to_string()));
+
+    rx.close();
+    join.await??;
+
+    Ok(())
+}
+
+/// This test exercises the aleph-client code for interacting with contracts by testing a simple
+/// contract that maintains some state and publishes some events. The events are obtained by
+/// fetching mechanism.
+#[tokio::test]
+pub async fn adder_fetching_events() -> Result<()> {
     let config = setup_test();
 
     let (conn, _authority, account) = basic_test_context(config).await?;
@@ -28,10 +83,9 @@ pub async fn adder() -> Result<()> {
 
     let tx_info = contract.add(&account.sign(&conn), increment).await?;
     let events = get_contract_events(&conn, &contract.contract, tx_info).await?;
-    let event = match events.len() {
-        0 => return Err(anyhow!("No event received")),
-        1 => events[0].clone(),
-        _ => return Err(anyhow!("Too many events received")),
+    let event = match &*events {
+        [event] => event,
+        _ => return Err(anyhow!("Expected single event, but got {events:?}")),
     };
 
     assert!(event.name == Some("ValueChanged".to_string()));

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
# Description

This PR introduces `get_contract_events` call which, similarly to `get_tx_events`, fetches all events that were emitted by a contract call and decodes them using metadata. This covers part of cases, when one had to use subscribing mechanism. 

One e2e test has been adapted to the new API.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- I have added tests
- I have made neccessary updates to the Infrastructure
- I have made corresponding changes to the existing documentation
- I have created new documentation
- I have bumped aleph-client version if relevant
