### PR TITLE
Fix run_nodes.sh script

### DIFF
--- a/scripts/run_nodes.sh
+++ b/scripts/run_nodes.sh
@@ -54,7 +54,7 @@ validator_ids_string="${validator_ids_string//${IFS:0:1}/,}"
 echo "Bootstrapping chain for nodes 0..$((N_VALIDATORS - 1))"
 ./target/release/aleph-node bootstrap-chain --raw --base-path "$BASE_PATH" --account-ids "$validator_ids_string" --chain-type local > "$BASE_PATH/chainspec.json"
 
-for i in $(seq "$N_VALIDATORS" "$(( N_VALIDATORS + N_NON_VALIDATORS - 1 ))"); do
+for i in $(seq 0 "$(( N_VALIDATORS + N_NON_VALIDATORS - 1 ))"); do
   echo "Bootstrapping node $i"
   account_id=${account_ids[$i]}
   ./target/release/aleph-node bootstrap-node --base-path "$BASE_PATH/$account_id" --account-id "$account_id" --chain-type local


### PR DESCRIPTION
# Description

`seq n m` won't iterate at all if `n > m`:
```sh
mateusz@DESKTOP-O514E9R:~/aleph/aleph-node$ for i in $(seq 2 0); do echo "${i}"; done
mateusz@DESKTOP-O514E9R:~/aleph/aleph-node$ for i in $(seq 0 1); do echo "${i}"; done
0
1
```
so for `./scripts/run_nodes.sh -v 2` we get:
```sh
N_VALIDATORS=2 # from -v 2
N_NON_VALIDATORS=0 # (default)
for i in $(seq "$N_VALIDATORS" "$(( N_VALIDATORS + N_NON_VALIDATORS - 1 ))"); do
```
resolves to
```sh
for i in $(seq 2 1); done
```

`seq` can be made to work with decreasing sequences:
```sh
mateusz@DESKTOP-O514E9R:~/aleph/aleph-node$ for i in $(seq 2 -1 0); do echo "Test: ${i}"; done
Test: 2
Test: 1
Test: 0
```
but even then the script would fail: last element in the key-generating loop is `N_VALIDATORS + N_NON_VALIDATORS - 1` (`N_VALIDATORS - 1 = 1` in our example) while the `bootstrap-node` starts from `N_VALIDATORS == 2` - it's _off by one error_ and we fail with _invalid account id_ error on the fail iteration of the `bootstrap-node` loop.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
