### PR TITLE
A0-1304: add state pruning compatibility

### DIFF
--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -4,7 +4,7 @@ use aleph_node::{new_authority, new_full, new_partial, Cli, Subcommand};
 #[cfg(feature = "try-runtime")]
 use aleph_runtime::Block;
 use log::warn;
-use sc_cli::{clap::Parser, PruningParams, SubstrateCli};
+use sc_cli::{clap::Parser, CliConfiguration, PruningParams, SubstrateCli};
 use sc_network::config::Role;
 use sc_service::PartialComponents;
 
@@ -116,8 +116,8 @@ fn main() -> sc_cli::Result<()> {
             let runner = cli.create_runner(&cli.run)?;
             if cli.aleph.experimental_pruning() {
                 warn!("Experimental_pruning was turned on. Usage of this flag can lead to misbehaviour, which can be punished. State pruning: {:?}; Blocks pruning: {:?};", 
-                    cli.run.import_params.pruning_params.state_pruning(),
-                    cli.run.import_params.pruning_params.blocks_pruning(),
+                    cli.run.state_pruning()?.unwrap_or_default(),
+                    cli.run.blocks_pruning()?,
                 );
             } else if overwritten_pruning {
                 warn!("Pruning not supported. Switching to keeping all block bodies and states.");

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -4,27 +4,29 @@ use aleph_node::{new_authority, new_full, new_partial, Cli, Subcommand};
 #[cfg(feature = "try-runtime")]
 use aleph_runtime::Block;
 use log::warn;
-use sc_cli::{clap::Parser, SubstrateCli};
+use sc_cli::{clap::Parser, PruningParams, SubstrateCli};
 use sc_network::config::Role;
 use sc_service::PartialComponents;
 
+const STATE_PRUNING: &str = "archive";
+const BLOCKS_PRUNING: &str = "archive-canonical";
+
+fn pruning_changed(params: &PruningParams) -> bool {
+    let state_pruning_changed =
+        params.state_pruning != Some(STATE_PRUNING.into()) && params.state_pruning.is_some();
+
+    let blocks_pruning_changed =
+        params.blocks_pruning != Some(BLOCKS_PRUNING.into()) && params.blocks_pruning.is_some();
+
+    state_pruning_changed || blocks_pruning_changed
+}
+
 fn main() -> sc_cli::Result<()> {
     let mut cli = Cli::parse();
+    let overwritten_pruning = pruning_changed(&cli.run.import_params.pruning_params);
     if !cli.aleph.experimental_pruning() {
-        if cli
-            .run
-            .import_params
-            .pruning_params
-            .blocks_pruning
-            .is_some()
-            || cli.run.import_params.pruning_params.state_pruning != Some("archive".into())
-        {
-            warn!("Pruning not supported. Switching to keeping all block bodies and states.");
-            cli.run.import_params.pruning_params.blocks_pruning = None;
-            cli.run.import_params.pruning_params.state_pruning = Some("archive".into());
-        }
-    } else {
-        warn!("Pruning not supported, but flag experimental_pruning was turned on. Usage of this flag can lead to misbehaviour, which can be punished.");
+        cli.run.import_params.pruning_params.state_pruning = Some(STATE_PRUNING.into());
+        cli.run.import_params.pruning_params.blocks_pruning = Some(BLOCKS_PRUNING.into());
     }
 
     match &cli.subcommand {
@@ -112,6 +114,15 @@ fn main() -> sc_cli::Result<()> {
             .into()),
         None => {
             let runner = cli.create_runner(&cli.run)?;
+            if cli.aleph.experimental_pruning() {
+                warn!("Experimental_pruning was turned on. Usage of this flag can lead to misbehaviour, which can be punished. State pruning: {:?}; Blocks pruning: {:?};", 
+                    cli.run.import_params.pruning_params.state_pruning(),
+                    cli.run.import_params.pruning_params.blocks_pruning(),
+                );
+            } else if overwritten_pruning {
+                warn!("Pruning not supported. Switching to keeping all block bodies and states.");
+            }
+
             let aleph_cli_config = cli.aleph;
             runner.run_node_until_exit(|config| async move {
                 match config.role {
@@ -124,5 +135,33 @@ fn main() -> sc_cli::Result<()> {
                 }
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sc_service::{BlocksPruning, PruningMode};
+
+    use super::{PruningParams, BLOCKS_PRUNING, STATE_PRUNING};
+
+    #[test]
+    fn pruning_sanity_check() {
+        let state_pruning = Some(String::from(STATE_PRUNING));
+        let blocks_pruning = Some(String::from(BLOCKS_PRUNING));
+
+        let pruning_params = PruningParams {
+            state_pruning,
+            blocks_pruning,
+        };
+
+        assert_eq!(
+            pruning_params.blocks_pruning().unwrap(),
+            BlocksPruning::KeepFinalized
+        );
+
+        assert_eq!(
+            pruning_params.state_pruning().unwrap().unwrap(),
+            PruningMode::ArchiveAll
+        );
     }
 }

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -28,7 +28,7 @@ use sp_blockchain::Backend as _;
 use sp_consensus_aura::{sr25519::AuthorityPair as AuraPair, Slot};
 use sp_runtime::{
     generic::BlockId,
-    traits::{Block as BlockT, Header as HeaderT, Zero},
+    traits::{Block as BlockT, Header as HeaderT},
 };
 
 use crate::{aleph_cli::AlephCli, chain_spec::DEFAULT_BACKUP_FOLDER, executor::AlephExecutor};
@@ -311,17 +311,19 @@ pub fn new_authority(
             .path(),
     );
 
+    let finalized = client.info().finalized_number;
+
     let session_period = SessionPeriod(
         client
             .runtime_api()
-            .session_period(&BlockId::Number(Zero::zero()))
+            .session_period(&BlockId::Number(finalized))
             .unwrap(),
     );
 
     let millisecs_per_block = MillisecsPerBlock(
         client
             .runtime_api()
-            .millisecs_per_block(&BlockId::Number(Zero::zero()))
+            .millisecs_per_block(&BlockId::Number(finalized))
             .unwrap(),
     );
 
@@ -452,17 +454,19 @@ pub fn new_full(
         justification_tx,
     )?;
 
+    let finalized = client.info().finalized_number;
+
     let session_period = SessionPeriod(
         client
             .runtime_api()
-            .session_period(&BlockId::Number(Zero::zero()))
+            .session_period(&BlockId::Number(finalized))
             .unwrap(),
     );
 
     let millisecs_per_block = MillisecsPerBlock(
         client
             .runtime_api()
-            .millisecs_per_block(&BlockId::Number(Zero::zero()))
+            .millisecs_per_block(&BlockId::Number(finalized))
             .unwrap(),
     );
 

--- a/finality-aleph/src/nodes/nonvalidator_node.rs
+++ b/finality-aleph/src/nodes/nonvalidator_node.rs
@@ -34,11 +34,12 @@ where
     let map_updater = SessionMapUpdater::<_, _, B>::new(
         AuthorityProviderImpl::new(client.clone()),
         FinalityNotificatorImpl::new(client.clone()),
+        session_period,
     );
     let session_authorities = map_updater.readonly_session_map();
     spawn_handle.spawn("aleph/updater", None, async move {
         debug!(target: "aleph-party", "SessionMapUpdater has started.");
-        map_updater.run(session_period).await
+        map_updater.run().await
     });
     let (_, handler_task) = setup_justification_handler(JustificationParams {
         justification_rx,

--- a/finality-aleph/src/nodes/validator_node.rs
+++ b/finality-aleph/src/nodes/validator_node.rs
@@ -103,11 +103,12 @@ where
     let map_updater = SessionMapUpdater::<_, _, B>::new(
         AuthorityProviderImpl::new(client.clone()),
         FinalityNotificatorImpl::new(client.clone()),
+        session_period,
     );
     let session_authorities = map_updater.readonly_session_map();
     spawn_handle.spawn("aleph/updater", None, async move {
         debug!(target: "aleph-party", "SessionMapUpdater has started.");
-        map_updater.run(session_period).await
+        map_updater.run().await
     });
 
     let (authority_justification_tx, handler_task) =

--- a/finality-aleph/src/sync/substrate/verification/cache.rs
+++ b/finality-aleph/src/sync/substrate/verification/cache.rs
@@ -38,7 +38,7 @@ impl Display for CacheError {
             UnknownAuthorities(session) => {
                 write!(
                     f,
-                    "authorities for session {:?} not present on chain. Most likely state is already pruned",
+                    "authorities for session {:?} not known even though they should be",
                     session
                 )
             }

--- a/finality-aleph/src/sync/substrate/verification/cache.rs
+++ b/finality-aleph/src/sync/substrate/verification/cache.rs
@@ -38,7 +38,7 @@ impl Display for CacheError {
             UnknownAuthorities(session) => {
                 write!(
                     f,
-                    "authorities for session {:?} not present on chain even though they should be",
+                    "authorities for session {:?} not present on chain. Most likely state is already pruned",
                     session
                 )
             }


### PR DESCRIPTION
# Description

This PR add compatibility for running Aleph Node with pruning turned on. For now it stays as an experimental feature and because of that whenever using it, appropriate warning will be logged.

To use pruning one needs to provide `--experimental-pruning` parameter. When providing it, `--state-pruning` and `--blocks-pruning` can be set to possible values:
* `archive` - Keep all blocks/states
* `archive-canonical` - Keep only finalized blocks/states
* `number` -  Keep the last `number` of finalized blocks/states

For now `archive-canonical` setting does not work for state pruning. 

Default values are
* `--state-pruning=archive`
* `--blocks-pruning=archive-canonical`

Using experimental pruning should result in warning similar to:
```
WARN main aleph_node: Experimental_pruning was turned on. Usage of this flag can lead to misbehaviour, which can be punished. State pruning: Constrained(Constraints { max_blocks: Some(1000), max_mem: None }); Blocks pruning: Some(1000);
```
Changing pruning parameters without setting experimental pruning should result in:
```
WARN main aleph_node: Pruning not supported. Switching to keeping all block bodies and states.    
```

## Changelog
- Fix experimental pruning warnings not showing up (logger is not yet initialized before `cli.create_runner(...)`)
- Change `runtime_api` calls in code to reference last finalized block (not genesis block, which can be discarded)
- `SessionMap` now supports old states being discarded during catch-up phase (only state required is of first block, of session in which `top_finalized` block is. This requirement can be narrowed down, and we can ask for state of last finalized block. Not needed yet, as we plan to use `2048` as recommended pruning setting)
- Add sanity check, so that we are not suprised in the future about pruning parameters values

# Checklist:

- I have added tests
