### PR TITLE
A0-1910 Added migration for a multisig

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -782,6 +782,7 @@ pub type Executive = frame_executive::Executive<
             migrations::original_staking_migrations::StakingMigrationV11OldPallet,
         >,
         pallet_staking::migrations::v12::MigrateToV12<Runtime>,
+        pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
     ),
 >;
 


### PR DESCRIPTION
# Description

PR 2/... for fixing Testnet migrations.

This was rather simple, just use the original migration (that does nothing apart from bumping `StorageVersion`)

See below log for test result
[try-runtime.log](https://github.com/Cardinal-Cryptography/aleph-node/files/10545903/try-runtime.log)

```
2023-01-31 11:41:25.426  INFO                 main runtime::multisig: [0] ✍️ Number of calls to refund and delete: 0    
```

Temporarily target branch is different as the original PR is not merged yet

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

