### PR TITLE
A0-1910 Added migration for a Scheduler

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -783,6 +783,7 @@ pub type Executive = frame_executive::Executive<
         >,
         pallet_staking::migrations::v12::MigrateToV12<Runtime>,
         pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
+        migrations::custom_scheduler_migration::MigrateToV3<Runtime>,
     ),
 >;
 

--- a/bin/runtime/src/migrations/custom_scheduler_migration.rs
+++ b/bin/runtime/src/migrations/custom_scheduler_migration.rs
@@ -10,7 +10,7 @@ use sp_std::vec::Vec;
 
 use crate::Weight;
 
-const TARGET: &'static str = "runtime::scheduler::migration";
+const TARGET: &str = "runtime::scheduler::migration";
 
 /// Custom migrations the scheduler pallet from V0 to V3 that only bumps StorageVersion to 3
 pub struct MigrateToV3<T>(sp_std::marker::PhantomData<T>);

--- a/bin/runtime/src/migrations/custom_scheduler_migration.rs
+++ b/bin/runtime/src/migrations/custom_scheduler_migration.rs
@@ -1,0 +1,77 @@
+use codec::{Decode, Encode};
+use frame_support::{
+    log,
+    pallet_prelude::{Get, StorageVersion},
+    traits::OnRuntimeUpgrade,
+};
+use pallet_scheduler::{Agenda, Config, Pallet};
+#[cfg(feature = "try-runtime")]
+use sp_std::vec::Vec;
+
+use crate::Weight;
+
+const TARGET: &'static str = "runtime::scheduler::migration";
+
+/// Custom migrations the scheduler pallet from V0 to V3 that only bumps StorageVersion to 3
+pub struct MigrateToV3<T>(sp_std::marker::PhantomData<T>);
+
+impl<T: Config> OnRuntimeUpgrade for MigrateToV3<T> {
+    fn on_runtime_upgrade() -> Weight {
+        let version = StorageVersion::get::<Pallet<T>>();
+        if version != 0 {
+            log::warn!(
+                target: TARGET,
+                "skipping v0 to v3 migration: executed on wrong storage version.\
+				Expected version 0, found {:?}",
+                version,
+            );
+            return T::DbWeight::get().reads(1);
+        }
+
+        let agendas = Agenda::<T>::iter_keys().count() as u32;
+        if agendas != 0 {
+            log::warn!(
+                target: TARGET,
+                "skipping v0 to v3 migration: Agendas are not empty. Found {:?} agendas.",
+                agendas,
+            );
+            return T::DbWeight::get().reads(2);
+        }
+
+        StorageVersion::new(3).put::<Pallet<T>>();
+        T::DbWeight::get().reads_writes(2, 1)
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+        assert_eq!(
+            StorageVersion::get::<Pallet<T>>(),
+            0,
+            "Can only upgrade from version 0"
+        );
+
+        let agendas = Agenda::<T>::iter_keys().count() as u32;
+        assert_eq!(agendas, 0, "Agendas should be empty pre-upgrade!");
+
+        Ok(agendas.encode())
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {
+        assert_eq!(StorageVersion::get::<Pallet<T>>(), 3, "Must upgrade");
+
+        let old_agendas: u32 =
+            Decode::decode(&mut &state[..]).expect("pre_upgrade provides a valid state; qed");
+        assert_eq!(old_agendas, 0, "Agendas should be empty pre-upgrade!");
+
+        let new_agendas = Agenda::<T>::iter_keys().count() as u32;
+        assert_eq!(new_agendas, 0, "Agendas should be empty post-upgrade!");
+
+        log::info!(
+            target: TARGET,
+            "Migrated 0 agendas, bumped StorageVersion to V3"
+        );
+
+        Ok(())
+    }
+}

--- a/bin/runtime/src/migrations/custom_scheduler_migration.rs
+++ b/bin/runtime/src/migrations/custom_scheduler_migration.rs
@@ -35,11 +35,11 @@ impl<T: Config> OnRuntimeUpgrade for MigrateToV3<T> {
                 "skipping v0 to v3 migration: Agendas are not empty. Found {:?} agendas.",
                 agendas,
             );
-            return T::DbWeight::get().reads(2);
+            return T::DbWeight::get().reads(1 + agendas as u64);
         }
 
         StorageVersion::new(3).put::<Pallet<T>>();
-        T::DbWeight::get().reads_writes(2, 1)
+        T::DbWeight::get().reads_writes(1 + agendas as u64, 1)
     }
 
     #[cfg(feature = "try-runtime")]

--- a/bin/runtime/src/migrations/mod.rs
+++ b/bin/runtime/src/migrations/mod.rs
@@ -1,2 +1,3 @@
+pub mod custom_scheduler_migration;
 pub mod custom_staking_migrations;
 pub mod original_staking_migrations;


### PR DESCRIPTION
# Description

PR 3/... for fixing Testetn migrations. This time custom Scheduler migration to `StorageVersion` 3 with some asserts that the `Agendas` map is empty. There's no such original migration that can be used here.

[try-runtime.log](https://github.com/Cardinal-Cryptography/aleph-node/files/10546463/try-runtime.log)

```
2023-01-31 13:48:20.596  INFO main remote-ext: downloaded data for module Scheduler (count: 1 / prefix: 3db7a24cfdc9de785974746c14a99df9).    
...
2023-01-31 13:48:23.864  INFO                 main runtime::scheduler::migration: Migrated 0 agendas, bumped StorageVersion to V3    
```


## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

<!-- delete when not applicable to your PR -->

- I have added tests

