### PR TITLE
A0-1916: Proper tangling and path verification

### DIFF
--- a/relations/src/lib.rs
+++ b/relations/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate core;
+
 mod environment;
 mod linear;
 mod merkle_tree;

--- a/relations/src/lib.rs
+++ b/relations/src/lib.rs
@@ -1,7 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate core;
-
 mod environment;
 mod linear;
 mod merkle_tree;

--- a/relations/src/shielder/circuit_utils.rs
+++ b/relations/src/shielder/circuit_utils.rs
@@ -1,6 +1,7 @@
 use core::borrow::Borrow;
 #[cfg(feature = "std")]
 use std::fmt::{Display, Formatter};
+use std::ops::Index;
 
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
@@ -34,9 +35,13 @@ impl PathShapeVar {
     pub(super) fn len(&self) -> usize {
         self.shape.len()
     }
+}
 
-    pub(super) fn at(&self, i: usize) -> &Boolean<CircuitField> {
-        &self.shape[i]
+impl Index<usize> for PathShapeVar {
+    type Output = Boolean<CircuitField>;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.shape[index]
     }
 }
 

--- a/relations/src/shielder/circuit_utils.rs
+++ b/relations/src/shielder/circuit_utils.rs
@@ -7,10 +7,7 @@ use ark_r1cs_std::{
     boolean::Boolean,
     R1CSVar,
 };
-use ark_relations::{
-    ns,
-    r1cs::{ConstraintSystemRef, Namespace, SynthesisError, SynthesisError::AssignmentMissing},
-};
+use ark_relations::r1cs::{Namespace, SynthesisError};
 
 use crate::CircuitField;
 

--- a/relations/src/shielder/circuit_utils.rs
+++ b/relations/src/shielder/circuit_utils.rs
@@ -1,0 +1,72 @@
+use core::borrow::Borrow;
+#[cfg(feature = "std")]
+use std::fmt::{Display, Formatter};
+
+use ark_r1cs_std::{
+    alloc::{AllocVar, AllocationMode},
+    boolean::Boolean,
+    R1CSVar,
+};
+use ark_relations::{
+    ns,
+    r1cs::{ConstraintSystemRef, Namespace, SynthesisError, SynthesisError::AssignmentMissing},
+};
+
+use crate::CircuitField;
+
+#[derive(Clone, Debug)]
+pub(super) struct PathShapeVar {
+    shape: Vec<Boolean<CircuitField>>,
+}
+
+#[cfg(feature = "std")]
+impl Display for PathShapeVar {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:?}",
+            self.shape
+                .iter()
+                .map(|b| b.value().map(|boo| if boo { "left" } else { "right" }))
+                .collect::<Vec<_>>()
+        )
+    }
+}
+
+impl PathShapeVar {
+    pub(super) fn len(&self) -> usize {
+        self.shape.len()
+    }
+
+    pub(super) fn at(&self, i: usize) -> &Boolean<CircuitField> {
+        &self.shape[i]
+    }
+}
+
+impl AllocVar<(u8, Result<u64, SynthesisError>), CircuitField> for PathShapeVar {
+    fn new_variable<T: Borrow<(u8, Result<u64, SynthesisError>)>>(
+        cs: impl Into<Namespace<CircuitField>>,
+        f: impl FnOnce() -> Result<T, SynthesisError>,
+        mode: AllocationMode,
+    ) -> Result<Self, SynthesisError> {
+        let ns = cs.into();
+        let cs = ns.cs();
+
+        let mut shape = vec![];
+
+        let (path_length, maybe_leaf_index) = *f()?.borrow();
+
+        for i in 0..path_length {
+            shape.push(Boolean::new_variable(
+                cs.clone(),
+                || {
+                    let current_index = maybe_leaf_index? / (1 << i);
+                    Ok(current_index & 1 != 1 || current_index == 1)
+                },
+                mode,
+            )?);
+        }
+
+        Ok(Self { shape })
+    }
+}

--- a/relations/src/shielder/deposit.rs
+++ b/relations/src/shielder/deposit.rs
@@ -1,4 +1,3 @@
-use ark_ff::BigInteger256;
 use ark_r1cs_std::alloc::AllocVar;
 use ark_relations::ns;
 use snark_relation_proc_macro::snark_relation;
@@ -11,8 +10,6 @@ use crate::{BackendNote, FrontendNote};
 /// `token_amount`, `trapdoor` and `nullifier`.
 #[snark_relation]
 mod relation {
-    use ark_r1cs_std::R1CSVar;
-
     use crate::{
         environment::FpVar,
         shielder::{
@@ -56,17 +53,16 @@ mod relation {
 #[cfg(test)]
 mod tests {
     use ark_bls12_381::Bls12_381;
-    use ark_ff::BigInteger256;
     use ark_groth16::Groth16;
-    use ark_relations::r1cs::{ConstraintLayer, ConstraintSynthesizer, ConstraintSystem};
+    use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
     use ark_snark::SNARK;
 
     use super::{
         DepositRelationWithFullInput, DepositRelationWithPublicInput, DepositRelationWithoutInput,
     };
     use crate::{
-        shielder::note::compute_note, CircuitField, FrontendNullifier, FrontendTokenAmount,
-        FrontendTokenId, FrontendTrapdoor,
+        shielder::note::compute_note, FrontendNullifier, FrontendTokenAmount, FrontendTokenId,
+        FrontendTrapdoor,
     };
 
     fn get_circuit_with_full_input() -> DepositRelationWithFullInput {

--- a/relations/src/shielder/deposit_and_merge.rs
+++ b/relations/src/shielder/deposit_and_merge.rs
@@ -131,9 +131,12 @@ mod tests {
     use ark_snark::SNARK;
 
     use super::*;
-    use crate::shielder::note::{compute_note, compute_parent_hash};
+    use crate::{
+        shielder::note::{compute_note, compute_parent_hash},
+        FrontendNote,
+    };
 
-    const MAX_PATH_LEN: u8 = 10;
+    const MAX_PATH_LEN: u8 = 4;
 
     fn get_circuit_with_full_input() -> DepositAndMergeRelationWithFullInput {
         let token_id: FrontendTokenId = 1;
@@ -151,15 +154,24 @@ mod tests {
         let old_note = compute_note(token_id, old_token_amount, old_trapdoor, old_nullifier);
         let new_note = compute_note(token_id, new_token_amount, new_trapdoor, new_nullifier);
 
-        // Our leaf has a left bro. Their parent has a right bro. Our grandpa is the root.
+        //                                          merkle root
+        //                placeholder                                        x
+        //        1                          x                     x                         x
+        //   2        3                x          x            x       x                 x       x
+        // 4  *5*   6   7            x   x      x   x        x   x   x   x             x   x   x   x
         let leaf_index = 5;
 
-        let sibling_note = compute_note(0, 1, 2, 3);
-        let parent_note = compute_parent_hash(sibling_note, old_note);
-        let uncle_note = compute_note(4, 5, 6, 7);
-        let merkle_root = compute_parent_hash(parent_note, uncle_note);
+        let zero_note = FrontendNote::default(); // x
 
-        let merkle_path = vec![sibling_note, uncle_note];
+        let sibling_note = compute_note(0, 1, 2, 3); // 4
+        let parent_note = compute_parent_hash(sibling_note, old_note); // 2
+        let uncle_note = compute_note(4, 5, 6, 7); // 3
+        let grandpa_root = compute_parent_hash(parent_note, uncle_note); // 1
+
+        let placeholder = compute_parent_hash(grandpa_root, zero_note);
+        let merkle_root = compute_parent_hash(placeholder, zero_note);
+
+        let merkle_path = vec![sibling_note, uncle_note, zero_note, zero_note];
 
         DepositAndMergeRelationWithFullInput::new(
             MAX_PATH_LEN,

--- a/relations/src/shielder/deposit_and_merge.rs
+++ b/relations/src/shielder/deposit_and_merge.rs
@@ -159,12 +159,13 @@ mod tests {
         //        1                          x                     x                         x
         //   2        3                x          x            x       x                 x       x
         // 4  *5*   6   7            x   x      x   x        x   x   x   x             x   x   x   x
-        let leaf_index = 5;
+        let leaf_index = 0;
 
         let zero_note = FrontendNote::default(); // x
 
         let sibling_note = compute_note(0, 1, 2, 3); // 4
-        let parent_note = compute_parent_hash(sibling_note, old_note); // 2
+                                                     // let parent_note = compute_parent_hash(sibling_note, old_note); // 2
+        let parent_note = compute_parent_hash(old_note, sibling_note); // 2
         let uncle_note = compute_note(4, 5, 6, 7); // 3
         let grandpa_root = compute_parent_hash(parent_note, uncle_note); // 1
 

--- a/relations/src/shielder/deposit_and_merge.rs
+++ b/relations/src/shielder/deposit_and_merge.rs
@@ -115,7 +115,7 @@ mod relation {
         check_merkle_proof(
             self.merkle_root(),
             self.leaf_index(),
-            old_note.to_bytes()?,
+            old_note,
             self.merkle_path().cloned().unwrap_or_default(),
             *self.max_path_len(),
             cs,

--- a/relations/src/shielder/deposit_and_merge.rs
+++ b/relations/src/shielder/deposit_and_merge.rs
@@ -14,7 +14,7 @@ use snark_relation_proc_macro::snark_relation;
 mod relation {
     use core::ops::Add;
 
-    use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar, ToBytesGadget};
+    use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar};
     use ark_relations::ns;
 
     use crate::shielder::{

--- a/relations/src/shielder/deposit_and_merge.rs
+++ b/relations/src/shielder/deposit_and_merge.rs
@@ -171,7 +171,7 @@ mod tests {
         let placeholder = compute_parent_hash(grandpa_root, zero_note);
         let merkle_root = compute_parent_hash(placeholder, zero_note);
 
-        let merkle_path = vec![sibling_note, uncle_note, zero_note, zero_note];
+        let merkle_path = vec![sibling_note, uncle_note];
 
         DepositAndMergeRelationWithFullInput::new(
             MAX_PATH_LEN,

--- a/relations/src/shielder/deposit_and_merge.rs
+++ b/relations/src/shielder/deposit_and_merge.rs
@@ -14,7 +14,6 @@ use snark_relation_proc_macro::snark_relation;
 mod relation {
     use core::ops::Add;
 
-    use ark_ff::Zero;
     use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar};
     use ark_relations::ns;
 

--- a/relations/src/shielder/mod.rs
+++ b/relations/src/shielder/mod.rs
@@ -40,7 +40,7 @@ pub use withdraw::{
 use crate::environment::{CircuitField, FpVar};
 
 fn convert_hash(front: [u64; 4]) -> CircuitField {
-    CircuitField::from(BigInteger256::new(front))
+    CircuitField::new(BigInteger256::new(front))
 }
 
 fn convert_vec(front: Vec<[u64; 4]>) -> Vec<CircuitField> {

--- a/relations/src/shielder/mod.rs
+++ b/relations/src/shielder/mod.rs
@@ -12,7 +12,7 @@ pub mod types;
 mod withdraw;
 
 use ark_ff::{BigInteger256, PrimeField, Zero};
-use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget};
+use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, R1CSVar};
 use ark_relations::{
     ns,
     r1cs::{ConstraintSystemRef, SynthesisError, SynthesisError::UnconstrainedVariable},
@@ -84,6 +84,11 @@ fn check_merkle_proof(
 
         current_note = tangle_in_field(&next_level)?;
         leaf_index /= 2;
+    }
+
+    if !cs.is_in_setup_mode() {
+        println!("merkle {}", merkle_root.value().unwrap());
+        println!("curren {}", current_note.value().unwrap());
     }
 
     merkle_root.enforce_equal(&current_note)

--- a/relations/src/shielder/mod.rs
+++ b/relations/src/shielder/mod.rs
@@ -73,13 +73,13 @@ fn check_merkle_proof(
     let mut current_note = leaf;
     let zero_note = CircuitField::zero();
 
-    for i in 0..max_path_len {
+    for i in 0..max_path_len as usize {
         let sibling = FpVar::new_witness(ns!(cs, "merkle path node"), || {
-            Ok(path.get(i as usize).unwrap_or(&zero_note))
+            Ok(path.get(i).unwrap_or(&zero_note))
         })?;
 
-        let left = path_shape.at(i as usize).select(&current_note, &sibling)?;
-        let right = path_shape.at(i as usize).select(&sibling, &current_note)?;
+        let left = path_shape[i].select(&current_note, &sibling)?;
+        let right = path_shape[i].select(&sibling, &current_note)?;
 
         current_note = tangle_in_circuit(&[left, right])?;
     }

--- a/relations/src/shielder/mod.rs
+++ b/relations/src/shielder/mod.rs
@@ -11,17 +11,13 @@ mod tangle;
 pub mod types;
 mod withdraw;
 
-use core::ops::Div;
-
-use ark_ff::{BigInteger, BigInteger256, PrimeField, Zero};
-use ark_r1cs_std::{
-    alloc::AllocVar, eq::EqGadget, fields::FieldVar, uint8::UInt8, R1CSVar, ToBytesGadget,
-};
+use ark_ff::{BigInteger256, PrimeField, Zero};
+use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget};
 use ark_relations::{
     ns,
     r1cs::{ConstraintSystemRef, SynthesisError, SynthesisError::UnconstrainedVariable},
 };
-use ark_std::{vec, vec::Vec};
+use ark_std::vec::Vec;
 pub use deposit::{
     DepositRelationWithFullInput, DepositRelationWithPublicInput, DepositRelationWithoutInput,
 };
@@ -31,7 +27,7 @@ pub use deposit_and_merge::{
 };
 pub use note::{bytes_from_note, compute_note, compute_parent_hash, note_from_bytes};
 use tangle::tangle_in_field;
-use types::{BackendLeafIndex, BackendMerklePath, BackendMerkleRoot, ByteVar};
+use types::{BackendMerklePath, BackendMerkleRoot};
 pub use types::{
     FrontendMerklePath as MerklePath, FrontendMerkleRoot as MerkleRoot, FrontendNote as Note,
     FrontendNullifier as Nullifier, FrontendTokenAmount as TokenAmount, FrontendTokenId as TokenId,

--- a/relations/src/shielder/mod.rs
+++ b/relations/src/shielder/mod.rs
@@ -13,7 +13,7 @@ pub mod types;
 mod withdraw;
 
 use ark_ff::{BigInteger256, PrimeField, Zero};
-use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, R1CSVar};
+use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget};
 use ark_relations::{
     ns,
     r1cs::{ConstraintSystemRef, SynthesisError, SynthesisError::UnconstrainedVariable},
@@ -27,8 +27,8 @@ pub use deposit_and_merge::{
     DepositAndMergeRelationWithoutInput,
 };
 pub use note::{bytes_from_note, compute_note, compute_parent_hash, note_from_bytes};
-use tangle::tangle_in_field;
-use types::{BackendMerklePath, BackendMerkleRoot};
+use tangle::tangle_in_circuit;
+use types::BackendMerklePath;
 pub use types::{
     FrontendMerklePath as MerklePath, FrontendMerkleRoot as MerkleRoot, FrontendNote as Note,
     FrontendNullifier as Nullifier, FrontendTokenAmount as TokenAmount, FrontendTokenId as TokenId,
@@ -81,7 +81,7 @@ fn check_merkle_proof(
         let left = path_shape.at(i as usize).select(&current_note, &sibling)?;
         let right = path_shape.at(i as usize).select(&sibling, &current_note)?;
 
-        current_note = tangle_in_field(&[left, right])?;
+        current_note = tangle_in_circuit(&[left, right])?;
     }
 
     merkle_root.enforce_equal(&current_note)

--- a/relations/src/shielder/note.rs
+++ b/relations/src/shielder/note.rs
@@ -1,15 +1,13 @@
 //! Module exposing some utilities regarding note generation and verification.
 
-use ark_ff::{BigInteger, BigInteger256};
-use ark_r1cs_std::{eq::EqGadget, ToBytesGadget};
+use ark_r1cs_std::eq::EqGadget;
 use ark_relations::r1cs::SynthesisError;
 use ark_std::{vec, vec::Vec};
 
 use super::{
     tangle::{tangle, tangle_in_field},
     types::{
-        ByteVar, FrontendNote, FrontendNullifier, FrontendTokenAmount, FrontendTokenId,
-        FrontendTrapdoor,
+        FrontendNote, FrontendNullifier, FrontendTokenAmount, FrontendTokenId, FrontendTrapdoor,
     },
 };
 use crate::{environment::FpVar, shielder::convert_hash, CircuitField};

--- a/relations/src/shielder/note.rs
+++ b/relations/src/shielder/note.rs
@@ -12,7 +12,7 @@ use super::{
         FrontendTrapdoor,
     },
 };
-use crate::environment::FpVar;
+use crate::{environment::FpVar, shielder::convert_hash, CircuitField};
 
 /// Verify that `note` is indeed the result of tangling `(token_id, token_amount, trapdoor,
 /// nullifier)`.
@@ -25,19 +25,14 @@ pub(super) fn check_note(
     nullifier: &FpVar,
     note: &FpVar,
 ) -> Result<(), SynthesisError> {
-    let bytes: Vec<ByteVar> = [
-        token_id.to_bytes()?,
-        token_amount.to_bytes()?,
-        trapdoor.to_bytes()?,
-        nullifier.to_bytes()?,
-    ]
-    .concat();
-    let bytes = tangle_in_field::<4>(bytes)?;
+    let tangled = tangle_in_field(&vec![
+        token_id.clone(),
+        token_amount.clone(),
+        trapdoor.clone(),
+        nullifier.clone(),
+    ])?;
 
-    for (a, b) in note.to_bytes()?.iter().zip(bytes.iter()) {
-        a.enforce_equal(b)?;
-    }
-    Ok(())
+    tangled.enforce_equal(note)
 }
 
 /// Compute note as the result of tangling `(token_id, token_amount, trapdoor, nullifier)`.
@@ -49,24 +44,18 @@ pub fn compute_note(
     trapdoor: FrontendTrapdoor,
     nullifier: FrontendNullifier,
 ) -> FrontendNote {
-    let bytes = [
-        BigInteger256::from(token_id as u64).to_bytes_le(),
-        BigInteger256::from(token_amount).to_bytes_le(),
-        BigInteger256::from(trapdoor).to_bytes_le(),
-        BigInteger256::from(nullifier).to_bytes_le(),
-    ]
-    .concat();
-
-    note_from_bytes(tangle::<4>(bytes).as_slice())
+    tangle(&vec![
+        CircuitField::from(token_id as u64),
+        CircuitField::from(token_amount),
+        CircuitField::from(trapdoor),
+        CircuitField::from(nullifier),
+    ])
+    .0
+     .0
 }
 
 pub fn compute_parent_hash(left: FrontendNote, right: FrontendNote) -> FrontendNote {
-    let bytes = [
-        BigInteger256::new(left).to_bytes_le(),
-        BigInteger256::new(right).to_bytes_le(),
-    ]
-    .concat();
-    note_from_bytes(tangle::<2>(bytes).as_slice())
+    tangle(&vec![convert_hash(left), convert_hash(right)]).0 .0
 }
 
 /// Create a note from the first 32 bytes of `bytes`.

--- a/relations/src/shielder/note.rs
+++ b/relations/src/shielder/note.rs
@@ -1,6 +1,6 @@
 //! Module exposing some utilities regarding note generation and verification.
 
-use ark_r1cs_std::eq::EqGadget;
+use ark_r1cs_std::{eq::EqGadget, R1CSVar};
 use ark_relations::r1cs::SynthesisError;
 use ark_std::{vec, vec::Vec};
 

--- a/relations/src/shielder/note.rs
+++ b/relations/src/shielder/note.rs
@@ -42,7 +42,7 @@ pub fn compute_note(
     trapdoor: FrontendTrapdoor,
     nullifier: FrontendNullifier,
 ) -> FrontendNote {
-    tangle(&vec![
+    tangle(&[
         CircuitField::from(token_id as u64),
         CircuitField::from(token_amount),
         CircuitField::from(trapdoor),
@@ -53,7 +53,7 @@ pub fn compute_note(
 }
 
 pub fn compute_parent_hash(left: FrontendNote, right: FrontendNote) -> FrontendNote {
-    tangle(&vec![convert_hash(left), convert_hash(right)]).0 .0
+    tangle(&[convert_hash(left), convert_hash(right)]).0 .0
 }
 
 /// Create a note from the first 32 bytes of `bytes`.

--- a/relations/src/shielder/note.rs
+++ b/relations/src/shielder/note.rs
@@ -1,11 +1,11 @@
 //! Module exposing some utilities regarding note generation and verification.
 
-use ark_r1cs_std::{eq::EqGadget, R1CSVar};
+use ark_r1cs_std::eq::EqGadget;
 use ark_relations::r1cs::SynthesisError;
 use ark_std::{vec, vec::Vec};
 
 use super::{
-    tangle::{tangle, tangle_in_field},
+    tangle::{tangle, tangle_in_circuit},
     types::{
         FrontendNote, FrontendNullifier, FrontendTokenAmount, FrontendTokenId, FrontendTrapdoor,
     },
@@ -23,7 +23,7 @@ pub(super) fn check_note(
     nullifier: &FpVar,
     note: &FpVar,
 ) -> Result<(), SynthesisError> {
-    let tangled = tangle_in_field(&vec![
+    let tangled = tangle_in_circuit(&vec![
         token_id.clone(),
         token_amount.clone(),
         trapdoor.clone(),

--- a/relations/src/shielder/tangle.rs
+++ b/relations/src/shielder/tangle.rs
@@ -6,14 +6,14 @@
 //! It operates in three steps:
 //!  1.1 We repeat the sequence until the result has [EXPAND_TO] elements. If the input sequence is
 //!      longer than [EXPAND_TO], it will be trimmed.
-//!  2.1 For every chunk of length `BASE_LENGTH` we compute _spiced_ suffix sums. Basically, apart
-//!      from just summing elements, we take their inverses and multiply them by an index-dependent
-//!      factor.
+//!  2.1 For every chunk of length `BASE_LENGTH` we compute _spiced_ suffix sums of inverses.
+//!     Basically, apart from just summing element inverses, we multiply intermediate results by an
+//!     index-dependent factor.
 //!  2.2 We build a binary tree over these chunks.
 //!  2.3 We go bottom-to-top and in every intermediate node we:
 //!      1.3.1 swap the halves
 //!      1.3.2 compute prefix products
-//!  2.1 A new mangled sequence of `n` elements is reduced by summing.
+//!  3.1 A new mangled sequence of `n` elements is reduced by summing.
 //!
 //! In some places, where an element turns out to be zero, we replace it by an index-dependent
 //! constant.

--- a/relations/src/shielder/tangle.rs
+++ b/relations/src/shielder/tangle.rs
@@ -20,9 +20,8 @@
 //! that we consider indices `a`, `a+1`, ..., `b-1`. We also use 0-based indexing.
 
 use ark_ff::Zero;
-use ark_r1cs_std::{alloc::AllocVar, fields::FieldVar, R1CSVar, ToConstraintFieldGadget};
-use ark_relations::{ns, r1cs::SynthesisError};
-use ark_std::vec::Vec;
+use ark_r1cs_std::{fields::FieldVar, R1CSVar};
+use ark_relations::r1cs::SynthesisError;
 
 use super::types::ByteVar;
 use crate::{environment::FpVar, CircuitField};
@@ -141,13 +140,13 @@ fn _tangle(bytes: &mut [u8], low: usize, high: usize) {
 
 #[cfg(test)]
 mod tests {
-    use ark_ff::{BigInteger, BigInteger256, Zero};
+    use ark_ff::Zero;
     use ark_r1cs_std::{fields::FieldVar, R1CSVar};
 
     use crate::{
         environment::FpVar,
         shielder::tangle::{tangle, tangle_in_field},
-        ByteVar, CircuitField,
+        CircuitField,
     };
 
     #[test]

--- a/relations/src/shielder/types.rs
+++ b/relations/src/shielder/types.rs
@@ -27,36 +27,5 @@ pub type BackendTokenId = CircuitField;
 pub type BackendTokenAmount = CircuitField;
 pub type BackendMerkleRoot = CircuitField;
 pub type BackendMerklePath = Vec<CircuitField>;
-pub type BackendLeafIndex = CircuitField;
+pub type BackendLeafIndex = u64;
 pub type BackendAccount = CircuitField;
-
-/*
-This is a setup for using Pedersen hashing (with field element compressing). It would work well, but
-there is a serious problem with keeping/retrieving parameters in the contract. With the window
-parameters defined below, serialized parameters take ~133kB. On the other hand, generating them
-exhausts block capacity.
-
-
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
-pub struct PedersenWindow;
-// We can hash 8 * 128 = 1024 bits.
-impl pedersen::Window for PedersenWindow {
-    const WINDOW_SIZE: usize = 8;
-    const NUM_WINDOWS: usize = 128;
-}
-
-pub type HashFunction = PedersenCRHCompressor<EdwardsProjective, TECompressor, PedersenWindow>;
-pub type HashFunctionParameters = <HashFunction as CRHTrait>::Parameters;
-pub type Hash = <HashFunction as CRHTrait>::Output;
-
-pub type HashFunctionGadget = PedersenCRHCompressorGadget<
-    EdwardsProjective,
-    TECompressor,
-    PedersenWindow,
-    EdwardsVar,
-    TECompressorGadget,
->;
-pub type HashFunctionParametersVar =
-    <HashFunctionGadget as CRHGadget<HashFunction, CircuitField>>::ParametersVar;
-pub type HashVar = <HashFunctionGadget as CRHGadget<HashFunction, CircuitField>>::OutputVar;
- */

--- a/relations/src/shielder/withdraw.rs
+++ b/relations/src/shielder/withdraw.rs
@@ -130,7 +130,7 @@ mod relation {
         check_merkle_proof(
             self.merkle_root(),
             self.leaf_index(),
-            old_note.to_bytes()?,
+            old_note,
             self.merkle_path().cloned().unwrap_or_default(),
             *self.max_path_len(),
             cs,

--- a/relations/src/shielder/withdraw.rs
+++ b/relations/src/shielder/withdraw.rs
@@ -18,7 +18,7 @@ use snark_relation_proc_macro::snark_relation;
 mod relation {
     use core::ops::Add;
 
-    use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar, ToBytesGadget};
+    use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar};
     use ark_relations::ns;
 
     use crate::shielder::{

--- a/relations/src/shielder/withdraw.rs
+++ b/relations/src/shielder/withdraw.rs
@@ -18,28 +18,20 @@ use snark_relation_proc_macro::snark_relation;
 mod relation {
     use core::ops::Add;
 
-    use ark_r1cs_std::{
-        alloc::{AllocVar, AllocationMode},
-        eq::EqGadget,
-        fields::fp::FpVar,
-    };
+    use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar};
     use ark_relations::ns;
 
-    use crate::{
-        shielder::{
-            check_merkle_proof,
-            circuit_utils::PathShapeVar,
-            convert_account, convert_hash, convert_vec,
-            note::check_note,
-            types::{
-                BackendAccount, BackendLeafIndex, BackendMerklePath, BackendMerkleRoot,
-                BackendNote, BackendNullifier, BackendTokenAmount, BackendTokenId, BackendTrapdoor,
-                FrontendAccount, FrontendLeafIndex, FrontendMerklePath, FrontendMerkleRoot,
-                FrontendNote, FrontendNullifier, FrontendTokenAmount, FrontendTokenId,
-                FrontendTrapdoor,
-            },
+    use crate::shielder::{
+        check_merkle_proof,
+        circuit_utils::PathShapeVar,
+        convert_account, convert_hash, convert_vec,
+        note::check_note,
+        types::{
+            BackendAccount, BackendLeafIndex, BackendMerklePath, BackendMerkleRoot, BackendNote,
+            BackendNullifier, BackendTokenAmount, BackendTokenId, BackendTrapdoor, FrontendAccount,
+            FrontendLeafIndex, FrontendMerklePath, FrontendMerkleRoot, FrontendNote,
+            FrontendNullifier, FrontendTokenAmount, FrontendTokenId, FrontendTrapdoor,
         },
-        CircuitField,
     };
 
     #[relation_object_definition]

--- a/relations/src/shielder/withdraw.rs
+++ b/relations/src/shielder/withdraw.rs
@@ -151,7 +151,7 @@ mod tests {
         FrontendAccount,
     };
 
-    const MAX_PATH_LEN: u8 = 10;
+    const MAX_PATH_LEN: u8 = 4;
 
     fn get_circuit_with_full_input() -> WithdrawRelationWithFullInput {
         let token_id: FrontendTokenId = 1;
@@ -169,13 +169,22 @@ mod tests {
         let old_note = compute_note(token_id, whole_token_amount, old_trapdoor, old_nullifier);
         let new_note = compute_note(token_id, new_token_amount, new_trapdoor, new_nullifier);
 
-        // Our leaf has a left bro. Their parent has a right bro. Our grandpa is the root.
+        //                                          merkle root
+        //                placeholder                                        x
+        //        1                          x                     x                         x
+        //   2        3                x          x            x       x                 x       x
+        // 4  *5*   6   7            x   x      x   x        x   x   x   x             x   x   x   x
         let leaf_index = 5;
 
-        let sibling_note = compute_note(0, 1, 2, 3);
-        let parent_note = compute_parent_hash(sibling_note, old_note);
-        let uncle_note = compute_note(4, 5, 6, 7);
-        let merkle_root = compute_parent_hash(parent_note, uncle_note);
+        let zero_note = FrontendNote::default(); // x
+
+        let sibling_note = compute_note(0, 1, 2, 3); // 4
+        let parent_note = compute_parent_hash(sibling_note, old_note); // 2
+        let uncle_note = compute_note(4, 5, 6, 7); // 3
+        let grandpa_root = compute_parent_hash(parent_note, uncle_note); // 1
+
+        let placeholder = compute_parent_hash(grandpa_root, zero_note);
+        let merkle_root = compute_parent_hash(placeholder, zero_note);
 
         let merkle_path = vec![sibling_note, uncle_note];
 


### PR DESCRIPTION
# Description

This PR fixes two things:
 - tangling
 - merkle path checking

# Story

The root problem was with in the tangling implementation. Two things here.
1. Tangling was really vulnerable to `0` in its input - once there were sufficiently many zero entries, the result was zero as well.
1. We were working on `ByteVar` (`Uint8<CircuitField>`) type, which is completely improper for arithmetic in a circuit. Although it doesn't expose calculation API (like `+` or `*`), it is not idiot-proof. We can still retrieve its underlying `u8` value with `.value()` method. **However, any operation on these values, doesn't have any impact on the circuit itself**. Unfortunately, this problem was hidden by the former point and thus we couldn't learn that something is no yes.

Similar bug was also present in the Merkle path checking, but again, it wasn't visible since, everything worked well with zeroed notes. In particular, `leaf_index` was perfectly broken.

# Fix for tangling

Firstly, we give up working on bytes. Although `arkworks` exposes API for converting `ByteVar`/`Vec<ByteVar>` to `Vec<CircuitField>` and back (with `ToBytesGadget::to_bytes`), **it is not homomorphic** with the conversion `CircuitField::to_bytes` (via underlying `BigInteger256`). And actually we need such homomorphism, since we are tangling both outside and inside circuit.

Secondly, in critical moments, we replace `0` inputs with an index-dependent constant value (see implementation).

# Fix for Merkle path checking

Initially we had just a leaf index and depending on its bits we restored path shape. However, **this logic must be baked into a circuit**. For this, `Boolean` type has `select` method, which together with the `CondSelectGadget` trait enables conditional execution. In order to make things a bit cleaner, we introduced `PathShapeVar` (that represents leaf index explicitly as circuit bits).