### PR TITLE
staking

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -6,6 +6,8 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+mod migrations;
+
 pub use frame_support::{
     construct_runtime, log, parameter_types,
     traits::{
@@ -56,6 +58,8 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
+use crate::migrations::BumpStorageVersionFromV7ToV10;
+
 /// An index to a block.
 pub type BlockNumber = u32;
 
@@ -104,7 +108,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 46,
+    spec_version: 47,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 14,
@@ -718,6 +722,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    (BumpStorageVersionFromV7ToV10<Runtime>,),
 >;
 
 impl_runtime_apis! {

--- a/bin/runtime/src/migrations/mod.rs
+++ b/bin/runtime/src/migrations/mod.rs
@@ -1,0 +1,3 @@
+mod staking;
+
+pub use staking::BumpStorageVersionFromV7ToV10;

--- a/bin/runtime/src/migrations/staking.rs
+++ b/bin/runtime/src/migrations/staking.rs
@@ -54,7 +54,7 @@ impl<T: Config> OnRuntimeUpgrade for BumpStorageVersionFromV7ToV10<T> {
                     "💸 Migration being executed on the wrong storage \
                     version, expected Releases::V10_0_0 or None"
                 );
-                return T::DbWeight::get().reads(1);
+                T::DbWeight::get().reads(1)
             }
         }
     }
@@ -62,9 +62,9 @@ impl<T: Config> OnRuntimeUpgrade for BumpStorageVersionFromV7ToV10<T> {
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<(), &'static str> {
         frame_support::ensure!(
-            StorageVersion::get() == Some(Releases::V7_0_0) || StorageVersion::get() == None,
+            StorageVersion::get() == Some(Releases::V10_0_0) || StorageVersion::get() == None,
             "💸 Migration being executed on the wrong storage \
-                version, expected Releases::V7_0_0 or None"
+                version, expected Releases::V10_0_0 or None"
         );
 
         Ok(())

--- a/bin/runtime/src/migrations/staking.rs
+++ b/bin/runtime/src/migrations/staking.rs
@@ -1,0 +1,82 @@
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::{
+    log,
+    pallet_prelude::{Get, TypeInfo},
+    storage_alias,
+    traits::OnRuntimeUpgrade,
+    RuntimeDebug,
+};
+use pallet_staking::Config;
+
+use crate::Weight;
+
+#[storage_alias]
+type StorageVersion = StorageValue<Staking, Releases>;
+
+// copied from pallet staking, hack for that fact that original struct is not exported
+#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+enum Releases {
+    V1_0_0Ancient,
+    V2_0_0,
+    V3_0_0,
+    V4_0_0,
+    V5_0_0,  // blockable validators.
+    V6_0_0,  // removal of all storage associated with offchain phragmen.
+    V7_0_0,  // keep track of number of nominators / validators in map
+    V8_0_0,  // populate `VoterList`.
+    V9_0_0,  // inject validators into `VoterList` as well.
+    V10_0_0, // remove `EarliestUnappliedSlash`.
+}
+
+pub struct BumpStorageVersionFromV7ToV10<T>(sp_std::marker::PhantomData<T>);
+impl<T: Config> OnRuntimeUpgrade for BumpStorageVersionFromV7ToV10<T> {
+    fn on_runtime_upgrade() -> Weight {
+        match StorageVersion::get() {
+            None => {
+                log::info!(
+                    target: "runtime::staking",
+                    "💸 Migrating storage to Releases::V10_0_0 from unknown version"
+                );
+                StorageVersion::put(Releases::V10_0_0);
+                T::DbWeight::get().reads_writes(1, 1)
+            }
+            Some(Releases::V10_0_0) => {
+                log::info!(
+                    target: "runtime::staking",
+                    "💸 Migrating storage to Releases::V10_0_0 from Releases::V10_0_0"
+                );
+                StorageVersion::put(Releases::V10_0_0);
+                T::DbWeight::get().reads_writes(1, 1)
+            }
+            _ => {
+                log::warn!(
+                    target: "runtime::staking",
+                    "💸 Migration being executed on the wrong storage \
+                    version, expected Releases::V10_0_0 or None"
+                );
+                return T::DbWeight::get().reads(1);
+            }
+        }
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<(), &'static str> {
+        frame_support::ensure!(
+            StorageVersion::get() == Some(Releases::V7_0_0) || StorageVersion::get() == None,
+            "💸 Migration being executed on the wrong storage \
+                version, expected Releases::V7_0_0 or None"
+        );
+
+        Ok(())
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade() -> Result<(), &'static str> {
+        frame_support::ensure!(
+            StorageVersion::get() == Some(Releases::V10_0_0),
+            "💸 must upgrade to Releases::V10_0_0"
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Simply set StorageVersion for pallet staking. Since we copied the 
release struct the storage returns None not the default from the staking pallet.

`RUST_LOG=runtime=trace,try-runtime::cli=trace,executor=trace ./target/release/aleph-node try-runtime --no-spec-name-check  --chain /tmp/chainspec.json on-runtime-upgrade live -p NominationPools -p Elections -p Staking -p Aleph --uri wss://ws.azero.dev:443 > ~/Desktop/try-runtime.log 2>&1
`
[try-runtime.log](https://github.com/Cardinal-Cryptography/aleph-node/files/10673715/try-runtime.log)