### PR TITLE
Use no_std variants in relations crate.

### DIFF
--- a/relations/src/shielder/circuit_utils.rs
+++ b/relations/src/shielder/circuit_utils.rs
@@ -1,7 +1,6 @@
-use core::borrow::Borrow;
+use core::{borrow::Borrow, ops::Index};
 #[cfg(feature = "std")]
 use std::fmt::{Display, Formatter};
-use std::ops::Index;
 
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
@@ -9,6 +8,7 @@ use ark_r1cs_std::{
     R1CSVar,
 };
 use ark_relations::r1cs::{Namespace, SynthesisError};
+use ark_std::vec::Vec;
 
 use crate::CircuitField;
 
@@ -54,7 +54,7 @@ impl AllocVar<(u8, Result<u64, SynthesisError>), CircuitField> for PathShapeVar 
         let ns = cs.into();
         let cs = ns.cs();
 
-        let mut shape = vec![];
+        let mut shape = Vec::new();
 
         let (path_length, maybe_leaf_index) = *f()?.borrow();
 

--- a/relations/src/shielder/circuit_utils.rs
+++ b/relations/src/shielder/circuit_utils.rs
@@ -8,7 +8,7 @@ use ark_r1cs_std::{
     R1CSVar,
 };
 use ark_relations::r1cs::{Namespace, SynthesisError};
-use ark_std::vec::Vec;
+use ark_std::{vec, vec::Vec};
 
 use crate::CircuitField;
 
@@ -54,7 +54,7 @@ impl AllocVar<(u8, Result<u64, SynthesisError>), CircuitField> for PathShapeVar 
         let ns = cs.into();
         let cs = ns.cs();
 
-        let mut shape = Vec::new();
+        let mut shape = vec![];
 
         let (path_length, maybe_leaf_index) = *f()?.borrow();
 

--- a/relations/src/shielder/tangle.rs
+++ b/relations/src/shielder/tangle.rs
@@ -26,11 +26,12 @@
 //! All the index intervals used here are closed-open, i.e. they are in form `[a, b)`, which means
 //! that we consider indices `a`, `a+1`, ..., `b-1`. We also use 0-based indexing.
 
-use std::ops::Add;
+use core::ops::Add;
 
 use ark_ff::{Field, Zero};
 use ark_r1cs_std::fields::FieldVar;
 use ark_relations::r1cs::SynthesisError;
+use ark_std::vec::Vec;
 
 use crate::{environment::FpVar, CircuitField};
 


### PR DESCRIPTION
When using `relations` as dependency of a `no_std` project (measuring performance of SNARKs in the browser), the following compilation errors were emitted (among others):
```sh
error[E0433]: failed to resolve: use of undeclared crate or module `std`
  --> /home/mateusz/aleph/aleph-node/relations/src/shielder/tangle.rs:29:5
   |
29 | use std::ops::Add;
   |     ^^^ use of undeclared crate or module `std`

error[E0433]: failed to resolve: use of undeclared crate or module `std`
 --> /home/mateusz/aleph/aleph-node/relations/src/shielder/circuit_utils.rs:4:5
  |
4 | use std::ops::Index;
  |     ^^^ use of undeclared crate or module `std`

```
switching to proper no std variants fixes the problem.