### PR TITLE
A0-1951: Some macro fixes

### DIFF
--- a/relations/src/proc_macro/src/code_generation.rs
+++ b/relations/src/proc_macro/src/code_generation.rs
@@ -48,6 +48,9 @@ fn generate_relation_without_input(ir: &IR) -> SynResult<TokenStream2> {
             #(#const_backend_decls),*
         }
         impl #struct_name {
+            #[allow(clippy::too_many_arguments)]
+            #[allow(clippy::new_without_default)]
+            #[allow(clippy::useless_conversion)]
             pub fn new(#(#const_frontend_decls),*) -> Self {
                 Self { #(#const_castings),* }
             }
@@ -112,6 +115,8 @@ fn generate_relation_with_public(ir: &IR) -> SynResult<TokenStream2> {
         }
         impl #struct_name {
             #[allow(clippy::too_many_arguments)]
+            #[allow(clippy::new_without_default)]
+            #[allow(clippy::useless_conversion)]
             pub fn new(#(#frontend_decls),*) -> Self {
                 Self { #(#castings),* }
             }
@@ -173,6 +178,8 @@ fn generate_relation_with_full(ir: &IR) -> SynResult<TokenStream2> {
         }
         impl #struct_name {
             #[allow(clippy::too_many_arguments)]
+            #[allow(clippy::new_without_default)]
+            #[allow(clippy::useless_conversion)]
             pub fn new(#(#frontend_decls),*) -> Self {
                 Self { #(#castings),* }
             }

--- a/relations/src/proc_macro/src/code_generation.rs
+++ b/relations/src/proc_macro/src/code_generation.rs
@@ -55,11 +55,17 @@ fn generate_relation_without_input(ir: &IR) -> SynResult<TokenStream2> {
 fn generate_public_input_serialization(ir: &IR) -> SynResult<TokenStream2> {
     let accesses = field_serializations(&ir.public_inputs, &Ident::new("self", Span::call_site()));
 
-    Ok(quote! {
-        pub fn serialize_public_input(&self) -> ark_std::vec::Vec<ark_bls12_381::Fr> {
-            [ #(#accesses),* ].concat()
-        }
-    })
+    if accesses.is_empty() {
+        Ok(quote! {
+            pub fn serialize_public_input(&self) -> ark_std::vec::Vec<ark_bls12_381::Fr> { ark_std::vec![] }
+        })
+    } else {
+        Ok(quote! {
+            pub fn serialize_public_input(&self) -> ark_std::vec::Vec<ark_bls12_381::Fr> {
+                [ #(#accesses),* ].concat()
+            }
+        })
+    }
 }
 
 /// Generates struct, constructor, getters, public input serialization and downcasting for the

--- a/relations/src/proc_macro/src/intermediate_representation.rs
+++ b/relations/src/proc_macro/src/intermediate_representation.rs
@@ -45,6 +45,12 @@ pub(super) struct RelationField {
     pub parse_with: Option<String>,
 }
 
+impl RelationField {
+    pub fn span(&self) -> Span {
+        self.field.span()
+    }
+}
+
 impl TryFrom<Field> for RelationField {
     type Error = SynError;
 
@@ -67,6 +73,12 @@ pub(super) struct PublicInputField {
     pub inner: RelationField,
     /// The value of the `serialize_with` modifier, if any.
     pub serialize_with: Option<String>,
+}
+
+impl PublicInputField {
+    pub fn span(&self) -> Span {
+        self.inner.span()
+    }
 }
 
 impl From<PublicInputField> for RelationField {


### PR DESCRIPTION
1. Allows for no public inputs in a relation
2. We use `quote_spanned` instead of `quote` which might help a bit with compilation errors

Unblocks #907 