### PR TITLE
A0-1923: add e2e tests for pruning

### DIFF
--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -62,7 +62,7 @@ jobs:
       - name: GIT | Checkout source code
         uses: actions/checkout@v2
 
-      - name: Install Rust toolchain
+      - name: Install Rust toolchainrun_e2e_testrun_e2e_test
         uses: actions-rs/toolchain@v1
 
       - name: Install Protoc
@@ -796,6 +796,9 @@ jobs:
     name: Test catching up
     runs-on: ubuntu-20.04
     needs: build-new-node
+    strategy:
+      matrix:
+        pruning: ['', '--state-pruning 90']
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -815,12 +818,15 @@ jobs:
         env:
           # Relative to local-tests/ directory
           ALEPH_NODE_BINARY: aleph-test-node/aleph-node
-        run: ./.github/scripts/test_catch_up.sh
+        run: ./.github/scripts/test_catch_up.sh ${{ matrix.pruning }}
 
   test-multiple-restarts:
     name: Test multiple restarts
     runs-on: ubuntu-20.04
     needs: build-new-node
+    strategy:
+      matrix:
+        pruning: ['', '--state-pruning 2048']
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -840,7 +846,7 @@ jobs:
         env:
           # Relative to local-tests/ directory
           ALEPH_NODE_BINARY: aleph-release-node/aleph-node
-        run: ./.github/scripts/test_multiple_restarts.sh
+        run: ./.github/scripts/test_multiple_restarts.sh ${{ matrix.pruning }}
 
   check-runtime-change:
     name: Inspect whether runtime version has been changed (compared with main)

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -62,7 +62,7 @@ jobs:
       - name: GIT | Checkout source code
         uses: actions/checkout@v2
 
-      - name: Install Rust toolchainrun_e2e_testrun_e2e_test
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
 
       - name: Install Protoc

--- a/local-tests/run_nodes.py
+++ b/local-tests/run_nodes.py
@@ -35,8 +35,7 @@ chain.set_flags('validator',
                 unit_creation_delay=500,
                 execution='Native',
                 rpc_cors='all',
-                rpc_methods='Unsafe',
-                state_pruning='archive')
+                rpc_methods='Unsafe')
 addresses = [n.address() for n in chain]
 chain.set_flags(bootnodes=addresses[0], public_addr=addresses)
 

--- a/local-tests/test_catch_up.py
+++ b/local-tests/test_catch_up.py
@@ -30,8 +30,6 @@ chain.bootstrap(binary,
                 nonvalidators=all_accounts[4:],
                 sudo_account_id=keys[phrases[0]],
                 chain_type='local')
-printt('Purging previous chain')
-chain.purge()
 
 chain.set_flags('no-mdns',
                 port=Seq(30334),
@@ -58,10 +56,14 @@ sleep(60)
 
 chain.start('aleph', nodes=[4, 5])
 
+printt('Waiting for finalization')
+chain.wait_for_finalization(0)
 printt('Waiting for authorities')
 chain.wait_for_authorities()
-printt('Waiting for finalization')
-chain.wait_for_finalization(90)
+if state_pruning is not None and state_pruning.isnumeric():
+    bound = min(256, int(state_pruning))
+    printt(f'Pruning turned on. Waiting for {bound} blocks to finalize')
+    chain.wait_for_finalization(bound)
 
 printt('Killing one validator and one nonvalidator')
 chain.stop(nodes=[3, 4])

--- a/local-tests/test_catch_up.py
+++ b/local-tests/test_catch_up.py
@@ -3,10 +3,17 @@ import os
 import sys
 from os.path import abspath, join
 from time import sleep, ctime
+import argparse
 
 from chainrunner import Chain, Seq, generate_keys, check_finalized
 
+
 def printt(s): print(ctime() + ' | ' + s)
+
+
+argParser = argparse.ArgumentParser()
+argParser.add_argument("--state-pruning", help="state pruning argument")
+state_pruning = argParser.parse_args().state_pruning
 
 # Path to working directory, where chainspec, logs and nodes' dbs are written:
 workdir = abspath(os.getenv('WORKDIR', '/tmp/workdir'))
@@ -23,6 +30,8 @@ chain.bootstrap(binary,
                 nonvalidators=all_accounts[4:],
                 sudo_account_id=keys[phrases[0]],
                 chain_type='local')
+printt('Purging previous chain')
+chain.purge()
 
 chain.set_flags('no-mdns',
                 port=Seq(30334),
@@ -30,12 +39,15 @@ chain.set_flags('no-mdns',
                 ws_port=Seq(9944),
                 rpc_port=Seq(9933),
                 unit_creation_delay=200,
-                execution='Native',
-                state_pruning='archive')
+                execution='Native')
 addresses = [n.address() for n in chain]
 validator_addresses = [n.validator_address() for n in chain]
 chain.set_flags(bootnodes=addresses[0])
-chain.set_flags_validator(public_addr=addresses, public_validator_addresses=validator_addresses)
+chain.set_flags_validator(public_addr=addresses,
+                          public_validator_addresses=validator_addresses)
+if state_pruning is not None:
+    chain.set_flags('experimental-pruning', state_pruning=state_pruning,
+                    )
 
 chain.set_flags_validator('validator')
 
@@ -46,10 +58,10 @@ sleep(60)
 
 chain.start('aleph', nodes=[4, 5])
 
-printt('Waiting for finalization')
-chain.wait_for_finalization(0)
 printt('Waiting for authorities')
 chain.wait_for_authorities()
+printt('Waiting for finalization')
+chain.wait_for_finalization(90)
 
 printt('Killing one validator and one nonvalidator')
 chain.stop(nodes=[3, 4])

--- a/local-tests/test_multiple_restarts.py
+++ b/local-tests/test_multiple_restarts.py
@@ -29,9 +29,6 @@ chain.bootstrap(binary,
                 sudo_account_id=keys[phrases[0]],
                 chain_type='local')
 
-printt('Purging previous chain')
-chain.purge()
-
 chain.set_flags('no-mdns',
                 port=Seq(30334),
                 validator_port=Seq(30343),
@@ -53,10 +50,14 @@ chain.set_flags_validator('validator')
 printt('Starting the chain')
 chain.start('aleph')
 
+printt('Waiting for finalization')
+chain.wait_for_finalization(0)
 printt('Waiting for authorities')
 chain.wait_for_authorities()
-printt('Waiting for finalization')
-chain.wait_for_finalization(256)
+if state_pruning is not None and state_pruning.isnumeric():
+    bound = min(256, int(state_pruning))
+    printt(f'Pruning turned on. Waiting for {bound} blocks to finalize')
+    chain.wait_for_finalization(bound)
 
 delta = 5
 


### PR DESCRIPTION
# Description

Test for nodes with pruning turned on.

## Type of change

Two new tests are added.
* catch up with state pruning 90 (short session is on)
* multiple restarts with state pruning 2048 (no short session)

Removed archive argument from tests (it does not need to be passed in normal usage).
Catch up tests waits for 90 finalized blocks, to check if pruning works.
Multiple restarts test waits for 256 finalized blocks, as default pruning setting for substrate is 256.

# Checklist:

- I have added tests
- I have made neccessary updates to the Infrastructure
