### PR TITLE
Add call indices to pallets

### DIFF
--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -234,6 +234,7 @@ pub mod pallet {
     impl<T: Config> Pallet<T> {
         /// Sets the emergency finalization key. If called in session `N` the key can be used to
         /// finalize blocks from session `N+2` onwards, until it gets overridden.
+        #[pallet::call_index(0)]
         #[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
         pub fn set_emergency_finalizer(
             origin: OriginFor<T>,
@@ -251,6 +252,7 @@ pub mod pallet {
         /// advance of the provided session of the version change.
         /// In order to cancel a scheduled version change, a new version change should be scheduled
         /// with the same version as the current one.
+        #[pallet::call_index(1)]
         #[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
         pub fn schedule_finality_version_change(
             origin: OriginFor<T>,

--- a/pallets/elections/src/lib.rs
+++ b/pallets/elections/src/lib.rs
@@ -228,6 +228,7 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #[pallet::call_index(0)]
         #[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
         pub fn change_validators(
             origin: OriginFor<T>,
@@ -262,6 +263,7 @@ pub mod pallet {
         }
 
         /// Sets ban config, it has an immediate effect
+        #[pallet::call_index(1)]
         #[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
         pub fn set_ban_config(
             origin: OriginFor<T>,
@@ -312,6 +314,7 @@ pub mod pallet {
         }
 
         /// Schedule a non-reserved node to be banned out from the committee at the end of the era
+        #[pallet::call_index(2)]
         #[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
         pub fn ban_from_committee(
             origin: OriginFor<T>,
@@ -330,6 +333,7 @@ pub mod pallet {
         }
 
         /// Schedule a non-reserved node to be banned out from the committee at the end of the era
+        #[pallet::call_index(3)]
         #[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
         pub fn cancel_ban(origin: OriginFor<T>, banned: T::AccountId) -> DispatchResult {
             ensure_root(origin)?;
@@ -339,6 +343,7 @@ pub mod pallet {
         }
 
         /// Set openness of the elections
+        #[pallet::call_index(4)]
         #[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
         pub fn set_elections_openness(
             origin: OriginFor<T>,


### PR DESCRIPTION
# Description

See https://github.com/paritytech/substrate/pull/12891

## Type of change

Enhancement.

# Checklist:

- I have **not** bumped `spec_version` and `transaction_version`
- I have **not** bumped** aleph-client version 

These changes do not change metadata (in some sense they are redundant with the current state)