### PR TITLE
change step reference from get_branch to vars in runtime path

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -82,8 +82,8 @@ jobs:
       - name: S3 CI | Download release runtime from S3 bucket
         shell: bash
         env:
-          S3BUCKET_URL: s3://${{ secrets.CI_MAINNET_S3BUCKET_NAME }}/builds/aleph-node/commits/${{ steps.get_branch.outputs.sha_short }}/aleph-runtime
-          S3BUCKET_FILE: aleph-runtime-${{ steps.get_branch.outputs.sha_short }}.tar.gz
+          S3BUCKET_URL: s3://${{ secrets.CI_MAINNET_S3BUCKET_NAME }}/builds/aleph-node/commits/${{ steps.vars.outputs.sha_short }}/aleph-runtime
+          S3BUCKET_FILE: aleph-runtime-${{ steps.vars.outputs.sha_short }}.tar.gz
         run: |
           aws s3 cp ${{ env.S3BUCKET_URL }}/${{ env.S3BUCKET_FILE }} ${{ env.S3BUCKET_FILE }}
 


### PR DESCRIPTION
# Description

Recently there appeared problem with retrieving `aleph-runtime.tar.gz` in testnet deploy workflow. It was caused by empty string appearing instead of `sha_short` of current commit resulting in inability to pull mentioned object.

## Type of change

- Bug fix 

# Checklist:

<!-- delete when not applicable to your PR -->

- I have changed step reference in testnet deploy workflow from nonexistent `get_branch` to `vars`
