### PR TITLE
A0-1306: add posibility for experimental pruning in docker_entrypoint.sh

### DIFF
--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -18,7 +18,8 @@ fn default_blocks_pruning() -> DatabasePruningMode {
 }
 
 fn pruning_changed(params: &PruningParams) -> bool {
-    let state_pruning_changed = params.state_pruning != default_state_pruning();
+    let state_pruning_changed =
+        params.state_pruning.is_some() && (params.state_pruning != default_state_pruning());
 
     let blocks_pruning_changed = params.blocks_pruning != default_blocks_pruning();
 

--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -42,7 +42,6 @@ fi
 
 ARGS=(
   --validator
-  --state-pruning archive
   --execution Native
   --name "${NAME}"
   --base-path "${BASE_PATH}"

--- a/scripts/run_nodes.sh
+++ b/scripts/run_nodes.sh
@@ -83,7 +83,6 @@ run_node() {
   ./target/release/aleph-node purge-chain --base-path $BASE_PATH/$account_id --chain $BASE_PATH/chainspec.json -y
   ./target/release/aleph-node \
     $validator \
-    --state-pruning=archive \
     --chain $BASE_PATH/chainspec.json \
     --base-path $BASE_PATH/$account_id \
     --name $auth \


### PR DESCRIPTION
# Description

Now there is no need to pass `--state-pruning archive` as this is always overwritten. Without it it is possible to run docker image with experimental pruning

## Type of change

- Bug fix (non-breaking change which fixes an issue)
