### PR TITLE
Delegate attribute parsing to `darling`

### DIFF
--- a/relations/src/linear.rs
+++ b/relations/src/linear.rs
@@ -13,16 +13,16 @@ mod relation {
     #[relation_object_definition]
     struct LinearEquationRelation {
         /// slope
-        #[constant]
+        #[constant()]
         pub a: u32,
         /// private witness
-        #[private_input]
+        #[private_input()]
         pub x: u32,
         /// an intercept
-        #[constant]
+        #[constant()]
         pub b: u32,
         /// constant
-        #[constant]
+        #[constant()]
         pub y: u32,
     }
 

--- a/relations/src/proc_macro/Cargo.lock
+++ b/relations/src/proc_macro/Cargo.lock
@@ -3,9 +3,57 @@
 version = 3
 
 [[package]]
-name = "liminal-ark-relation-macro"
-version = "0.1.0"
+name = "darling"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "liminal-ark-relation-macro"
+version = "0.1.1"
+dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -28,6 +76,12 @@ checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/relations/src/proc_macro/Cargo.toml
+++ b/relations/src/proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liminal-ark-relation-macro"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Cardinal"]
 documentation = "https://docs.rs/?"
@@ -14,6 +14,7 @@ description = "Procedural macro for concise defining SNARK relations."
 proc-macro = true
 
 [dependencies]
+darling = "0.14.3"
 proc-macro2 = "1.0"
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"

--- a/relations/src/proc_macro/src/intermediate_representation.rs
+++ b/relations/src/proc_macro/src/intermediate_representation.rs
@@ -1,3 +1,4 @@
+use darling::FromMeta;
 use proc_macro2::{Ident, Span};
 use syn::{
     spanned::Spanned, Error as SynError, Field, Fields, FieldsNamed, Item, ItemFn, ItemMod,
@@ -5,14 +6,8 @@ use syn::{
 };
 
 use crate::{
-    naming::{
-        CONSTANT_FIELD, FIELD_FRONTEND_TYPE, FIELD_PARSER, FIELD_SERIALIZER, PRIVATE_INPUT_FIELD,
-        PUBLIC_INPUT_FIELD,
-    },
-    parse_utils::{
-        as_circuit_def, as_relation_object_def, get_field_attr, get_public_input_field_config,
-        get_relation_field_config,
-    },
+    naming::{CONSTANT_FIELD, PRIVATE_INPUT_FIELD, PUBLIC_INPUT_FIELD},
+    parse_utils::{as_circuit_def, as_relation_object_def, get_field_attr},
 };
 
 /// Intermediate representation of the source code.
@@ -34,20 +29,35 @@ pub(super) struct IR {
     pub imports: Vec<ItemUse>,
 }
 
-/// Common data for constant, public and private inputs.
-#[derive(Clone)]
-pub(super) struct RelationField {
-    /// The source item AST.
-    pub field: Field,
+#[derive(Clone, Default, FromMeta)]
+pub(super) struct RelationFieldAttrs {
     /// The value of the `frontend_type` modifier, if any.
     pub frontend_type: Option<String>,
     /// The value of the `parse_with` modifier, if any.
     pub parse_with: Option<String>,
 }
 
+/// Common data for constant, public and private inputs.
+#[derive(Clone)]
+pub(super) struct RelationField {
+    /// Field itself (the source item AST).
+    pub field: Field,
+    /// Field attributes and modifiers.
+    pub attrs: RelationFieldAttrs,
+}
+
 impl RelationField {
+    /// Returns the span of the field.
     pub fn span(&self) -> Span {
         self.field.span()
+    }
+
+    /// Forcibly extracts ident from the field.
+    pub fn ident(&self) -> &Ident {
+        self.field
+            .ident
+            .as_ref()
+            .expect("Expected struct with named fields")
     }
 }
 
@@ -56,34 +66,55 @@ impl TryFrom<Field> for RelationField {
 
     fn try_from(field: Field) -> Result<Self, Self::Error> {
         let attr = get_field_attr(&field)?;
-        let config = get_relation_field_config(attr)?;
+        let attrs = RelationFieldAttrs::from_meta(&attr.parse_meta()?)?;
 
-        Ok(RelationField {
-            field,
-            frontend_type: config.get(FIELD_FRONTEND_TYPE).cloned(),
-            parse_with: config.get(FIELD_PARSER).cloned(),
-        })
+        Ok(RelationField { field, attrs })
     }
+}
+
+#[derive(Clone, Default, FromMeta)]
+pub(super) struct PublicFieldAttrs {
+    /// The value of the `frontend_type` modifier, if any.
+    pub frontend_type: Option<String>,
+    /// The value of the `parse_with` modifier, if any.
+    pub parse_with: Option<String>,
+    /// The value of the `serialize_with` modifier, if any.
+    pub serialize_with: Option<String>,
 }
 
 /// Full data for public inputs.
 #[derive(Clone)]
 pub(super) struct PublicInputField {
-    /// Common data for all inputs.
-    pub inner: RelationField,
-    /// The value of the `serialize_with` modifier, if any.
-    pub serialize_with: Option<String>,
+    /// Field itself (the source item AST).
+    pub field: Field,
+    /// Field attributes and modifiers.
+    pub attrs: PublicFieldAttrs,
 }
 
 impl PublicInputField {
+    /// Returns the span of the field.
     pub fn span(&self) -> Span {
-        self.inner.span()
+        self.field.span()
+    }
+
+    /// Forcibly extracts ident from the field.
+    pub fn ident(&self) -> &Ident {
+        self.field
+            .ident
+            .as_ref()
+            .expect("Expected struct with named fields")
     }
 }
 
 impl From<PublicInputField> for RelationField {
     fn from(public_input_field: PublicInputField) -> Self {
-        public_input_field.inner
+        RelationField {
+            field: public_input_field.field,
+            attrs: RelationFieldAttrs {
+                frontend_type: public_input_field.attrs.frontend_type,
+                parse_with: public_input_field.attrs.parse_with,
+            },
+        }
     }
 }
 
@@ -92,16 +123,9 @@ impl TryFrom<Field> for PublicInputField {
 
     fn try_from(field: Field) -> Result<Self, Self::Error> {
         let attr = get_field_attr(&field)?;
-        let config = get_public_input_field_config(attr)?;
+        let attrs = PublicFieldAttrs::from_meta(&attr.parse_meta()?)?;
 
-        Ok(PublicInputField {
-            inner: RelationField {
-                field,
-                frontend_type: config.get(FIELD_FRONTEND_TYPE).cloned(),
-                parse_with: config.get(FIELD_PARSER).cloned(),
-            },
-            serialize_with: config.get(FIELD_SERIALIZER).cloned(),
-        })
+        Ok(PublicInputField { field, attrs })
     }
 }
 
@@ -222,7 +246,7 @@ fn extract_items(item_mod: ItemMod) -> SynResult<Items> {
 
 /// Returns all the elements of `fields` that are attributed with `field_type`, e.g.
 /// ```ignore
-/// #[public_input]
+/// #[public_input()]
 /// a: u8
 /// ```
 fn extract_relation_fields<FieldType: ?Sized>(

--- a/relations/src/proc_macro/src/lib.rs
+++ b/relations/src/proc_macro/src/lib.rs
@@ -48,11 +48,11 @@ use crate::{code_generation::generate_code, intermediate_representation::IR};
 ///mod relation {
 ///    #[relation_object_definition]
 ///    struct SomeRelation {
-///        #[constant]
+///        #[constant()]
 ///        a: CF,
-///        #[public_input]
+///        #[public_input()]
 ///        b: CF,
-///        #[private_input]
+///        #[private_input()]
 ///        c: CF,
 ///    }
 ///
@@ -109,7 +109,7 @@ use crate::{code_generation::generate_code, intermediate_representation::IR};
 /// mod relation {
 ///     #[relation_object_definition]
 ///     struct SomeRelation {
-///         #[constant]
+///         #[constant()]
 ///         a: u8,
 ///         #[public_input(frontend_type = "u16", parse_with = "parse_u16")]
 ///         b: CF,

--- a/relations/src/proc_macro/src/naming.rs
+++ b/relations/src/proc_macro/src/naming.rs
@@ -10,10 +10,6 @@ pub(super) const CONSTANT_FIELD: &str = "constant";
 pub(super) const PUBLIC_INPUT_FIELD: &str = "public_input";
 pub(super) const PRIVATE_INPUT_FIELD: &str = "private_input";
 
-pub(super) const FIELD_SERIALIZER: &str = "serialize_with";
-pub(super) const FIELD_FRONTEND_TYPE: &str = "frontend_type";
-pub(super) const FIELD_PARSER: &str = "parse_with";
-
 pub(super) fn struct_name_without_input<T: Display>(relation_base_name: T) -> Ident {
     format_ident!("{relation_base_name}WithoutInput")
 }

--- a/relations/src/proc_macro/src/parse_utils.rs
+++ b/relations/src/proc_macro/src/parse_utils.rs
@@ -1,17 +1,14 @@
-use std::collections::{HashMap, HashSet};
-
 use syn::{
-    spanned::Spanned, Attribute, Error as SynError, Field, Item, ItemFn, ItemStruct, Lit, Meta,
-    MetaList, MetaNameValue, NestedMeta, Result as SynResult,
+    spanned::Spanned, Attribute, Error as SynError, Field, Item, ItemFn, ItemStruct,
+    Result as SynResult,
 };
 
 use crate::naming::{
-    CIRCUIT_DEF, CONSTANT_FIELD, FIELD_FRONTEND_TYPE, FIELD_PARSER, FIELD_SERIALIZER,
-    PRIVATE_INPUT_FIELD, PUBLIC_INPUT_FIELD, RELATION_OBJECT_DEF,
+    CIRCUIT_DEF, CONSTANT_FIELD, PRIVATE_INPUT_FIELD, PUBLIC_INPUT_FIELD, RELATION_OBJECT_DEF,
 };
 
-/// Returns the unique field attribute (either `#[constant]`, `#[public_input]` or
-/// `#[private_input]`).
+/// Returns the unique field attribute (either `#[constant(..)]`, `#[public_input(..)]` or
+/// `#[private_input(..)]`).
 pub(super) fn get_field_attr(field: &Field) -> SynResult<&Attribute> {
     let attrs = field
         .attrs
@@ -28,56 +25,6 @@ pub(super) fn get_field_attr(field: &Field) -> SynResult<&Attribute> {
             field.span(),
             "Relation field should have exactly one type: constant, public or private input.",
         )),
-    }
-}
-
-/// Returns mapping from the modifier name to the literal value. Expects only common modifiers in
-/// `attr`.
-pub(super) fn get_relation_field_config(attr: &Attribute) -> SynResult<HashMap<String, String>> {
-    let permissible_config = HashSet::from([FIELD_FRONTEND_TYPE, FIELD_PARSER]);
-    get_field_config(attr, &permissible_config)
-}
-
-/// Returns mapping from the modifier name to the literal value. Accepts all modifiers.
-pub(super) fn get_public_input_field_config(
-    attr: &Attribute,
-) -> SynResult<HashMap<String, String>> {
-    let permissible_config = HashSet::from([FIELD_FRONTEND_TYPE, FIELD_PARSER, FIELD_SERIALIZER]);
-    get_field_config(attr, &permissible_config)
-}
-
-/// Returns mapping from the modifier name to the literal value.
-fn get_field_config(
-    attr: &Attribute,
-    permissible_config: &HashSet<&str>,
-) -> SynResult<HashMap<String, String>> {
-    let err = SynError::new(attr.span(), "Invalid attribute syntax");
-
-    match attr.parse_meta()? {
-        Meta::Path(_) => Ok(HashMap::new()),
-        Meta::NameValue(_) => Err(err),
-        Meta::List(MetaList { nested, .. }) => {
-            let mut config = HashMap::new();
-            for nm in nested {
-                match nm {
-                    NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit, .. })) => {
-                        let path = path.get_ident().map(|i| i.to_string()).ok_or(err.clone())?;
-                        if !permissible_config.contains(path.as_str()) {
-                            return Err(err);
-                        }
-                        let lit = match lit {
-                            Lit::Str(lit_str) => lit_str.value(),
-                            Lit::Int(lit_int) => lit_int.token().to_string(),
-                            _ => return Err(err),
-                        };
-                        config.insert(path, lit);
-                    }
-                    _ => return Err(err),
-                }
-            }
-
-            Ok(config)
-        }
     }
 }
 

--- a/relations/src/shielder/deposit_and_merge.rs
+++ b/relations/src/shielder/deposit_and_merge.rs
@@ -32,7 +32,7 @@ mod relation {
 
     #[relation_object_definition]
     struct DepositAndMergeRelation {
-        #[constant]
+        #[constant()]
         pub max_path_len: u8,
 
         // Public inputs

--- a/relations/src/shielder/withdraw.rs
+++ b/relations/src/shielder/withdraw.rs
@@ -36,7 +36,7 @@ mod relation {
 
     #[relation_object_definition]
     struct WithdrawRelation {
-        #[constant]
+        #[constant()]
         pub max_path_len: u8,
 
         // Public inputs

--- a/relations/src/xor.rs
+++ b/relations/src/xor.rs
@@ -19,9 +19,9 @@ mod relation {
         // Otherwise, we have to provide it to circuit bit by bit.
         #[public_input(serialize_with = "byte_to_bits")]
         public_xoree: u8,
-        #[private_input]
+        #[private_input()]
         private_xoree: u8,
-        #[constant]
+        #[constant()]
         result: u8,
     }
 


### PR DESCRIPTION
# Description

We give up parsing field attributes on our side (which was pretty sketchy and a bit fragile). For that we use `darling`. The only drawback is that now empty attributes must include `()` (`#[constant]` -> `#[constant()]`). This can be removed by the cost of digging back into metadata on macro side.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- I have made corresponding changes to the existing documentation
