### PR TITLE
adding key ownership and lockabel deposits

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -330,13 +330,16 @@ parameter_types! {
     // We allow 10kB keys, proofs and public inputs. This is a 100% blind guess.
     pub const MaximumVerificationKeyLength: u32 = 10_000;
     pub const MaximumDataLength: u32 = 10_000;
+    pub const VerificationKeyDepositAmount: u128 = 1_000_000_000;
 }
 
 impl pallet_baby_liminal::Config for Runtime {
+    type Currency = Balances;
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = pallet_baby_liminal::AlephWeight<Runtime>;
     type MaximumVerificationKeyLength = MaximumVerificationKeyLength;
     type MaximumDataLength = MaximumDataLength;
+    type VerificationKeyDepositAmount = VerificationKeyDepositAmount;
 }
 
 impl_opaque_keys! {


### PR DESCRIPTION
# Description

Adding ownership info for verification keys. A configurable amount of native token is locked until the key is deleted. Only original owner is able to delete or overwrite a key. 
Deposits are tracked such that even if runtime changed the correct amount is unlocked.
In case of key overwrites we do not bother with deposit difference if it changed in the meantime - it will be returned at key delete anyway. 