### PR TITLE
Fail early with helpful error message.

### DIFF
--- a/.github/scripts/run_consensus.sh
+++ b/.github/scripts/run_consensus.sh
@@ -17,6 +17,15 @@ MIN_VALIDATOR_COUNT=4
 
 export NODE_IMAGE
 
+if [[ $(docker images | grep ${NODE_IMAGE}) ]]; then
+  echo "${NODE_IMAGE} found locally"
+else
+  echo "${NODE_IMAGE} not found locally."
+  echo "Build image first with:"
+  echo "docker build -t aleph-node:latest -f docker/Dockerfile ."
+  exit 1;
+fi
+
 mkdir -p docker/data/
 
 function usage {


### PR DESCRIPTION
If `aleph-node:latest` docker image can't be found locally we should fail early and inform user with actionable instructions. Otherwise docker will try to pull `aleph-node:latest` from the official docker hub and fail with confusing messages.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)