### PR TITLE
Add skip-workflows for required checks that have to succeed

### DIFF
--- a/.github/workflows/skip-check-excluded-packages.yml
+++ b/.github/workflows/skip-check-excluded-packages.yml
@@ -1,0 +1,28 @@
+---
+name: Check excluded packages
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'flooder/**'
+      - 'e2e-tests/**'
+      - 'aleph-client/**'
+      - 'fork-off/**'
+      - 'bin/cliain/**'
+      - 'benches/**'
+      - 'contracts/**'
+      # TODO this package needs to be moved to /bin
+      - 'scripts/synthetic-network/synthetic-link/**'
+      - .github/workflows/check-excluded-packages.yml
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Skip 'Check excluded packages'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Return success
+        run: echo "'Check excluded packages' not required"

--- a/.github/workflows/skip-check-excluded-packages.yml
+++ b/.github/workflows/skip-check-excluded-packages.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   build:
-    name: Skip 'Check excluded packages'
+    name: Check excluded packages
     runs-on: ubuntu-20.04
     steps:
       - name: Return success

--- a/.github/workflows/skip-check-excluded-packages.yml
+++ b/.github/workflows/skip-check-excluded-packages.yml
@@ -11,7 +11,6 @@ on:
       - 'bin/cliain/**'
       - 'benches/**'
       - 'contracts/**'
-      # TODO this package needs to be moved to /bin
       - 'scripts/synthetic-network/synthetic-link/**'
       - .github/workflows/check-excluded-packages.yml
 

--- a/.github/workflows/skip-e2e-tests-main-devnet.yml
+++ b/.github/workflows/skip-e2e-tests-main-devnet.yml
@@ -9,14 +9,6 @@ on:
     branches:
       - main
       - 'release-*'
-  push:
-    paths:
-      - 'fork-off/**'
-      - 'flooder/**'
-    branches:
-      - main
-      - 'release-*'
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/skip-e2e-tests-main-devnet.yml
+++ b/.github/workflows/skip-e2e-tests-main-devnet.yml
@@ -1,0 +1,38 @@
+---
+name: e2e-tests-main-devnet
+
+on:
+  pull_request:
+    paths:
+      - 'fork-off/**'
+      - 'flooder/**'
+    branches:
+      - main
+      - 'release-*'
+  push:
+    paths:
+      - 'fork-off/**'
+      - 'flooder/**'
+    branches:
+      - main
+      - 'release-*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  check-e2e-test-suite-completion:
+    name: Check e2e test suite completion
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Return success
+        run: echo "'Check e2e test suite completion' not required"
+
+  check-determinism:
+    name: Verify runtime build determinism
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Return success
+        run: echo "'Verify runtime build determinism' not required"

--- a/.github/workflows/skip-unit_tests.yml
+++ b/.github/workflows/skip-unit_tests.yml
@@ -1,0 +1,23 @@
+---
+name: unit-tests
+
+on:
+  pull_request:
+    paths:
+      - 'fork-off/**'
+      - 'flooder/**'
+  push:
+    branches:
+      - 'release-*'
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Skip 'unit-tests'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Return success
+        run: echo "'unit-tests' not required"

--- a/.github/workflows/skip-unit_tests.yml
+++ b/.github/workflows/skip-unit_tests.yml
@@ -6,9 +6,6 @@ on:
     paths:
       - 'fork-off/**'
       - 'flooder/**'
-  push:
-    branches:
-      - 'release-*'
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/skip-yaml-lint.yml
+++ b/.github/workflows/skip-yaml-lint.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   main:
-    name: Skip 'YAML Lint'
+    name: YAML Lint
     runs-on: ubuntu-20.04
     steps:
       - name: Return success

--- a/.github/workflows/skip-yaml-lint.yml
+++ b/.github/workflows/skip-yaml-lint.yml
@@ -1,0 +1,20 @@
+---
+name: GH Action YAML linter
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    name: Skip 'YAML Lint'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Return success
+        run: echo "'YAML lint' not required"


### PR DESCRIPTION
In repository settings, we require certain statuses to be reported as succeeded.  These come from our workflows.  However, some of our workflows have `paths` configured.  Thus, they're not getting triggered and we end up in a situation where PR is stuck with a required status of Pending.  
As a solution, suggested by GitHub, we shall add additional workflows doing nothing but returning exit code of 0, with the same name, with `paths-ignored` set to `paths` from the original workflows (so it's invertion).