### PR TITLE
A0-1876: refactor session info

### DIFF
--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -23,10 +23,7 @@ use crate::{
     abft::{CurrentNetworkData, LegacyNetworkData, CURRENT_VERSION, LEGACY_VERSION},
     aggregation::{CurrentRmcNetworkData, LegacyRmcNetworkData},
     network::data::split::Split,
-    session::{
-        first_block_of_session, last_block_of_session, session_id_from_block_num,
-        SessionBoundaries, SessionId,
-    },
+    session::{SessionBoundaries, SessionId},
     VersionedTryFromError::{ExpectedNewGotOld, ExpectedOldGotNew},
 };
 

--- a/finality-aleph/src/nodes/mod.rs
+++ b/finality-aleph/src/nodes/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     mpsc,
     mpsc::UnboundedSender,
-    session::SessionInfo as SessionBoundInfo,
+    session::SessionBoundaryInfo,
     session_map::ReadOnlySessionMap,
     sync::SessionVerifier,
     BlockchainBackend, JustificationNotification, Metrics, MillisecsPerBlock, SessionPeriod,
@@ -45,14 +45,14 @@ struct JustificationParams<B: Block, H: ExHashT, C, BB> {
 
 struct SessionInfoProviderImpl {
     session_authorities: ReadOnlySessionMap,
-    session_info: SessionBoundInfo,
+    session_info: SessionBoundaryInfo,
 }
 
 impl SessionInfoProviderImpl {
     fn new(session_authorities: ReadOnlySessionMap, session_period: SessionPeriod) -> Self {
         Self {
             session_authorities,
-            session_info: SessionBoundInfo::new(session_period),
+            session_info: SessionBoundaryInfo::new(session_period),
         }
     }
 }

--- a/finality-aleph/src/nodes/mod.rs
+++ b/finality-aleph/src/nodes/mod.rs
@@ -3,6 +3,7 @@ mod validator_node;
 
 use std::{future::Future, sync::Arc};
 
+use aleph_primitives::BlockNumber;
 pub use nonvalidator_node::run_nonvalidator_node;
 use sc_client_api::Backend;
 use sc_network::NetworkService;
@@ -15,9 +16,9 @@ use crate::{
     justification::{
         JustificationHandler, JustificationRequestSchedulerImpl, SessionInfo, SessionInfoProvider,
     },
-    last_block_of_session, mpsc,
+    mpsc,
     mpsc::UnboundedSender,
-    session_id_from_block_num,
+    session::SessionInfo as SessionBoundInfo,
     session_map::ReadOnlySessionMap,
     sync::SessionVerifier,
     BlockchainBackend, JustificationNotification, Metrics, MillisecsPerBlock, SessionPeriod,
@@ -44,23 +45,26 @@ struct JustificationParams<B: Block, H: ExHashT, C, BB> {
 
 struct SessionInfoProviderImpl {
     session_authorities: ReadOnlySessionMap,
-    session_period: SessionPeriod,
+    session_info: SessionBoundInfo,
 }
 
 impl SessionInfoProviderImpl {
     fn new(session_authorities: ReadOnlySessionMap, session_period: SessionPeriod) -> Self {
         Self {
             session_authorities,
-            session_period,
+            session_info: SessionBoundInfo::new(session_period),
         }
     }
 }
 
 #[async_trait::async_trait]
-impl<B: Block> SessionInfoProvider<B, SessionVerifier> for SessionInfoProviderImpl {
+impl<B: Block> SessionInfoProvider<B, SessionVerifier> for SessionInfoProviderImpl
+where
+    B::Header: Header<Number = BlockNumber>,
+{
     async fn for_block_num(&self, number: NumberFor<B>) -> SessionInfo<B, SessionVerifier> {
-        let current_session = session_id_from_block_num(number, self.session_period);
-        let last_block_height = last_block_of_session(current_session, self.session_period);
+        let current_session = self.session_info.session_id_from_block_num(number);
+        let last_block_height = self.session_info.last_block_of_session(current_session);
         let verifier = self
             .session_authorities
             .get(current_session)
@@ -83,6 +87,7 @@ fn setup_justification_handler<B, H, C, BB, BE>(
 )
 where
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
     H: ExHashT,
     C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
     C::Api: aleph_primitives::AlephSessionApi<B>,

--- a/finality-aleph/src/nodes/nonvalidator_node.rs
+++ b/finality-aleph/src/nodes/nonvalidator_node.rs
@@ -1,8 +1,9 @@
+use aleph_primitives::BlockNumber;
 use log::{debug, error};
 use sc_client_api::Backend;
 use sc_network_common::ExHashT;
 use sp_consensus::SelectChain;
-use sp_runtime::traits::Block;
+use sp_runtime::traits::{Block, Header};
 
 use crate::{
     nodes::{setup_justification_handler, JustificationParams},
@@ -13,6 +14,7 @@ use crate::{
 pub async fn run_nonvalidator_node<B, H, C, BB, BE, SC>(aleph_config: AlephConfig<B, H, C, SC, BB>)
 where
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
     H: ExHashT,
     C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
     C::Api: aleph_primitives::AlephSessionApi<B>,

--- a/finality-aleph/src/nodes/validator_node.rs
+++ b/finality-aleph/src/nodes/validator_node.rs
@@ -20,10 +20,10 @@ use crate::{
     },
     nodes::{setup_justification_handler, JustificationParams},
     party::{
-        impls::{ChainStateImpl, SessionInfoImpl},
-        manager::NodeSessionManagerImpl,
-        ConsensusParty, ConsensusPartyParams,
+        impls::ChainStateImpl, manager::NodeSessionManagerImpl, ConsensusParty,
+        ConsensusPartyParams,
     },
+    session::SessionInfo,
     session_map::{AuthorityProviderImpl, FinalityNotificatorImpl, SessionMapUpdater},
     AlephConfig, BlockchainBackend,
 };
@@ -165,7 +165,7 @@ where
             connection_manager,
             keystore,
         ),
-        session_info: SessionInfoImpl::new(session_period),
+        session_info: SessionInfo::new(session_period),
     });
 
     debug!(target: "aleph-party", "Consensus party has started.");

--- a/finality-aleph/src/nodes/validator_node.rs
+++ b/finality-aleph/src/nodes/validator_node.rs
@@ -23,7 +23,7 @@ use crate::{
         impls::ChainStateImpl, manager::NodeSessionManagerImpl, ConsensusParty,
         ConsensusPartyParams,
     },
-    session::SessionInfo,
+    session::SessionBoundaryInfo,
     session_map::{AuthorityProviderImpl, FinalityNotificatorImpl, SessionMapUpdater},
     AlephConfig, BlockchainBackend,
 };
@@ -165,7 +165,7 @@ where
             connection_manager,
             keystore,
         ),
-        session_info: SessionInfo::new(session_period),
+        session_info: SessionBoundaryInfo::new(session_period),
     });
 
     debug!(target: "aleph-party", "Consensus party has started.");

--- a/finality-aleph/src/party/impls.rs
+++ b/finality-aleph/src/party/impls.rs
@@ -8,9 +8,8 @@ use sp_consensus::SyncOracle;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 
 use crate::{
-    party::traits::{ChainState, SessionInfo, SyncState},
-    session::{first_block_of_session, last_block_of_session, session_id_from_block_num},
-    ClientForAleph, SessionId, SessionPeriod,
+    party::traits::{ChainState, SyncState},
+    ClientForAleph,
 };
 
 pub struct ChainStateImpl<B, BE, CFA>
@@ -35,30 +34,6 @@ where
     }
     fn finalized_number(&self) -> BlockNumber {
         self.client.info().finalized_number
-    }
-}
-
-pub struct SessionInfoImpl {
-    session_period: SessionPeriod,
-}
-
-impl SessionInfoImpl {
-    pub fn new(session_period: SessionPeriod) -> Self {
-        Self { session_period }
-    }
-}
-
-impl SessionInfo for SessionInfoImpl {
-    fn session_id_from_block_num(&self, n: BlockNumber) -> SessionId {
-        session_id_from_block_num(n, self.session_period)
-    }
-
-    fn last_block_of_session(&self, session_id: SessionId) -> BlockNumber {
-        last_block_of_session(session_id, self.session_period)
-    }
-
-    fn first_block_of_session(&self, session_id: SessionId) -> BlockNumber {
-        first_block_of_session(session_id, self.session_period)
     }
 }
 

--- a/finality-aleph/src/party/mocks.rs
+++ b/finality-aleph/src/party/mocks.rs
@@ -13,10 +13,9 @@ use crate::{
     party::{
         backup::ABFTBackup,
         manager::AuthorityTask,
-        traits::{ChainState, NodeSessionManager, SessionInfo, SyncState},
+        traits::{ChainState, NodeSessionManager, SyncState},
     },
-    session::{first_block_of_session, last_block_of_session, session_id_from_block_num},
-    AuthorityId, NodeIndex, SessionId, SessionPeriod,
+    AuthorityId, NodeIndex, SessionId,
 };
 
 type AMutex<T> = Arc<Mutex<T>>;
@@ -174,31 +173,5 @@ impl NodeSessionManager for Arc<MockNodeSessionManager> {
         }
 
         None
-    }
-}
-
-pub struct MockSessionInfo {
-    pub session_period: SessionPeriod,
-}
-
-impl MockSessionInfo {
-    pub fn new(session_period: u32) -> Self {
-        Self {
-            session_period: SessionPeriod(session_period),
-        }
-    }
-}
-
-impl SessionInfo for MockSessionInfo {
-    fn session_id_from_block_num(&self, n: BlockNumber) -> SessionId {
-        session_id_from_block_num(n, self.session_period)
-    }
-
-    fn last_block_of_session(&self, session_id: SessionId) -> BlockNumber {
-        last_block_of_session(session_id, self.session_period)
-    }
-
-    fn first_block_of_session(&self, session_id: SessionId) -> BlockNumber {
-        first_block_of_session(session_id, self.session_period)
     }
 }

--- a/finality-aleph/src/party/mod.rs
+++ b/finality-aleph/src/party/mod.rs
@@ -7,8 +7,9 @@ use tokio::{task::spawn_blocking, time::sleep};
 use crate::{
     party::{
         manager::{Handle, SubtaskCommon as AuthoritySubtaskCommon, Task},
-        traits::{ChainState, NodeSessionManager, SessionInfo, SyncState},
+        traits::{ChainState, NodeSessionManager, SyncState},
     },
+    session::SessionInfo,
     session_map::ReadOnlySessionMap,
     SessionId,
 };
@@ -21,40 +22,38 @@ pub mod traits;
 #[cfg(test)]
 mod mocks;
 
-pub(crate) struct ConsensusPartyParams<ST, CS, NSM, SI> {
+pub(crate) struct ConsensusPartyParams<ST, CS, NSM> {
     pub session_authorities: ReadOnlySessionMap,
     pub chain_state: CS,
     pub sync_state: ST,
     pub backup_saving_path: Option<PathBuf>,
     pub session_manager: NSM,
-    pub session_info: SI,
+    pub session_info: SessionInfo,
 }
 
-pub(crate) struct ConsensusParty<ST, CS, NSM, SI>
+pub(crate) struct ConsensusParty<ST, CS, NSM>
 where
     ST: SyncState,
     CS: ChainState,
     NSM: NodeSessionManager,
-    SI: SessionInfo,
 {
     session_authorities: ReadOnlySessionMap,
     chain_state: CS,
     sync_state: ST,
     backup_saving_path: Option<PathBuf>,
     session_manager: NSM,
-    session_info: SI,
+    session_info: SessionInfo,
 }
 
 const SESSION_STATUS_CHECK_PERIOD: Duration = Duration::from_millis(1000);
 
-impl<ST, CS, NSM, SI> ConsensusParty<ST, CS, NSM, SI>
+impl<ST, CS, NSM> ConsensusParty<ST, CS, NSM>
 where
     ST: SyncState,
     CS: ChainState,
     NSM: NodeSessionManager,
-    SI: SessionInfo,
 {
-    pub(crate) fn new(params: ConsensusPartyParams<ST, CS, NSM, SI>) -> Self {
+    pub(crate) fn new(params: ConsensusPartyParams<ST, CS, NSM>) -> Self {
         let ConsensusPartyParams {
             session_authorities,
             sync_state,
@@ -269,19 +268,16 @@ mod tests {
 
     use crate::{
         party::{
-            mocks::{MockChainState, MockNodeSessionManager, MockSessionInfo, MockSyncState},
+            mocks::{MockChainState, MockNodeSessionManager, MockSyncState},
             ConsensusParty, ConsensusPartyParams, SESSION_STATUS_CHECK_PERIOD,
         },
+        session::SessionInfo,
         session_map::SharedSessionMap,
         SessionId, SessionPeriod,
     };
 
-    type Party = ConsensusParty<
-        Arc<MockSyncState>,
-        Arc<MockChainState>,
-        Arc<MockNodeSessionManager>,
-        MockSessionInfo,
-    >;
+    type Party =
+        ConsensusParty<Arc<MockSyncState>, Arc<MockChainState>, Arc<MockNodeSessionManager>>;
 
     struct PartyState {
         validator_started: Vec<SessionId>,
@@ -504,12 +500,7 @@ mod tests {
     fn create_mocked_consensus_party(
         session_period: SessionPeriod,
     ) -> (
-        ConsensusParty<
-            Arc<MockSyncState>,
-            Arc<MockChainState>,
-            Arc<MockNodeSessionManager>,
-            MockSessionInfo,
-        >,
+        ConsensusParty<Arc<MockSyncState>, Arc<MockChainState>, Arc<MockNodeSessionManager>>,
         MockController,
     ) {
         let shared_map = SharedSessionMap::new();
@@ -518,7 +509,7 @@ mod tests {
         let chain_state = Arc::new(MockChainState::new());
         let sync_state = Arc::new(MockSyncState::new());
         let session_manager = Arc::new(MockNodeSessionManager::new());
-        let session_info = MockSessionInfo::new(session_period.0);
+        let session_info = SessionInfo::new(session_period);
 
         let controller = MockController {
             shared_session_map: shared_map,

--- a/finality-aleph/src/party/mod.rs
+++ b/finality-aleph/src/party/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         manager::{Handle, SubtaskCommon as AuthoritySubtaskCommon, Task},
         traits::{ChainState, NodeSessionManager, SyncState},
     },
-    session::SessionInfo,
+    session::SessionBoundaryInfo,
     session_map::ReadOnlySessionMap,
     SessionId,
 };
@@ -28,7 +28,7 @@ pub(crate) struct ConsensusPartyParams<ST, CS, NSM> {
     pub sync_state: ST,
     pub backup_saving_path: Option<PathBuf>,
     pub session_manager: NSM,
-    pub session_info: SessionInfo,
+    pub session_info: SessionBoundaryInfo,
 }
 
 pub(crate) struct ConsensusParty<ST, CS, NSM>
@@ -42,7 +42,7 @@ where
     sync_state: ST,
     backup_saving_path: Option<PathBuf>,
     session_manager: NSM,
-    session_info: SessionInfo,
+    session_info: SessionBoundaryInfo,
 }
 
 const SESSION_STATUS_CHECK_PERIOD: Duration = Duration::from_millis(1000);
@@ -271,7 +271,7 @@ mod tests {
             mocks::{MockChainState, MockNodeSessionManager, MockSyncState},
             ConsensusParty, ConsensusPartyParams, SESSION_STATUS_CHECK_PERIOD,
         },
-        session::SessionInfo,
+        session::SessionBoundaryInfo,
         session_map::SharedSessionMap,
         SessionId, SessionPeriod,
     };
@@ -509,7 +509,7 @@ mod tests {
         let chain_state = Arc::new(MockChainState::new());
         let sync_state = Arc::new(MockSyncState::new());
         let session_manager = Arc::new(MockNodeSessionManager::new());
-        let session_info = SessionInfo::new(session_period);
+        let session_info = SessionBoundaryInfo::new(session_period);
 
         let controller = MockController {
             shared_session_map: shared_map,

--- a/finality-aleph/src/party/traits.rs
+++ b/finality-aleph/src/party/traits.rs
@@ -60,13 +60,3 @@ pub trait SyncState {
     /// [1]: finality_aleph::network::RequestBlocks::is_major_syncing
     fn is_major_syncing(&self) -> bool;
 }
-
-/// Abstraction of the session boundaries.
-pub trait SessionInfo {
-    /// Returns session id of the session that block belongs to.
-    fn session_id_from_block_num(&self, n: BlockNumber) -> SessionId;
-    /// Returns block number which is the last block of the session.
-    fn last_block_of_session(&self, session_id: SessionId) -> BlockNumber;
-    /// Returns block number which is the first block of the session.
-    fn first_block_of_session(&self, session_id: SessionId) -> BlockNumber;
-}

--- a/finality-aleph/src/session.rs
+++ b/finality-aleph/src/session.rs
@@ -1,8 +1,6 @@
+use aleph_primitives::BlockNumber;
 use codec::{Decode, Encode};
-use sp_runtime::{
-    traits::{AtLeast32BitUnsigned, Block},
-    SaturatedConversion,
-};
+use sp_runtime::traits::Block;
 
 use crate::NumberFor;
 
@@ -15,8 +13,8 @@ pub struct SessionBoundaries<B: Block> {
 impl<B: Block> SessionBoundaries<B> {
     pub fn new(session_id: SessionId, period: SessionPeriod) -> Self {
         SessionBoundaries {
-            first_block: first_block_of_session(session_id, period),
-            last_block: last_block_of_session(session_id, period),
+            first_block: first_block_of_session(session_id, period).into(),
+            last_block: last_block_of_session(session_id, period).into(),
         }
     }
 
@@ -29,25 +27,44 @@ impl<B: Block> SessionBoundaries<B> {
     }
 }
 
-pub fn first_block_of_session<N: AtLeast32BitUnsigned>(
-    session_id: SessionId,
-    period: SessionPeriod,
-) -> N {
-    (session_id.0 * period.0).into()
+fn first_block_of_session(session_id: SessionId, period: SessionPeriod) -> BlockNumber {
+    session_id.0 * period.0
 }
 
-pub fn last_block_of_session<N: AtLeast32BitUnsigned>(
-    session_id: SessionId,
-    period: SessionPeriod,
-) -> N {
-    ((session_id.0 + 1) * period.0 - 1).into()
+fn last_block_of_session(session_id: SessionId, period: SessionPeriod) -> BlockNumber {
+    (session_id.0 + 1) * period.0 - 1
 }
 
-pub fn session_id_from_block_num<N: AtLeast32BitUnsigned>(
-    num: N,
-    period: SessionPeriod,
-) -> SessionId {
-    SessionId((num / period.0.into()).saturated_into())
+fn session_id_from_block_num(num: BlockNumber, period: SessionPeriod) -> SessionId {
+    SessionId(num / period.0)
+}
+
+pub struct SessionInfo {
+    session_period: SessionPeriod,
+}
+
+impl SessionInfo {
+    pub fn new(session_period: SessionPeriod) -> Self {
+        Self { session_period }
+    }
+}
+
+/// Struct for getting the session boundaries.
+impl SessionInfo {
+    /// Returns session id of the session that block belongs to.
+    pub fn session_id_from_block_num(&self, n: BlockNumber) -> SessionId {
+        session_id_from_block_num(n, self.session_period)
+    }
+
+    /// Returns block number which is the last block of the session.
+    pub fn last_block_of_session(&self, session_id: SessionId) -> BlockNumber {
+        last_block_of_session(session_id, self.session_period)
+    }
+
+    /// Returns block number which is the first block of the session.
+    pub fn first_block_of_session(&self, session_id: SessionId) -> BlockNumber {
+        first_block_of_session(session_id, self.session_period)
+    }
 }
 
 #[cfg(test)]

--- a/finality-aleph/src/session.rs
+++ b/finality-aleph/src/session.rs
@@ -39,18 +39,16 @@ fn session_id_from_block_num(num: BlockNumber, period: SessionPeriod) -> Session
     SessionId(num / period.0)
 }
 
-pub struct SessionInfo {
+pub struct SessionBoundaryInfo {
     session_period: SessionPeriod,
 }
 
-impl SessionInfo {
+/// Struct for getting the session boundaries.
+impl SessionBoundaryInfo {
     pub fn new(session_period: SessionPeriod) -> Self {
         Self { session_period }
     }
-}
 
-/// Struct for getting the session boundaries.
-impl SessionInfo {
     /// Returns session id of the session that block belongs to.
     pub fn session_id_from_block_num(&self, n: BlockNumber) -> SessionId {
         session_id_from_block_num(n, self.session_period)

--- a/finality-aleph/src/session_map.rs
+++ b/finality-aleph/src/session_map.rs
@@ -14,7 +14,7 @@ use tokio::sync::{
     RwLock,
 };
 
-use crate::{session::SessionInfo, ClientForAleph, SessionId, SessionPeriod};
+use crate::{session::SessionBoundaryInfo, ClientForAleph, SessionId, SessionPeriod};
 
 const PRUNING_THRESHOLD: u32 = 10;
 type SessionMap = HashMap<SessionId, SessionAuthorityData>;
@@ -241,7 +241,7 @@ where
     session_map: SharedSessionMap,
     authority_provider: AP,
     finality_notificator: FN,
-    session_info: SessionInfo,
+    session_info: SessionBoundaryInfo,
     _phantom: PhantomData<B>,
 }
 
@@ -257,7 +257,7 @@ where
             session_map: SharedSessionMap::new(),
             authority_provider,
             finality_notificator,
-            session_info: SessionInfo::new(period),
+            session_info: SessionBoundaryInfo::new(period),
             _phantom: PhantomData,
         }
     }

--- a/finality-aleph/src/session_map.rs
+++ b/finality-aleph/src/session_map.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 
-use aleph_primitives::{AlephSessionApi, SessionAuthorityData};
+use aleph_primitives::{AlephSessionApi, BlockNumber, SessionAuthorityData};
 use futures::StreamExt;
 use log::{debug, error, trace};
 use sc_client_api::{Backend, FinalityNotification};
@@ -14,19 +14,17 @@ use tokio::sync::{
     RwLock,
 };
 
-use crate::{
-    first_block_of_session, session_id_from_block_num, ClientForAleph, SessionId, SessionPeriod,
-};
+use crate::{session::SessionInfo, ClientForAleph, SessionId, SessionPeriod};
 
 const PRUNING_THRESHOLD: u32 = 10;
 type SessionMap = HashMap<SessionId, SessionAuthorityData>;
 type SessionSubscribers = HashMap<SessionId, Vec<OneShotSender<SessionAuthorityData>>>;
 
-pub trait AuthorityProvider<B> {
+pub trait AuthorityProvider<N> {
     /// returns authority data for block
-    fn authority_data(&self, block: B) -> Option<SessionAuthorityData>;
+    fn authority_data(&self, block: N) -> Option<SessionAuthorityData>;
     /// returns next session authority data where current session is for block
-    fn next_authority_data(&self, block: B) -> Option<SessionAuthorityData>;
+    fn next_authority_data(&self, block: N) -> Option<SessionAuthorityData>;
 }
 
 /// Default implementation of authority provider trait.
@@ -63,6 +61,7 @@ where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
     C::Api: aleph_primitives::AlephSessionApi<B>,
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,
 {
     fn authority_data(&self, num: NumberFor<B>) -> Option<SessionAuthorityData> {
@@ -103,9 +102,9 @@ where
     }
 }
 
-pub trait FinalityNotificator<B, N> {
+pub trait FinalityNotificator<B> {
     fn notification_stream(&mut self) -> TracingUnboundedReceiver<B>;
-    fn last_finalized(&self) -> N;
+    fn last_finalized(&self) -> BlockNumber;
 }
 
 /// Default implementation of finality notificator trait.
@@ -114,6 +113,7 @@ where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
     C::Api: aleph_primitives::AlephSessionApi<B>,
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,
 {
     client: Arc<C>,
@@ -125,6 +125,7 @@ where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
     C::Api: aleph_primitives::AlephSessionApi<B>,
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,
 {
     pub fn new(client: Arc<C>) -> Self {
@@ -135,12 +136,12 @@ where
     }
 }
 
-impl<C, B, BE> FinalityNotificator<FinalityNotification<B>, NumberFor<B>>
-    for FinalityNotificatorImpl<C, B, BE>
+impl<C, B, BE> FinalityNotificator<FinalityNotification<B>> for FinalityNotificatorImpl<C, B, BE>
 where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
     C::Api: aleph_primitives::AlephSessionApi<B>,
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,
 {
     fn notification_stream(&mut self) -> TracingUnboundedReceiver<FinalityNotification<B>> {
@@ -233,28 +234,30 @@ impl ReadOnlySessionMap {
 pub struct SessionMapUpdater<AP, FN, B>
 where
     AP: AuthorityProvider<NumberFor<B>>,
-    FN: FinalityNotificator<FinalityNotification<B>, NumberFor<B>>,
+    FN: FinalityNotificator<FinalityNotification<B>>,
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
 {
     session_map: SharedSessionMap,
     authority_provider: AP,
     finality_notificator: FN,
-    period: SessionPeriod,
+    session_info: SessionInfo,
     _phantom: PhantomData<B>,
 }
 
 impl<AP, FN, B> SessionMapUpdater<AP, FN, B>
 where
     AP: AuthorityProvider<NumberFor<B>>,
-    FN: FinalityNotificator<FinalityNotification<B>, NumberFor<B>>,
+    FN: FinalityNotificator<FinalityNotification<B>>,
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
 {
     pub fn new(authority_provider: AP, finality_notificator: FN, period: SessionPeriod) -> Self {
         Self {
             session_map: SharedSessionMap::new(),
             authority_provider,
             finality_notificator,
-            period,
+            session_info: SessionInfo::new(period),
             _phantom: PhantomData,
         }
     }
@@ -266,7 +269,7 @@ where
 
     /// Puts authority data for the next session into the session map
     async fn handle_first_block_of_session(&mut self, session_id: SessionId) {
-        let first_block = first_block_of_session(session_id, self.period);
+        let first_block = self.session_info.first_block_of_session(session_id);
         debug!(target: "aleph-session-updater",
             "Handling first block #{:?} of session {:?}",
             first_block, session_id.0
@@ -292,7 +295,7 @@ where
     }
 
     fn authorities_for_session(&mut self, session_id: SessionId) -> Option<SessionAuthorityData> {
-        let first_block = first_block_of_session(session_id, self.period);
+        let first_block = self.session_info.first_block_of_session(session_id);
         self.authority_provider.authority_data(first_block)
     }
 
@@ -301,7 +304,7 @@ where
     async fn catch_up(&mut self) -> SessionId {
         let last_finalized = self.finality_notificator.last_finalized();
 
-        let current_session = session_id_from_block_num(last_finalized, self.period);
+        let current_session = self.session_info.session_id_from_block_num(last_finalized);
         let starting_session = SessionId(current_session.0.saturating_sub(PRUNING_THRESHOLD - 1));
 
         debug!(target: "aleph-session-updater",
@@ -345,7 +348,7 @@ where
             let last_finalized = header.number();
             trace!(target: "aleph-session-updater", "got FinalityNotification about #{:?}", last_finalized);
 
-            let session_id = session_id_from_block_num(*last_finalized, self.period);
+            let session_id = self.session_info.session_id_from_block_num(*last_finalized);
 
             if last_updated >= session_id {
                 continue;
@@ -380,12 +383,12 @@ mod tests {
     };
 
     struct MockProvider {
-        pub session_map: HashMap<NumberFor<TBlock>, SessionAuthorityData>,
-        pub next_session_map: HashMap<NumberFor<TBlock>, SessionAuthorityData>,
+        pub session_map: HashMap<BlockNumber, SessionAuthorityData>,
+        pub next_session_map: HashMap<BlockNumber, SessionAuthorityData>,
     }
 
     struct MockNotificator {
-        pub last_finalized: NumberFor<TBlock>,
+        pub last_finalized: BlockNumber,
         pub receiver: Mutex<Option<TracingUnboundedReceiver<FinalityNotification<TBlock>>>>,
     }
 
@@ -414,24 +417,24 @@ mod tests {
         }
     }
 
-    impl AuthorityProvider<NumberFor<TBlock>> for MockProvider {
-        fn authority_data(&self, b: NumberFor<TBlock>) -> Option<SessionAuthorityData> {
+    impl AuthorityProvider<BlockNumber> for MockProvider {
+        fn authority_data(&self, b: BlockNumber) -> Option<SessionAuthorityData> {
             self.session_map.get(&b).cloned()
         }
 
-        fn next_authority_data(&self, b: NumberFor<TBlock>) -> Option<SessionAuthorityData> {
+        fn next_authority_data(&self, b: BlockNumber) -> Option<SessionAuthorityData> {
             self.next_session_map.get(&b).cloned()
         }
     }
 
-    impl FinalityNotificator<FinalityNotification<TBlock>, NumberFor<TBlock>> for MockNotificator {
+    impl FinalityNotificator<FinalityNotification<TBlock>> for MockNotificator {
         fn notification_stream(
             &mut self,
         ) -> TracingUnboundedReceiver<FinalityNotification<TBlock>> {
             self.receiver.get_mut().unwrap().take().unwrap()
         }
 
-        fn last_finalized(&self) -> NumberFor<TBlock> {
+        fn last_finalized(&self) -> BlockNumber {
             self.last_finalized
         }
     }

--- a/finality-aleph/src/session_map.rs
+++ b/finality-aleph/src/session_map.rs
@@ -22,9 +22,9 @@ type SessionSubscribers = HashMap<SessionId, Vec<OneShotSender<SessionAuthorityD
 
 pub trait AuthorityProvider<N> {
     /// returns authority data for block
-    fn authority_data(&self, block: N) -> Option<SessionAuthorityData>;
+    fn authority_data(&self, block_number: N) -> Option<SessionAuthorityData>;
     /// returns next session authority data where current session is for block
-    fn next_authority_data(&self, block: N) -> Option<SessionAuthorityData>;
+    fn next_authority_data(&self, block_number: N) -> Option<SessionAuthorityData>;
 }
 
 /// Default implementation of authority provider trait.
@@ -64,34 +64,34 @@ where
     B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,
 {
-    fn authority_data(&self, num: NumberFor<B>) -> Option<SessionAuthorityData> {
+    fn authority_data(&self, block_number: NumberFor<B>) -> Option<SessionAuthorityData> {
         match self
             .client
             .runtime_api()
-            .authority_data(&BlockId::Number(num))
+            .authority_data(&BlockId::Number(block_number))
         {
             Ok(data) => Some(data),
             Err(_) => self
                 .client
                 .runtime_api()
-                .authorities(&BlockId::Number(num))
+                .authorities(&BlockId::Number(block_number))
                 .map(|authorities| SessionAuthorityData::new(authorities, None))
                 .ok(),
         }
     }
 
-    fn next_authority_data(&self, num: NumberFor<B>) -> Option<SessionAuthorityData> {
+    fn next_authority_data(&self, block_number: NumberFor<B>) -> Option<SessionAuthorityData> {
         match self
             .client
             .runtime_api()
-            .next_session_authority_data(&BlockId::Number(num))
+            .next_session_authority_data(&BlockId::Number(block_number))
             .map(|r| r.ok())
         {
             Ok(maybe_data) => maybe_data,
             Err(_) => self
                 .client
                 .runtime_api()
-                .next_session_authorities(&BlockId::Number(num))
+                .next_session_authorities(&BlockId::Number(block_number))
                 .map(|r| {
                     r.map(|authorities| SessionAuthorityData::new(authorities, None))
                         .ok()
@@ -418,12 +418,12 @@ mod tests {
     }
 
     impl AuthorityProvider<BlockNumber> for MockProvider {
-        fn authority_data(&self, b: BlockNumber) -> Option<SessionAuthorityData> {
-            self.session_map.get(&b).cloned()
+        fn authority_data(&self, block_number: BlockNumber) -> Option<SessionAuthorityData> {
+            self.session_map.get(&block_number).cloned()
         }
 
-        fn next_authority_data(&self, b: BlockNumber) -> Option<SessionAuthorityData> {
-            self.next_session_map.get(&b).cloned()
+        fn next_authority_data(&self, block_number: BlockNumber) -> Option<SessionAuthorityData> {
+            self.next_session_map.get(&block_number).cloned()
         }
     }
 

--- a/finality-aleph/src/sync/handler.rs
+++ b/finality-aleph/src/sync/handler.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Error as FmtError, Formatter};
 
 use crate::{
-    session::{last_block_of_session, session_id_from_block_num, SessionId, SessionPeriod},
+    session::{SessionId, SessionInfo, SessionPeriod},
     sync::{
         data::{NetworkData, Request, State},
         forest::{Error as ForestError, Forest, Interest},
@@ -20,7 +20,7 @@ pub struct Handler<I: PeerId, J: Justification, CS: ChainStatus<J>, V: Verifier<
     verifier: V,
     finalizer: F,
     forest: Forest<I, J>,
-    period: SessionPeriod,
+    session_info: SessionInfo,
 }
 
 /// What actions can the handler recommend as a reaction to some data.
@@ -116,7 +116,7 @@ impl<I: PeerId, J: Justification, CS: ChainStatus<J>, V: Verifier<J>, F: Finaliz
             verifier,
             finalizer,
             forest,
-            period,
+            session_info: SessionInfo::new(period),
         })
     }
 
@@ -136,8 +136,9 @@ impl<I: PeerId, J: Justification, CS: ChainStatus<J>, V: Verifier<J>, F: Finaliz
                     .map_err(Error::Finalizer)?;
                 number += 1;
             }
-            number =
-                last_block_of_session(session_id_from_block_num(number, self.period), self.period);
+            number = self
+                .session_info
+                .last_block_of_session(self.session_info.session_id_from_block_num(number));
             match self.forest.try_finalize(&number) {
                 Some(justification) => {
                     self.finalizer
@@ -194,10 +195,9 @@ impl<I: PeerId, J: Justification, CS: ChainStatus<J>, V: Verifier<J>, F: Finaliz
                     number += 1;
                 }
                 None => {
-                    number = last_block_of_session(
-                        session_id_from_block_num(number, self.period),
-                        self.period,
-                    );
+                    number = self
+                        .session_info
+                        .last_block_of_session(self.session_info.session_id_from_block_num(number));
                     match self
                         .chain_status
                         .finalized_at(number)
@@ -235,7 +235,7 @@ impl<I: PeerId, J: Justification, CS: ChainStatus<J>, V: Verifier<J>, F: Finaliz
         use Error::*;
         Ok(self
             .chain_status
-            .finalized_at(last_block_of_session(session, self.period))
+            .finalized_at(self.session_info.last_block_of_session(session))
             .map_err(ChainStatus)?
             .ok_or(MissingJustification)?
             .into_unverified())
@@ -251,8 +251,12 @@ impl<I: PeerId, J: Justification, CS: ChainStatus<J>, V: Verifier<J>, F: Finaliz
         let remote_top_number = state.top_justification().id().number();
         let local_top = self.chain_status.top_finalized().map_err(ChainStatus)?;
         let local_top_number = local_top.header().id().number();
-        let remote_session = session_id_from_block_num(remote_top_number, self.period);
-        let local_session = session_id_from_block_num(local_top_number, self.period);
+        let remote_session = self
+            .session_info
+            .session_id_from_block_num(remote_top_number);
+        let local_session = self
+            .session_info
+            .session_id_from_block_num(local_top_number);
         match local_session.0.checked_sub(remote_session.0) {
             // remote session number larger than ours, we can try to import the justification
             None => Ok(self

--- a/finality-aleph/src/sync/handler.rs
+++ b/finality-aleph/src/sync/handler.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Error as FmtError, Formatter};
 
 use crate::{
-    session::{SessionId, SessionInfo, SessionPeriod},
+    session::{SessionId, SessionBoundaryInfo, SessionPeriod},
     sync::{
         data::{NetworkData, Request, State},
         forest::{Error as ForestError, Forest, Interest},
@@ -20,7 +20,7 @@ pub struct Handler<I: PeerId, J: Justification, CS: ChainStatus<J>, V: Verifier<
     verifier: V,
     finalizer: F,
     forest: Forest<I, J>,
-    session_info: SessionInfo,
+    session_info: SessionBoundaryInfo,
 }
 
 /// What actions can the handler recommend as a reaction to some data.
@@ -116,7 +116,7 @@ impl<I: PeerId, J: Justification, CS: ChainStatus<J>, V: Verifier<J>, F: Finaliz
             verifier,
             finalizer,
             forest,
-            session_info: SessionInfo::new(period),
+            session_info: SessionBoundaryInfo::new(period),
         })
     }
 

--- a/finality-aleph/src/sync/substrate/verification/cache.rs
+++ b/finality-aleph/src/sync/substrate/verification/cache.rs
@@ -7,7 +7,7 @@ use aleph_primitives::BlockNumber;
 use sp_runtime::SaturatedConversion;
 
 use crate::{
-    session::{SessionId, SessionInfo},
+    session::{SessionId, SessionBoundaryInfo},
     session_map::AuthorityProvider,
     sync::substrate::verification::{verifier::SessionVerifier, FinalizationInfo},
     SessionPeriod,
@@ -56,7 +56,7 @@ where
     FI: FinalizationInfo,
 {
     sessions: HashMap<SessionId, SessionVerifier>,
-    session_info: SessionInfo,
+    session_info: SessionBoundaryInfo,
     finalization_info: FI,
     authority_provider: AP,
     cache_size: usize,
@@ -77,7 +77,7 @@ where
     ) -> Self {
         Self {
             sessions: HashMap::new(),
-            session_info: SessionInfo::new(session_period),
+            session_info: SessionBoundaryInfo::new(session_period),
             finalization_info,
             authority_provider,
             cache_size,
@@ -91,7 +91,7 @@ where
 fn download_session_verifier<AP: AuthorityProvider<BlockNumber>>(
     authority_provider: &AP,
     session_id: SessionId,
-    session_info: &SessionInfo,
+    session_info: &SessionBoundaryInfo,
 ) -> Option<SessionVerifier> {
     let maybe_authority_data = match session_id {
         SessionId(0) => authority_provider.authority_data(0),
@@ -176,7 +176,7 @@ mod tests {
         VerifierCache,
     };
     use crate::{
-        session::{testing::authority_data, SessionId, SessionInfo},
+        session::{testing::authority_data, SessionId, SessionBoundaryInfo},
         SessionPeriod,
     };
 
@@ -197,7 +197,7 @@ mod tests {
 
     struct MockAuthorityProvider {
         session_map: HashMap<SessionId, SessionAuthorityData>,
-        session_info: SessionInfo,
+        session_info: SessionBoundaryInfo,
     }
 
     fn authority_data_for_session(session_id: u32) -> SessionAuthorityData {
@@ -212,7 +212,7 @@ mod tests {
 
             Self {
                 session_map,
-                session_info: SessionInfo::new(SessionPeriod(SESSION_PERIOD)),
+                session_info: SessionBoundaryInfo::new(SessionPeriod(SESSION_PERIOD)),
             }
         }
     }

--- a/finality-aleph/src/sync/substrate/verification/cache.rs
+++ b/finality-aleph/src/sync/substrate/verification/cache.rs
@@ -7,7 +7,7 @@ use aleph_primitives::BlockNumber;
 use sp_runtime::SaturatedConversion;
 
 use crate::{
-    session::{SessionId, SessionBoundaryInfo},
+    session::{SessionBoundaryInfo, SessionId},
     session_map::AuthorityProvider,
     sync::substrate::verification::{verifier::SessionVerifier, FinalizationInfo},
     SessionPeriod,
@@ -176,7 +176,7 @@ mod tests {
         VerifierCache,
     };
     use crate::{
-        session::{testing::authority_data, SessionId, SessionBoundaryInfo},
+        session::{testing::authority_data, SessionBoundaryInfo, SessionId},
         SessionPeriod,
     };
 
@@ -218,16 +218,16 @@ mod tests {
     }
 
     impl AuthorityProvider<BlockNumber> for MockAuthorityProvider {
-        fn authority_data(&self, block: BlockNumber) -> Option<SessionAuthorityData> {
+        fn authority_data(&self, block_number: BlockNumber) -> Option<SessionAuthorityData> {
             self.session_map
-                .get(&self.session_info.session_id_from_block_num(block))
+                .get(&self.session_info.session_id_from_block_num(block_number))
                 .cloned()
         }
 
-        fn next_authority_data(&self, block: BlockNumber) -> Option<SessionAuthorityData> {
+        fn next_authority_data(&self, block_number: BlockNumber) -> Option<SessionAuthorityData> {
             self.session_map
                 .get(&SessionId(
-                    self.session_info.session_id_from_block_num(block).0 + 1,
+                    self.session_info.session_id_from_block_num(block_number).0 + 1,
                 ))
                 .cloned()
         }

--- a/finality-aleph/src/sync/substrate/verification/cache.rs
+++ b/finality-aleph/src/sync/substrate/verification/cache.rs
@@ -7,7 +7,7 @@ use aleph_primitives::BlockNumber;
 use sp_runtime::SaturatedConversion;
 
 use crate::{
-    session::{first_block_of_session, session_id_from_block_num, SessionId},
+    session::{SessionId, SessionInfo},
     session_map::AuthorityProvider,
     sync::substrate::verification::{verifier::SessionVerifier, FinalizationInfo},
     SessionPeriod,
@@ -56,7 +56,7 @@ where
     FI: FinalizationInfo,
 {
     sessions: HashMap<SessionId, SessionVerifier>,
-    session_period: SessionPeriod,
+    session_info: SessionInfo,
     finalization_info: FI,
     authority_provider: AP,
     cache_size: usize,
@@ -77,7 +77,7 @@ where
     ) -> Self {
         Self {
             sessions: HashMap::new(),
-            session_period,
+            session_info: SessionInfo::new(session_period),
             finalization_info,
             authority_provider,
             cache_size,
@@ -91,12 +91,12 @@ where
 fn download_session_verifier<AP: AuthorityProvider<BlockNumber>>(
     authority_provider: &AP,
     session_id: SessionId,
-    session_period: SessionPeriod,
+    session_info: &SessionInfo,
 ) -> Option<SessionVerifier> {
     let maybe_authority_data = match session_id {
         SessionId(0) => authority_provider.authority_data(0),
         SessionId(id) => {
-            let prev_first = first_block_of_session(SessionId(id - 1), session_period);
+            let prev_first = session_info.first_block_of_session(SessionId(id - 1));
             authority_provider.next_authority_data(prev_first)
         }
     };
@@ -117,7 +117,7 @@ where
 
     /// Returns session verifier for block number if available. Updates cache if necessary.
     pub fn get(&mut self, number: BlockNumber) -> Result<&SessionVerifier, CacheError> {
-        let session_id = session_id_from_block_num(number, self.session_period);
+        let session_id = self.session_info.session_id_from_block_num(number);
 
         if session_id < self.lower_bound {
             return Err(CacheError::SessionTooOld(session_id, self.lower_bound));
@@ -125,11 +125,10 @@ where
 
         // We are sure about authorities in all session that have first block from previous session finalized.
         let upper_bound = SessionId(
-            session_id_from_block_num(
-                self.finalization_info.finalized_number(),
-                self.session_period,
-            )
-            .0 + 1,
+            self.session_info
+                .session_id_from_block_num(self.finalization_info.finalized_number())
+                .0
+                + 1,
         );
         if session_id > upper_bound {
             return Err(CacheError::SessionInFuture(session_id, upper_bound));
@@ -155,7 +154,7 @@ where
                 let verifier = download_session_verifier(
                     &self.authority_provider,
                     session_id,
-                    self.session_period,
+                    &self.session_info,
                 )
                 .ok_or(CacheError::UnknownAuthorities(session_id))?;
                 vacant.insert(verifier)
@@ -177,7 +176,7 @@ mod tests {
         VerifierCache,
     };
     use crate::{
-        session::{session_id_from_block_num, testing::authority_data, SessionId},
+        session::{testing::authority_data, SessionId, SessionInfo},
         SessionPeriod,
     };
 
@@ -198,7 +197,7 @@ mod tests {
 
     struct MockAuthorityProvider {
         session_map: HashMap<SessionId, SessionAuthorityData>,
-        session_period: SessionPeriod,
+        session_info: SessionInfo,
     }
 
     fn authority_data_for_session(session_id: u32) -> SessionAuthorityData {
@@ -213,7 +212,7 @@ mod tests {
 
             Self {
                 session_map,
-                session_period: SessionPeriod(SESSION_PERIOD),
+                session_info: SessionInfo::new(SessionPeriod(SESSION_PERIOD)),
             }
         }
     }
@@ -221,14 +220,14 @@ mod tests {
     impl AuthorityProvider<BlockNumber> for MockAuthorityProvider {
         fn authority_data(&self, block: BlockNumber) -> Option<SessionAuthorityData> {
             self.session_map
-                .get(&session_id_from_block_num(block, self.session_period))
+                .get(&self.session_info.session_id_from_block_num(block))
                 .cloned()
         }
 
         fn next_authority_data(&self, block: BlockNumber) -> Option<SessionAuthorityData> {
             self.session_map
                 .get(&SessionId(
-                    session_id_from_block_num(block, self.session_period).0 + 1,
+                    self.session_info.session_id_from_block_num(block).0 + 1,
                 ))
                 .cloned()
         }

--- a/finality-aleph/src/testing/mocks/session_info.rs
+++ b/finality-aleph/src/testing/mocks/session_info.rs
@@ -4,7 +4,7 @@ use aleph_primitives::BlockNumber;
 
 use crate::{
     justification::{AlephJustification, SessionInfo, SessionInfoProvider, Verifier},
-    last_block_of_session, session_id_from_block_num,
+    session::SessionInfo as SessionBoundInfo,
     testing::mocks::{AcceptancePolicy, TBlock, THash},
     SessionPeriod,
 };
@@ -20,14 +20,14 @@ impl Verifier<TBlock> for VerifierWrapper {
 }
 
 pub struct SessionInfoProviderImpl {
-    session_period: SessionPeriod,
+    session_info: SessionBoundInfo,
     acceptance_policy: Arc<Mutex<AcceptancePolicy>>,
 }
 
 impl SessionInfoProviderImpl {
     pub fn new(session_period: SessionPeriod, acceptance_policy: AcceptancePolicy) -> Self {
         Self {
-            session_period,
+            session_info: SessionBoundInfo::new(session_period),
             acceptance_policy: Arc::new(Mutex::new(acceptance_policy)),
         }
     }
@@ -36,10 +36,10 @@ impl SessionInfoProviderImpl {
 #[async_trait::async_trait]
 impl SessionInfoProvider<TBlock, VerifierWrapper> for SessionInfoProviderImpl {
     async fn for_block_num(&self, number: BlockNumber) -> SessionInfo<TBlock, VerifierWrapper> {
-        let current_session = session_id_from_block_num(number, self.session_period);
+        let current_session = self.session_info.session_id_from_block_num(number);
         SessionInfo {
             current_session,
-            last_block_height: last_block_of_session(current_session, self.session_period),
+            last_block_height: self.session_info.last_block_of_session(current_session),
             verifier: match &*self.acceptance_policy.lock().unwrap() {
                 AcceptancePolicy::Unavailable => None,
                 _ => Some(VerifierWrapper {

--- a/finality-aleph/src/testing/mocks/session_info.rs
+++ b/finality-aleph/src/testing/mocks/session_info.rs
@@ -4,7 +4,7 @@ use aleph_primitives::BlockNumber;
 
 use crate::{
     justification::{AlephJustification, SessionInfo, SessionInfoProvider, Verifier},
-    session::SessionInfo as SessionBoundInfo,
+    session::SessionBoundaryInfo as SessionBoundInfo,
     testing::mocks::{AcceptancePolicy, TBlock, THash},
     SessionPeriod,
 };


### PR DESCRIPTION
# Description

Previously session info was either taken from implementations of `SessionInfo` trait, or functions that were inside this trait. Now the functions are private, and session info is taken from `SessionInfo` struct. 

`SessionBoundries` struct and `AuthorityProvider` trait will be refactored in another PR to not be generic over `B: Block`

## Type of change

- Refactor
