### PR TITLE
Use `GITHUB_OUTPUT` instead of `set-output` in github workflows

### DIFF
--- a/.github/actions/get-branch/action.yaml
+++ b/.github/actions/get-branch/action.yaml
@@ -25,8 +25,7 @@ runs:
       env:
         HEAD_REF: ${{ github.head_ref || github.ref }}
       run: |
-        echo "##[set-output name=branch_name;]$(echo ${HEAD_REF#refs/heads/} \
-          | tr / -)" >> $GITHUB_OUTPUT
-        echo "##[set-output name=branch_appname;]$(printf ${HEAD_REF#refs/heads/} \
+        echo "branch_name=$(echo ${HEAD_REF#refs/heads/} | tr / -)" >> $GITHUB_OUTPUT
+        echo "branch_appname=$(printf ${HEAD_REF#refs/heads/} \
           | tr / - | tr '[:upper:]' '[:lower:]' | tr -c '[a-z0-9-.]' '-')" >> $GITHUB_OUTPUT
         echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/actions/get-branch/action.yaml
+++ b/.github/actions/get-branch/action.yaml
@@ -25,7 +25,7 @@ runs:
       env:
         HEAD_REF: ${{ github.head_ref || github.ref }}
       run: |
-        echo "##[set-output name=branch_name;]$(echo ${HEAD_REF#refs/heads/} | tr / -)"
+        echo "##[set-output name=branch_name;]$(echo ${HEAD_REF#refs/heads/} | tr / -)" >> $GITHUB_OUTPUT
         echo "##[set-output name=branch_appname;]$(printf ${HEAD_REF#refs/heads/} \
-          | tr / - | tr '[:upper:]' '[:lower:]' | tr -c '[a-z0-9-.]' '-')"
-        echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          | tr / - | tr '[:upper:]' '[:lower:]' | tr -c '[a-z0-9-.]' '-')" >> $GITHUB_OUTPUT
+        echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/actions/get-branch/action.yaml
+++ b/.github/actions/get-branch/action.yaml
@@ -25,7 +25,8 @@ runs:
       env:
         HEAD_REF: ${{ github.head_ref || github.ref }}
       run: |
-        echo "##[set-output name=branch_name;]$(echo ${HEAD_REF#refs/heads/} | tr / -)" >> $GITHUB_OUTPUT
+        echo "##[set-output name=branch_name;]$(echo ${HEAD_REF#refs/heads/} \
+          | tr / -)" >> $GITHUB_OUTPUT
         echo "##[set-output name=branch_appname;]$(printf ${HEAD_REF#refs/heads/} \
           | tr / - | tr '[:upper:]' '[:lower:]' | tr -c '[a-z0-9-.]' '-')" >> $GITHUB_OUTPUT
         echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-send-postsync-hook-runtime-image.yml
+++ b/.github/workflows/build-send-postsync-hook-runtime-image.yml
@@ -29,7 +29,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
+          echo "branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Install rust toolchain

--- a/.github/workflows/build-send-postsync-hook-runtime-image.yml
+++ b/.github/workflows/build-send-postsync-hook-runtime-image.yml
@@ -29,8 +29,8 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/check-excluded-packages.yml
+++ b/.github/workflows/check-excluded-packages.yml
@@ -50,8 +50,8 @@ jobs:
           packages="${packages//$'\n'/'%0A'}"
           targets="${targets//$'\n'/'%0A'}"
 
-          echo "::set-output name=packages::$packages"
-          echo "::set-output name=targets::$targets"
+          echo "packages=$packages" >> $GITHUB_OUTPUT
+          echo "targets=$targets" >> $GITHUB_OUTPUT
 
       - name: Check excluded packages
         env:

--- a/.github/workflows/check-excluded-packages.yml
+++ b/.github/workflows/check-excluded-packages.yml
@@ -59,6 +59,7 @@ jobs:
           RUSTC_WORKSPACE_WRAPPER: sccache
         run: |
           packages="${{ steps.format_output.outputs.packages }}"
+          packages="${packages//'%0A'/$'\n'}"
           for p in ${packages[@]}
           do
             # skip checking the contracts for now

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -641,8 +641,8 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Push aleph-node Current Image to Public ECR
         env:
@@ -729,9 +729,9 @@ jobs:
         run: |
           if [ ! $(git diff HEAD origin/main -- bin/runtime/src/lib.rs | grep ' spec_version: ') ]
           then
-            echo "::set-output name=diff::0"
+            echo "diff=0" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=diff::1"
+            echo "diff=1" >> $GITHUB_OUTPUT
           fi
 
   build-new-runtime-and-try_runtime:

--- a/.github/workflows/e2e-tests-main-devnet.yml
+++ b/.github/workflows/e2e-tests-main-devnet.yml
@@ -641,7 +641,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
+          echo "branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Push aleph-node Current Image to Public ECR


### PR DESCRIPTION
# Description

https://cardinal-cryptography.atlassian.net/browse/A0-2096
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Replacing soon-to-be deprecated `set-output` with `GITHUB_OUTPUT`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)