### PR TITLE
Change nightly-pipeline steps with 'cargo' to use 'self-hosted' runner

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -78,7 +78,7 @@ jobs:
   check-determinism:
     needs: [build-new-node]
     name: Verify runtime build determinism
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache
@@ -111,7 +111,7 @@ jobs:
 
   build-test-client:
     name: Build e2e test client suite
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache


### PR DESCRIPTION
Steps with `cargo` fail because of sccache not present.  To get it fixed, let's just get them running on our runners. 

A sample failed run:
https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/4399876971/jobs/7704710711 

    could not execute process `sccache rustc