### PR TITLE
A0-2102: Bump EndBug/add-and-commit GH action version from 5.1.0 to 9.1.1

### DIFF
--- a/.github/actions/destroy-feature-environment/action.yml
+++ b/.github/actions/destroy-feature-environment/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: ./.github/actions/get-branch
 
     - name: Checkout aleph-apps repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
       with:
         repository: Cardinal-Cryptography/aleph-apps
         token: ${{ inputs.gh-ci-token }}
@@ -55,17 +55,15 @@ runs:
         rm -rf $ALEPH_PATH/aleph-apps/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
 
     - name: Commit deletion of the feature environment.
-      uses: EndBug/add-and-commit@v5.1.0
+      uses: EndBug/add-and-commit@v9.1.1
       env:
         APP_NAME: fe-${{ steps.get_branch.outputs.branch_appname }}
-        GITHUB_TOKEN: ${{ inputs.gh-ci-token }}
       with:
         author_name: AlephZero Automation
         author_email: alephzero@10clouds.com
         message: "Feature Environment: ${{ env.APP_NAME }} has been deleted"
         add: "*.yaml"
         cwd: "aleph-apps"
-        branch: main
 
     - name: Refresh Argo and wait for the deletion to be finished
       shell: bash

--- a/.github/workflows/build-send-postsync-hook-runtime-image.yml
+++ b/.github/workflows/build-send-postsync-hook-runtime-image.yml
@@ -83,7 +83,7 @@ jobs:
           docker push ${{ env.ECR_LATEST }}
 
       - name: GIT | Checkout aleph-apps repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           repository: Cardinal-Cryptography/aleph-apps
           token: ${{ secrets.CI_GH_TOKEN }}
@@ -105,13 +105,10 @@ jobs:
             kustomize edit set image "send-runtime-hook-image-placeholder=${{ env.RELEASE_IMAGE }}"
 
       - name: GIT | Commit changes to aleph-apps repository.
-        uses: EndBug/add-and-commit@v5.1.0
+        uses: EndBug/add-and-commit@v9.1.1
         with:
           author_name: AlephZero Automation
           author_email: alephzero@10clouds.com
           message: "Updating postsync hook image tag to: ${{ steps.vars.outputs.sha_short }}"
           add: "*.yaml"
           cwd: "aleph-apps"
-          branch: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}

--- a/.github/workflows/deploy-feature-envs.yaml
+++ b/.github/workflows/deploy-feature-envs.yaml
@@ -231,7 +231,7 @@ jobs:
       # yamllint enable rule:line-length
 
       - name: GIT | Checkout aleph-apps repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           repository: Cardinal-Cryptography/aleph-apps
           token: ${{ secrets.CI_GH_TOKEN }}
@@ -320,17 +320,15 @@ jobs:
             $ALEPH_PATH/aleph-apps/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
 
       - name: GIT | Commit changes to aleph-apps repository.
-        uses: EndBug/add-and-commit@v5.1.0
+        uses: EndBug/add-and-commit@v9.1.1
         env:
           APP_NAME: ${{ env.FE_APP_PREFIX }}${{ steps.get_branch.outputs.branch_appname }}
-          GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}
         with:
           author_name: AlephZero Automation
           author_email: alephzero@10clouds.com
           message: "New Feature Environment Deployment with name: ${{ env.APP_NAME }}"
           add: "*.yaml"
           cwd: "aleph-apps"
-          branch: main
 
       - name: Refresh Argo and wait for the testnet image deployment to be finished
         env:
@@ -373,7 +371,7 @@ jobs:
         uses: ./.github/actions/get-branch
 
       - name: GIT | Checkout aleph-apps repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           repository: Cardinal-Cryptography/aleph-apps
           token: ${{ secrets.CI_GH_TOKEN }}
@@ -416,12 +414,11 @@ jobs:
             $ALEPH_PATH/aleph-apps/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
 
       - name: GIT | Commit changes to aleph-apps repository.
-        uses: EndBug/add-and-commit@v5.1.0
+        uses: EndBug/add-and-commit@v9.1.1
         env:
           IMAGE_TAG:
             ${{ env.FE_IMAGETAG_PREFIX }}${{ steps.get_branch.outputs.branch_imagetag_full }}
           APP_NAME: ${{ env.FE_APP_PREFIX }}${{ steps.get_branch.outputs.branch_appname }}
-          GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}
         with:
           author_name: AlephZero Automation
           author_email: alephzero@10clouds.com
@@ -430,7 +427,6 @@ jobs:
             ${{ env.FE_ALEPHNODE_REGISTRY }}:${{ env.IMAGE_TAG }}"
           add: "*.yaml"
           cwd: "aleph-apps"
-          branch: main
 
       - name: Refresh Argo and wait for the PR image deployment to be finished
         env:

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -100,7 +100,7 @@ jobs:
             aleph-runtime-${{ steps.vars.outputs.sha_short }}.tar.gz
 
       - name: GIT | Checkout aleph-apps repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           ref: mainnet
           repository: Cardinal-Cryptography/aleph-apps
@@ -132,16 +132,13 @@ jobs:
           done
 
       - name: GIT | Commit changes to aleph-apps repository.
-        uses: EndBug/add-and-commit@v5.1.0
+        uses: EndBug/add-and-commit@v9.1.1
         with:
           author_name: AlephZero Automation
           author_email: alephzero@10clouds.com
           message: "Updating Mainnet docker image tag for release: ${{ steps.vars.outputs.branch }}"
           add: "*.yaml"
           cwd: "aleph-apps"
-          branch: mainnet
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}
 
   slack:
     name: Slack notification

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -98,7 +98,7 @@ jobs:
             aleph-runtime-${{ steps.vars.outputs.sha_short }}.tar.gz
 
       - name: GIT | Checkout aleph-apps repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           ref: testnet
           repository: Cardinal-Cryptography/aleph-apps
@@ -130,7 +130,7 @@ jobs:
           done
 
       - name: GIT | Commit changes to aleph-apps repository.
-        uses: EndBug/add-and-commit@v5.1.0
+        uses: EndBug/add-and-commit@v9.1.1
         with:
           author_name: AlephZero Automation
           author_email: alephzero@10clouds.com
@@ -138,9 +138,6 @@ jobs:
             "Updating Testnet docker image tag for pre-release: ${{ steps.vars.outputs.branch }}"
           add: "*.yaml"
           cwd: "aleph-apps"
-          branch: testnet
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}
 
   slack:
     name: Slack notification

--- a/.github/workflows/deploy-to-devnet.yml
+++ b/.github/workflows/deploy-to-devnet.yml
@@ -39,7 +39,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: GIT | Checkout aleph-apps repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           repository: Cardinal-Cryptography/aleph-apps
           token: ${{ secrets.CI_GH_TOKEN }}
@@ -118,16 +118,13 @@ jobs:
           sleep 300
 
       - name: GIT | Commit changes to aleph-apps repository.
-        uses: EndBug/add-and-commit@v5.1.0
+        uses: EndBug/add-and-commit@v9.1.1
         with:
           author_name: AlephZero Automation
           author_email: alephzero@10clouds.com
           message: "Updating Devnet docker image tag to: ${{ steps.vars.outputs.sha_short }}"
           add: "*.yaml"
           cwd: "aleph-apps"
-          branch: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_GH_TOKEN }}
 
   slack:
     name: Slack notification


### PR DESCRIPTION
This PR updates EndBug/add-and-commit action from version 5.1.0 to 9.1.1, as suggested by Dependabot on https://github.com/Cardinal-Cryptography/aleph-node/pull/980.

It's quite a bump so changelog has been checked and there are breaking changes in version 7.0.0: https://github.com/EndBug/add-and-commit/releases/tag/v7.0.0 
A major breaking change is the token input that has been removed.  That token will be now taken from the previously used `actions/checkout@v3` action.  Thus, if a repository `aleph-apps` is checked out in `aleph-apps` directory, our `add-and-commit` action can be used on that directory without passing the token.

New version has been tested on some temporary branches:  
* the following workflow has been created on a temporary branch: https://github.com/Cardinal-Cryptography/aleph-node/blob/test-new-addandcommit-action/.github/workflows/test-addandcommit-action.yml
* and result of its run can be found here: https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/4411153835/jobs/7729381015 
* along with the commit that it was meant to add here: https://github.com/Cardinal-Cryptography/aleph-apps/commit/62c3c51fb4ff4940edb9d636e63a89168005ffdb . 

Please check above to ensure it's all right.
