### PR TITLE
refactor SessionBoundaries

### DIFF
--- a/finality-aleph/src/abft/current.rs
+++ b/finality-aleph/src/abft/current.rs
@@ -1,8 +1,8 @@
-pub use aleph_primitives::CURRENT_FINALITY_VERSION as VERSION;
+pub use aleph_primitives::{BlockNumber, CURRENT_FINALITY_VERSION as VERSION};
 use current_aleph_bft::{default_config, Config, LocalIO, Terminator};
 use log::debug;
 use sp_blockchain::HeaderBackend;
-use sp_runtime::traits::Block;
+use sp_runtime::traits::{Block, Header};
 
 use crate::{
     abft::{common::unit_creation_delay_fn, NetworkWrapper, SpawnHandleT},
@@ -17,11 +17,7 @@ use crate::{
     CurrentNetworkData, Hasher, Keychain, NodeIndex, SessionId, SignatureSet, UnitCreationDelay,
 };
 
-pub fn run_member<
-    B: Block,
-    C: HeaderBackend<B> + Send + 'static,
-    ADN: Network<CurrentNetworkData<B>> + 'static,
->(
+pub fn run_member<B, C, ADN>(
     subtask_common: SubtaskCommon,
     multikeychain: Keychain,
     config: Config,
@@ -32,7 +28,13 @@ pub fn run_member<
     data_provider: impl current_aleph_bft::DataProvider<AlephData<B>> + Send + 'static,
     ordered_data_interpreter: OrderedDataInterpreter<B, C>,
     backup: ABFTBackup,
-) -> Task {
+) -> Task
+where
+    B: Block,
+    B::Header: Header<Number = BlockNumber>,
+    C: HeaderBackend<B> + Send + 'static,
+    ADN: Network<CurrentNetworkData<B>> + 'static,
+{
     let SubtaskCommon {
         spawn_handle,
         session_id,

--- a/finality-aleph/src/abft/legacy.rs
+++ b/finality-aleph/src/abft/legacy.rs
@@ -1,8 +1,8 @@
-pub use aleph_primitives::LEGACY_FINALITY_VERSION as VERSION;
+pub use aleph_primitives::{BlockNumber, LEGACY_FINALITY_VERSION as VERSION};
 use legacy_aleph_bft::{default_config, Config, LocalIO, Terminator};
 use log::debug;
 use sp_blockchain::HeaderBackend;
-use sp_runtime::traits::Block;
+use sp_runtime::traits::{Block, Header};
 
 use super::common::unit_creation_delay_fn;
 use crate::{
@@ -17,11 +17,7 @@ use crate::{
     Keychain, LegacyNetworkData, NodeIndex, SessionId, UnitCreationDelay,
 };
 
-pub fn run_member<
-    B: Block,
-    C: HeaderBackend<B> + Send + 'static,
-    ADN: Network<LegacyNetworkData<B>> + 'static,
->(
+pub fn run_member<B, C, ADN>(
     subtask_common: SubtaskCommon,
     multikeychain: Keychain,
     config: Config,
@@ -29,7 +25,13 @@ pub fn run_member<
     data_provider: impl legacy_aleph_bft::DataProvider<AlephData<B>> + Send + 'static,
     ordered_data_interpreter: OrderedDataInterpreter<B, C>,
     backup: ABFTBackup,
-) -> Task {
+) -> Task
+where
+    B: Block,
+    B::Header: Header<Number = BlockNumber>,
+    C: HeaderBackend<B> + Send + 'static,
+    ADN: Network<LegacyNetworkData<B>> + 'static,
+{
     let SubtaskCommon {
         spawn_handle,
         session_id,

--- a/finality-aleph/src/abft/traits.rs
+++ b/finality-aleph/src/abft/traits.rs
@@ -2,10 +2,11 @@
 
 use std::{cmp::Ordering, fmt::Debug, hash::Hash as StdHash, marker::PhantomData, pin::Pin};
 
+use aleph_primitives::BlockNumber;
 use codec::{Codec, Decode, Encode};
 use futures::{channel::oneshot, Future, TryFutureExt};
 use sc_service::SpawnTaskHandle;
-use sp_api::BlockT;
+use sp_api::{BlockT, HeaderT};
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Hash as SpHash;
 
@@ -30,16 +31,22 @@ impl<B: BlockT> legacy_aleph_bft::DataProvider<AlephData<B>> for DataProvider<B>
     }
 }
 
-impl<B: BlockT, C: HeaderBackend<B> + Send + 'static>
-    current_aleph_bft::FinalizationHandler<AlephData<B>> for OrderedDataInterpreter<B, C>
+impl<B, C> current_aleph_bft::FinalizationHandler<AlephData<B>> for OrderedDataInterpreter<B, C>
+where
+    B: BlockT,
+    B::Header: HeaderT<Number = BlockNumber>,
+    C: HeaderBackend<B> + Send + 'static,
 {
     fn data_finalized(&mut self, data: AlephData<B>) {
         OrderedDataInterpreter::data_finalized(self, data)
     }
 }
 
-impl<B: BlockT, C: HeaderBackend<B> + Send + 'static>
-    legacy_aleph_bft::FinalizationHandler<AlephData<B>> for OrderedDataInterpreter<B, C>
+impl<B, C> legacy_aleph_bft::FinalizationHandler<AlephData<B>> for OrderedDataInterpreter<B, C>
+where
+    B: BlockT,
+    B::Header: HeaderT<Number = BlockNumber>,
+    C: HeaderBackend<B> + Send + 'static,
 {
     fn data_finalized(&mut self, data: AlephData<B>) {
         OrderedDataInterpreter::data_finalized(self, data)

--- a/finality-aleph/src/data_io/data_store.rs
+++ b/finality-aleph/src/data_io/data_store.rs
@@ -6,6 +6,7 @@ use std::{
     time::{self, Duration},
 };
 
+use aleph_primitives::BlockNumber;
 use futures::{
     channel::{
         mpsc::{self, UnboundedSender},
@@ -176,6 +177,7 @@ impl Default for DataStoreConfig {
 pub struct DataStore<B, C, RB, Message, R>
 where
     B: BlockT,
+    B::Header: HeaderT<Number = BlockNumber>,
     C: HeaderBackend<B> + BlockchainEvents<B> + Send + Sync + 'static,
     RB: RequestBlocks<B> + 'static,
     Message:
@@ -192,7 +194,7 @@ where
     available_proposals_cache: LruCache<AlephProposal<B>, ProposalStatus<B>>,
     num_triggers_registered_since_last_pruning: usize,
     highest_finalized_num: NumberFor<B>,
-    session_boundaries: SessionBoundaries<B>,
+    session_boundaries: SessionBoundaries,
     client: Arc<C>,
     block_requester: RB,
     config: DataStoreConfig,
@@ -203,6 +205,7 @@ where
 impl<B, C, RB, Message, R> DataStore<B, C, RB, Message, R>
 where
     B: BlockT,
+    B::Header: HeaderT<Number = BlockNumber>,
     C: HeaderBackend<B> + BlockchainEvents<B> + Send + Sync + 'static,
     RB: RequestBlocks<B> + 'static,
     Message:
@@ -211,7 +214,7 @@ where
 {
     /// Returns a struct to be run and a network that outputs messages filtered as appropriate
     pub fn new<N: ComponentNetwork<Message, R = R>>(
-        session_boundaries: SessionBoundaries<B>,
+        session_boundaries: SessionBoundaries,
         client: Arc<C>,
         block_requester: RB,
         config: DataStoreConfig,

--- a/finality-aleph/src/data_io/proposal.rs
+++ b/finality-aleph/src/data_io/proposal.rs
@@ -4,9 +4,10 @@ use std::{
     ops::Index,
 };
 
+use aleph_primitives::BlockNumber;
 use codec::{Decode, Encode};
 use sp_runtime::{
-    traits::{Block as BlockT, NumberFor},
+    traits::{Block as BlockT, Header as HeaderT, NumberFor},
     SaturatedConversion,
 };
 
@@ -68,7 +69,10 @@ impl<B: BlockT> PartialEq for UnvalidatedAlephProposal<B> {
 
 impl<B: BlockT> Eq for UnvalidatedAlephProposal<B> {}
 
-impl<B: BlockT> UnvalidatedAlephProposal<B> {
+impl<B: BlockT> UnvalidatedAlephProposal<B>
+where
+    B::Header: HeaderT<Number = BlockNumber>,
+{
     pub(crate) fn new(branch: Vec<B::Hash>, block_number: NumberFor<B>) -> Self {
         UnvalidatedAlephProposal {
             branch,
@@ -78,7 +82,7 @@ impl<B: BlockT> UnvalidatedAlephProposal<B> {
 
     pub(crate) fn validate_bounds(
         &self,
-        session_boundaries: &SessionBoundaries<B>,
+        session_boundaries: &SessionBoundaries,
     ) -> Result<AlephProposal<B>, ValidationError<B>> {
         use ValidationError::*;
 
@@ -150,7 +154,10 @@ impl<B: BlockT> Index<usize> for AlephProposal<B> {
     }
 }
 
-impl<B: BlockT> AlephProposal<B> {
+impl<B: BlockT> AlephProposal<B>
+where
+    B::Header: HeaderT<Number = BlockNumber>,
+{
     /// Outputs the length the branch.
     pub fn len(&self) -> usize {
         self.branch.len()
@@ -182,25 +189,25 @@ impl<B: BlockT> AlephProposal<B> {
     }
 
     /// Outputs the number one below the lowest block in the branch.
-    pub fn number_below_branch(&self) -> NumberFor<B> {
+    pub fn number_below_branch(&self) -> BlockNumber {
         // Assumes that data is within bounds
-        self.number - <NumberFor<B>>::saturated_from(self.branch.len())
+        self.number - <BlockNumber>::saturated_from(self.branch.len())
     }
 
     /// Outputs the number of the lowest block in the branch.
-    pub fn number_bottom_block(&self) -> NumberFor<B> {
+    pub fn number_bottom_block(&self) -> BlockNumber {
         // Assumes that data is within bounds
-        self.number - <NumberFor<B>>::saturated_from(self.branch.len() - 1)
+        self.number - <BlockNumber>::saturated_from(self.branch.len() - 1)
     }
 
     /// Outputs the number of the highest block in the branch.
-    pub fn number_top_block(&self) -> NumberFor<B> {
+    pub fn number_top_block(&self) -> BlockNumber {
         self.number
     }
 
     /// Outputs the block corresponding to the number in the proposed branch in case num is
     /// between the lowest and highest block number of the branch. Otherwise returns None.
-    pub fn block_at_num(&self, num: NumberFor<B>) -> Option<BlockHashNum<B>> {
+    pub fn block_at_num(&self, num: BlockNumber) -> Option<BlockHashNum<B>> {
         if self.number_bottom_block() <= num && num <= self.number_top_block() {
             let ind: usize = (num - self.number_bottom_block()).saturated_into();
             return Some((self.branch[ind], num).into());
@@ -210,14 +217,14 @@ impl<B: BlockT> AlephProposal<B> {
 
     /// Outputs an iterator over blocks starting at num. If num is too high, the iterator is
     /// empty, if it's too low the whole branch is returned.
-    pub fn blocks_from_num(&self, num: NumberFor<B>) -> impl Iterator<Item = BlockHashNum<B>> + '_ {
+    pub fn blocks_from_num(&self, num: BlockNumber) -> impl Iterator<Item = BlockHashNum<B>> + '_ {
         let num = max(num, self.number_bottom_block());
         self.branch
             .iter()
             .skip((num - self.number_bottom_block()).saturated_into())
             .cloned()
             .zip(0u32..)
-            .map(move |(hash, index)| (hash, num + index.into()).into())
+            .map(move |(hash, index)| (hash, num + index).into())
     }
 }
 
@@ -242,15 +249,17 @@ mod tests {
 
     use super::{UnvalidatedAlephProposal, ValidationError::*};
     use crate::{
-        data_io::MAX_DATA_BRANCH_LEN, testing::mocks::TBlock, SessionBoundaries, SessionId,
+        data_io::MAX_DATA_BRANCH_LEN, testing::mocks::TBlock, SessionBoundaryInfo, SessionId,
         SessionPeriod,
     };
 
     #[test]
     fn proposal_with_empty_branch_is_invalid() {
-        let session_boundaries = SessionBoundaries::<TBlock>::new(SessionId(1), SessionPeriod(20));
+        let session_boundaries =
+            SessionBoundaryInfo::new(SessionPeriod(20)).boundaries_for_session(SessionId(1));
         let branch = vec![];
-        let proposal = UnvalidatedAlephProposal::new(branch, session_boundaries.first_block());
+        let proposal =
+            UnvalidatedAlephProposal::<TBlock>::new(branch, session_boundaries.first_block());
         assert_eq!(
             proposal.validate_bounds(&session_boundaries),
             Err(BranchEmpty)
@@ -259,11 +268,12 @@ mod tests {
 
     #[test]
     fn too_long_proposal_is_invalid() {
-        let session_boundaries = SessionBoundaries::<TBlock>::new(SessionId(1), SessionPeriod(20));
+        let session_boundaries =
+            SessionBoundaryInfo::new(SessionPeriod(20)).boundaries_for_session(SessionId(1));
         let session_end = session_boundaries.last_block();
         let branch = vec![H256::default(); MAX_DATA_BRANCH_LEN + 1];
         let branch_size = branch.len();
-        let proposal = UnvalidatedAlephProposal::new(branch, session_end);
+        let proposal = UnvalidatedAlephProposal::<TBlock>::new(branch, session_end);
         assert_eq!(
             proposal.validate_bounds(&session_boundaries),
             Err(BranchTooLong { branch_size })
@@ -272,12 +282,13 @@ mod tests {
 
     #[test]
     fn proposal_not_within_session_is_invalid() {
-        let session_boundaries = SessionBoundaries::<TBlock>::new(SessionId(1), SessionPeriod(20));
+        let session_boundaries =
+            SessionBoundaryInfo::new(SessionPeriod(20)).boundaries_for_session(SessionId(1));
         let session_start = session_boundaries.first_block();
         let session_end = session_boundaries.last_block();
         let branch = vec![H256::default(); 2];
 
-        let proposal = UnvalidatedAlephProposal::new(branch.clone(), session_start);
+        let proposal = UnvalidatedAlephProposal::<TBlock>::new(branch.clone(), session_start);
         assert_eq!(
             proposal.validate_bounds(&session_boundaries),
             Err(BlockOutsideSessionBoundaries {
@@ -288,7 +299,7 @@ mod tests {
             })
         );
 
-        let proposal = UnvalidatedAlephProposal::new(branch, session_end + 1);
+        let proposal = UnvalidatedAlephProposal::<TBlock>::new(branch, session_end + 1);
         assert_eq!(
             proposal.validate_bounds(&session_boundaries),
             Err(BlockOutsideSessionBoundaries {
@@ -302,10 +313,11 @@ mod tests {
 
     #[test]
     fn proposal_starting_at_zero_block_is_invalid() {
-        let session_boundaries = SessionBoundaries::<TBlock>::new(SessionId(0), SessionPeriod(20));
+        let session_boundaries =
+            SessionBoundaryInfo::new(SessionPeriod(20)).boundaries_for_session(SessionId(1));
         let branch = vec![H256::default(); 2];
 
-        let proposal = UnvalidatedAlephProposal::new(branch, 1);
+        let proposal = UnvalidatedAlephProposal::<TBlock>::new(branch, 1);
         assert_eq!(
             proposal.validate_bounds(&session_boundaries),
             Err(BlockNumberOutOfBounds {
@@ -317,16 +329,21 @@ mod tests {
 
     #[test]
     fn valid_proposal_is_validated_positively() {
-        let session_boundaries = SessionBoundaries::<TBlock>::new(SessionId(0), SessionPeriod(20));
+        let session_boundaries =
+            SessionBoundaryInfo::new(SessionPeriod(20)).boundaries_for_session(SessionId(1));
 
         let branch = vec![H256::default(); MAX_DATA_BRANCH_LEN];
-        let proposal =
-            UnvalidatedAlephProposal::new(branch, (MAX_DATA_BRANCH_LEN + 1) as BlockNumber);
+        let proposal = UnvalidatedAlephProposal::<TBlock>::new(
+            branch,
+            (MAX_DATA_BRANCH_LEN + 1) as BlockNumber,
+        );
         assert!(proposal.validate_bounds(&session_boundaries).is_ok());
 
         let branch = vec![H256::default(); 1];
-        let proposal =
-            UnvalidatedAlephProposal::new(branch, (MAX_DATA_BRANCH_LEN + 1) as BlockNumber);
+        let proposal = UnvalidatedAlephProposal::<TBlock>::new(
+            branch,
+            (MAX_DATA_BRANCH_LEN + 1) as BlockNumber,
+        );
         assert!(proposal.validate_bounds(&session_boundaries).is_ok());
     }
 }

--- a/finality-aleph/src/justification/handler.rs
+++ b/finality-aleph/src/justification/handler.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, Instant};
 
+use aleph_primitives::BlockNumber;
 use futures::{channel::mpsc, Stream, StreamExt};
 use futures_timer::Delay;
 use log::{debug, error};
@@ -19,6 +20,7 @@ use crate::{
 pub struct JustificationHandler<B, V, RB, S, SI, F, BB>
 where
     B: BlockT,
+    B::Header: Header<Number = BlockNumber>,
     V: Verifier<B>,
     RB: network::RequestBlocks<B> + 'static,
     S: JustificationRequestScheduler,
@@ -35,6 +37,7 @@ where
 impl<B, V, RB, S, SI, F, BB> JustificationHandler<B, V, RB, S, SI, F, BB>
 where
     B: BlockT,
+    B::Header: Header<Number = BlockNumber>,
     V: Verifier<B>,
     RB: network::RequestBlocks<B> + 'static,
     S: JustificationRequestScheduler,
@@ -83,7 +86,7 @@ where
                 current_session,
             } = self
                 .session_info_provider
-                .for_block_num(last_finalized_number + 1u32.into())
+                .for_block_num(last_finalized_number + 1)
                 .await;
             if verifier.is_none() {
                 debug!(target: "aleph-justification", "Verifier for session {:?} not yet available. Waiting {}ms and will try again ...", current_session, self.verifier_timeout.as_millis());

--- a/finality-aleph/src/justification/requester.rs
+++ b/finality-aleph/src/justification/requester.rs
@@ -1,10 +1,10 @@
 use std::{fmt, marker::PhantomData, time::Instant};
 
-use aleph_primitives::ALEPH_ENGINE_ID;
+use aleph_primitives::{BlockNumber, ALEPH_ENGINE_ID};
 use log::{debug, error, info, warn};
 use sc_client_api::blockchain::Info;
 use sp_api::{BlockId, BlockT, NumberFor};
-use sp_runtime::traits::{Header, One, Saturating};
+use sp_runtime::traits::{Header, One};
 
 use crate::{
     finalization::BlockFinalizer,
@@ -100,6 +100,7 @@ impl<B: BlockT> fmt::Display for JustificationRequestStatus<B> {
 pub struct BlockRequester<B, RB, S, F, V, BB>
 where
     B: BlockT,
+    B::Header: Header<Number = BlockNumber>,
     RB: network::RequestBlocks<B> + 'static,
     S: JustificationRequestScheduler,
     F: BlockFinalizer<B>,
@@ -118,6 +119,7 @@ where
 impl<B, RB, S, F, V, BB> BlockRequester<B, RB, S, F, V, BB>
 where
     B: BlockT,
+    B::Header: Header<Number = BlockNumber>,
     RB: network::RequestBlocks<B> + 'static,
     S: JustificationRequestScheduler,
     F: BlockFinalizer<B>,

--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -1,7 +1,8 @@
 extern crate core;
 
-use std::{fmt::Debug, path::PathBuf, sync::Arc};
+use std::{fmt::Debug, hash::Hash, path::PathBuf, sync::Arc};
 
+use aleph_primitives::BlockNumber;
 use codec::{Decode, Encode, Output};
 use derive_more::Display;
 use futures::{
@@ -23,7 +24,7 @@ use crate::{
     abft::{CurrentNetworkData, LegacyNetworkData, CURRENT_VERSION, LEGACY_VERSION},
     aggregation::{CurrentRmcNetworkData, LegacyRmcNetworkData},
     network::data::split::Split,
-    session::{SessionBoundaries, SessionId},
+    session::{SessionBoundaries, SessionBoundaryInfo, SessionId},
     VersionedTryFromError::{ExpectedNewGotOld, ExpectedOldGotNew},
 };
 
@@ -225,14 +226,14 @@ pub struct HashNum<H, N> {
     num: N,
 }
 
-impl<H, N> HashNum<H, N> {
-    fn new(hash: H, num: N) -> Self {
+impl<H> HashNum<H, BlockNumber> {
+    fn new(hash: H, num: BlockNumber) -> Self {
         HashNum { hash, num }
     }
 }
 
-impl<H, N> From<(H, N)> for HashNum<H, N> {
-    fn from(pair: (H, N)) -> Self {
+impl<H> From<(H, BlockNumber)> for HashNum<H, BlockNumber> {
+    fn from(pair: (H, BlockNumber)) -> Self {
         HashNum::new(pair.0, pair.1)
     }
 }

--- a/finality-aleph/src/party/manager/aggregator.rs
+++ b/finality-aleph/src/party/manager/aggregator.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use aleph_primitives::BlockNumber;
 use futures::{
     channel::{mpsc, oneshot},
     pin_mut, StreamExt,
@@ -76,12 +77,13 @@ async fn run_aggregator<B, C, CN, LN>(
     mut aggregator: Aggregator<'_, B, CN, LN>,
     io: IO<B>,
     client: Arc<C>,
-    session_boundaries: &SessionBoundaries<B>,
+    session_boundaries: &SessionBoundaries,
     metrics: Option<Metrics<<B::Header as Header>::Hash>>,
     mut exit_rx: oneshot::Receiver<()>,
 ) -> Result<(), ()>
 where
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
     C: HeaderBackend<B> + Send + Sync + 'static,
     LN: Network<LegacyRmcNetworkData<B>>,
     CN: Network<CurrentRmcNetworkData<B>>,
@@ -161,13 +163,14 @@ pub fn task<B, C, CN, LN>(
     subtask_common: AuthoritySubtaskCommon,
     client: Arc<C>,
     io: IO<B>,
-    session_boundaries: SessionBoundaries<B>,
+    session_boundaries: SessionBoundaries,
     metrics: Option<Metrics<<B::Header as Header>::Hash>>,
     multikeychain: Keychain,
     version: AggregatorVersion<CN, LN>,
 ) -> Task
 where
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
     C: HeaderBackend<B> + Send + Sync + 'static,
     LN: Network<LegacyRmcNetworkData<B>> + 'static,
     CN: Network<CurrentRmcNetworkData<B>> + 'static,

--- a/finality-aleph/src/party/manager/chain_tracker.rs
+++ b/finality-aleph/src/party/manager/chain_tracker.rs
@@ -1,8 +1,9 @@
+use aleph_primitives::BlockNumber;
 use futures::channel::oneshot;
 use log::debug;
 use sc_client_api::HeaderBackend;
 use sp_consensus::SelectChain;
-use sp_runtime::traits::Block;
+use sp_runtime::traits::{Block, Header};
 
 use crate::{
     abft::SpawnHandleT,
@@ -17,6 +18,7 @@ pub fn task<B, SC, C>(
 ) -> Task
 where
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
     C: HeaderBackend<B> + 'static,
     SC: SelectChain<B> + 'static,
 {

--- a/finality-aleph/src/party/manager/data_store.rs
+++ b/finality-aleph/src/party/manager/data_store.rs
@@ -1,10 +1,11 @@
 use std::fmt::Debug;
 
+use aleph_primitives::BlockNumber;
 use codec::Codec;
 use futures::channel::oneshot;
 use log::debug;
 use sc_client_api::{BlockchainEvents, HeaderBackend};
-use sp_runtime::traits::Block;
+use sp_runtime::traits::{Block, Header};
 
 use crate::{
     abft::SpawnHandleT,
@@ -20,6 +21,7 @@ pub fn task<B, C, RB, R, Message>(
 ) -> Task
 where
     B: Block,
+    B::Header: Header<Number = BlockNumber>,
     C: HeaderBackend<B> + BlockchainEvents<B> + Send + Sync + 'static,
     RB: RequestBlocks<B> + 'static,
     Message: AlephNetworkMessage<B> + Debug + Send + Sync + Codec + 'static,

--- a/finality-aleph/src/party/manager/mod.rs
+++ b/finality-aleph/src/party/manager/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};
 
-use aleph_primitives::{AlephSessionApi, KEY_TYPE};
+use aleph_primitives::{AlephSessionApi, BlockNumber, KEY_TYPE};
 use async_trait::async_trait;
 use futures::channel::oneshot;
 use log::{debug, info, trace, warn};
@@ -9,7 +9,7 @@ use sp_consensus::SelectChain;
 use sp_keystore::CryptoStore;
 use sp_runtime::{
     generic::BlockId,
-    traits::{Block as BlockT, Header, NumberFor, One, Saturating},
+    traits::{Block as BlockT, Header as HeaderT},
 };
 
 use crate::{
@@ -32,8 +32,8 @@ use crate::{
         backup::ABFTBackup, manager::aggregator::AggregatorVersion, traits::NodeSessionManager,
     },
     AuthorityId, CurrentRmcNetworkData, JustificationNotification, Keychain, LegacyRmcNetworkData,
-    Metrics, NodeIndex, SessionBoundaries, SessionId, SessionPeriod, UnitCreationDelay,
-    VersionedNetworkData,
+    Metrics, NodeIndex, SessionBoundaries, SessionBoundaryInfo, SessionId, SessionPeriod,
+    UnitCreationDelay, VersionedNetworkData,
 };
 
 mod aggregator;
@@ -67,6 +67,7 @@ type CurrentNetworkType<B> = SimpleNetwork<
 struct SubtasksParams<C, SC, B, N, BE>
 where
     B: BlockT,
+    B::Header: HeaderT<Number = BlockNumber>,
     C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
     BE: Backend<B> + 'static,
     SC: SelectChain<B> + 'static,
@@ -76,7 +77,7 @@ where
     node_id: NodeIndex,
     session_id: SessionId,
     data_network: N,
-    session_boundaries: SessionBoundaries<B>,
+    session_boundaries: SessionBoundaries,
     subtask_common: SubtaskCommon,
     data_provider: DataProvider<B>,
     ordered_data_interpreter: OrderedDataInterpreter<B, C>,
@@ -91,6 +92,7 @@ where
 pub struct NodeSessionManagerImpl<C, SC, B, RB, BE, SM>
 where
     B: BlockT,
+    B::Header: HeaderT<Number = BlockNumber>,
     C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
     BE: Backend<B> + 'static,
     SC: SelectChain<B> + 'static,
@@ -99,11 +101,11 @@ where
 {
     client: Arc<C>,
     select_chain: SC,
-    session_period: SessionPeriod,
+    session_info: SessionBoundaryInfo,
     unit_creation_delay: UnitCreationDelay,
     authority_justification_tx: mpsc::UnboundedSender<JustificationNotification<B>>,
     block_requester: RB,
-    metrics: Option<Metrics<<B::Header as Header>::Hash>>,
+    metrics: Option<Metrics<<B::Header as HeaderT>::Hash>>,
     spawn_handle: SpawnHandle,
     session_manager: SM,
     keystore: Arc<dyn CryptoStore>,
@@ -113,6 +115,7 @@ where
 impl<C, SC, B, RB, BE, SM> NodeSessionManagerImpl<C, SC, B, RB, BE, SM>
 where
     B: BlockT,
+    B::Header: HeaderT<Number = BlockNumber>,
     C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
     C::Api: aleph_primitives::AlephSessionApi<B>,
     BE: Backend<B> + 'static,
@@ -128,7 +131,7 @@ where
         unit_creation_delay: UnitCreationDelay,
         authority_justification_tx: mpsc::UnboundedSender<JustificationNotification<B>>,
         block_requester: RB,
-        metrics: Option<Metrics<<B::Header as Header>::Hash>>,
+        metrics: Option<Metrics<<B::Header as HeaderT>::Hash>>,
         spawn_handle: SpawnHandle,
         session_manager: SM,
         keystore: Arc<dyn CryptoStore>,
@@ -136,7 +139,7 @@ where
         Self {
             client,
             select_chain,
-            session_period,
+            session_info: SessionBoundaryInfo::new(session_period),
             unit_creation_delay,
             authority_justification_tx,
             block_requester,
@@ -282,7 +285,7 @@ where
         let multikeychain =
             Keychain::new(node_id, authority_verifier.clone(), authority_pen.clone());
 
-        let session_boundaries = SessionBoundaries::new(session_id, self.session_period);
+        let session_boundaries = self.session_info.boundaries_for_session(session_id);
         let (blocks_for_aggregator, blocks_from_interpreter) = mpsc::unbounded();
 
         let (chain_tracker, data_provider) = ChainTracker::new(
@@ -317,9 +320,7 @@ where
             Err(e) => panic!("Failed to start validator session: {}", e),
         };
 
-        let last_block_of_previous_session = session_boundaries
-            .first_block()
-            .saturating_sub(<NumberFor<B>>::one());
+        let last_block_of_previous_session = session_boundaries.first_block().saturating_sub(1);
 
         let params = SubtasksParams {
             n_members: authorities.len(),
@@ -380,6 +381,7 @@ where
 impl<C, SC, B, RB, BE, SM> NodeSessionManager for NodeSessionManagerImpl<C, SC, B, RB, BE, SM>
 where
     B: BlockT,
+    B::Header: HeaderT<Number = BlockNumber>,
     C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
     C::Api: aleph_primitives::AlephSessionApi<B>,
     BE: Backend<B> + 'static,

--- a/finality-aleph/src/session.rs
+++ b/finality-aleph/src/session.rs
@@ -1,42 +1,20 @@
 use aleph_primitives::BlockNumber;
 use codec::{Decode, Encode};
-use sp_runtime::traits::Block;
-
-use crate::NumberFor;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
-pub struct SessionBoundaries<B: Block> {
-    first_block: NumberFor<B>,
-    last_block: NumberFor<B>,
+pub struct SessionBoundaries {
+    first_block: BlockNumber,
+    last_block: BlockNumber,
 }
 
-impl<B: Block> SessionBoundaries<B> {
-    pub fn new(session_id: SessionId, period: SessionPeriod) -> Self {
-        SessionBoundaries {
-            first_block: first_block_of_session(session_id, period).into(),
-            last_block: last_block_of_session(session_id, period).into(),
-        }
-    }
-
-    pub fn first_block(&self) -> NumberFor<B> {
+impl SessionBoundaries {
+    pub fn first_block(&self) -> BlockNumber {
         self.first_block
     }
 
-    pub fn last_block(&self) -> NumberFor<B> {
+    pub fn last_block(&self) -> BlockNumber {
         self.last_block
     }
-}
-
-fn first_block_of_session(session_id: SessionId, period: SessionPeriod) -> BlockNumber {
-    session_id.0 * period.0
-}
-
-fn last_block_of_session(session_id: SessionId, period: SessionPeriod) -> BlockNumber {
-    (session_id.0 + 1) * period.0 - 1
-}
-
-fn session_id_from_block_num(num: BlockNumber, period: SessionPeriod) -> SessionId {
-    SessionId(num / period.0)
 }
 
 pub struct SessionBoundaryInfo {
@@ -49,19 +27,26 @@ impl SessionBoundaryInfo {
         Self { session_period }
     }
 
+    pub fn boundaries_for_session(&self, session_id: SessionId) -> SessionBoundaries {
+        SessionBoundaries {
+            first_block: self.first_block_of_session(session_id),
+            last_block: self.last_block_of_session(session_id),
+        }
+    }
+
     /// Returns session id of the session that block belongs to.
     pub fn session_id_from_block_num(&self, n: BlockNumber) -> SessionId {
-        session_id_from_block_num(n, self.session_period)
+        SessionId(n / self.session_period.0)
     }
 
     /// Returns block number which is the last block of the session.
     pub fn last_block_of_session(&self, session_id: SessionId) -> BlockNumber {
-        last_block_of_session(session_id, self.session_period)
+        (session_id.0 + 1) * self.session_period.0 - 1
     }
 
     /// Returns block number which is the first block of the session.
     pub fn first_block_of_session(&self, session_id: SessionId) -> BlockNumber {
-        first_block_of_session(session_id, self.session_period)
+        session_id.0 * self.session_period.0
     }
 }
 

--- a/finality-aleph/src/sync/handler.rs
+++ b/finality-aleph/src/sync/handler.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Error as FmtError, Formatter};
 
 use crate::{
-    session::{SessionId, SessionBoundaryInfo, SessionPeriod},
+    session::{SessionBoundaryInfo, SessionId, SessionPeriod},
     sync::{
         data::{NetworkData, Request, State},
         forest::{Error as ForestError, Forest, Interest},


### PR DESCRIPTION
# Description

After this PR;
* `HashNum` only be created with `N = BlockNumber`
* `SessionBoundaries` no longer is generic over `B: Block`
* `SessionBoundaries` is created using `SessionBoundaryInfo` as suggested in https://github.com/Cardinal-Cryptography/aleph-node/pull/1000#discussion_r1133938346

Next steps for the refactor will be:
* `AuthorityProvider` not generic over `N` and `FinalityNotificator` not generic over `B` in result `SessionMapUpdater` does not need to be generic over `B`
* `RequestBlocks` not generic over `B`. Could be generic over `H: Hash`
* other changes, for example somehow unifying `HashNum` with `BlockIdentifier` in `sync`

## Type of change

- Refactor
