### PR TITLE
Make dependabot to work on Sundays and do not update PRs automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
-
+      day: sunday
+      rebase-strategy: disabled


### PR DESCRIPTION
# Description

* Dependabot should raise PRs only on Sunday to not interfere with ppl work
* Dpendabot should not update PRs automatically. Especially on Mondays it auto bump PRs when someone merges to `main`, this is waste of our custom runners time 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:
