### PR TITLE
Update poseidon dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,24 +715,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-sponge"
-version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/sponge?branch=r1cs#113469aef48a9c5f458dbf523a509d4769affbf2"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-nonnative-field",
- "ark-r1cs-std",
- "ark-relations",
- "ark-serialize",
- "ark-std",
- "derivative",
- "digest 0.9.0",
- "rand_chacha 0.3.1",
- "tracing",
-]
-
-[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4586,6 +4568,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "liminal-ark-pnbr-poseidon-parameters"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8723da56ab98f2182cbd27b9c510ca3c7f7bd616a56ca0e6b8f1b4bbc2c5f2ee"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "num-integer",
+]
+
+[[package]]
+name = "liminal-ark-pnbr-poseidon-paramgen"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e7de36eb888e7ba29bcc4dcd664db0df190f073e807baa230054abbbadaf6d"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-std",
+ "getrandom 0.2.8",
+ "liminal-ark-pnbr-poseidon-parameters",
+ "merlin 3.0.0",
+ "num",
+ "num-bigint",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "liminal-ark-pnbr-poseidon-permutation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0419b780a13b09a1ed2db09c6c61752f24e5f341f77a93719cd8bc963b72d3"
+dependencies = [
+ "ark-ff",
+ "ark-std",
+ "liminal-ark-pnbr-poseidon-parameters",
+]
+
+[[package]]
+name = "liminal-ark-pnbr-sponge"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c178b0470950ac7fb73646df0f6ef60452d7b0fb0819e41dbe66674abc622f"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-nonnative-field",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.9.0",
+ "rand_chacha 0.3.1",
+ "tracing",
+]
+
+[[package]]
 name = "liminal-ark-poseidon"
 version = "0.1.0"
 dependencies = [
@@ -4593,11 +4633,11 @@ dependencies = [
  "ark-ff",
  "ark-r1cs-std",
  "ark-relations",
- "ark-sponge",
+ "liminal-ark-pnbr-poseidon-parameters",
+ "liminal-ark-pnbr-poseidon-paramgen",
+ "liminal-ark-pnbr-poseidon-permutation",
+ "liminal-ark-pnbr-sponge",
  "paste",
- "poseidon-parameters",
- "poseidon-paramgen",
- "poseidon-permutation",
 ]
 
 [[package]]
@@ -6252,42 +6292,6 @@ dependencies = [
  "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash 0.5.0",
-]
-
-[[package]]
-name = "poseidon-parameters"
-version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?rev=50699746#50699746c031a915d5434088a1240f4b568d9ee8"
-dependencies = [
- "anyhow",
- "ark-ff",
- "num-integer",
-]
-
-[[package]]
-name = "poseidon-paramgen"
-version = "0.1.1"
-source = "git+https://github.com/penumbra-zone/poseidon377?rev=50699746#50699746c031a915d5434088a1240f4b568d9ee8"
-dependencies = [
- "anyhow",
- "ark-ff",
- "ark-std",
- "getrandom 0.2.8",
- "merlin 3.0.0",
- "num",
- "num-bigint",
- "poseidon-parameters",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "poseidon-permutation"
-version = "0.1.1"
-source = "git+https://github.com/penumbra-zone/poseidon377?rev=50699746#50699746c031a915d5434088a1240f4b568d9ee8"
-dependencies = [
- "ark-ff",
- "ark-std",
- "poseidon-parameters",
 ]
 
 [[package]]

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -380,24 +380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-sponge"
-version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/sponge?branch=r1cs#113469aef48a9c5f458dbf523a509d4769affbf2"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-nonnative-field",
- "ark-r1cs-std",
- "ark-relations",
- "ark-serialize",
- "ark-std",
- "derivative",
- "digest 0.9.0",
- "rand_chacha 0.3.1",
- "tracing",
-]
-
-[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,6 +2271,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "liminal-ark-pnbr-poseidon-parameters"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8723da56ab98f2182cbd27b9c510ca3c7f7bd616a56ca0e6b8f1b4bbc2c5f2ee"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "num-integer",
+]
+
+[[package]]
+name = "liminal-ark-pnbr-poseidon-permutation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0419b780a13b09a1ed2db09c6c61752f24e5f341f77a93719cd8bc963b72d3"
+dependencies = [
+ "ark-ff",
+ "ark-std",
+ "liminal-ark-pnbr-poseidon-parameters",
+]
+
+[[package]]
+name = "liminal-ark-pnbr-sponge"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c178b0470950ac7fb73646df0f6ef60452d7b0fb0819e41dbe66674abc622f"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-nonnative-field",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.9.0",
+ "rand_chacha 0.3.1",
+ "tracing",
+]
+
+[[package]]
 name = "liminal-ark-poseidon"
 version = "0.1.0"
 dependencies = [
@@ -2296,10 +2319,10 @@ dependencies = [
  "ark-ff",
  "ark-r1cs-std",
  "ark-relations",
- "ark-sponge",
+ "liminal-ark-pnbr-poseidon-parameters",
+ "liminal-ark-pnbr-poseidon-permutation",
+ "liminal-ark-pnbr-sponge",
  "paste",
- "poseidon-parameters",
- "poseidon-permutation",
 ]
 
 [[package]]
@@ -2976,26 +2999,6 @@ checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
-]
-
-[[package]]
-name = "poseidon-parameters"
-version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?rev=50699746#50699746c031a915d5434088a1240f4b568d9ee8"
-dependencies = [
- "anyhow",
- "ark-ff",
- "num-integer",
-]
-
-[[package]]
-name = "poseidon-permutation"
-version = "0.1.1"
-source = "git+https://github.com/penumbra-zone/poseidon377?rev=50699746#50699746c031a915d5434088a1240f4b568d9ee8"
-dependencies = [
- "ark-ff",
- "ark-std",
- "poseidon-parameters",
 ]
 
 [[package]]

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -18,12 +18,12 @@ ark-r1cs-std = {version = "^0.3.0" , default-features = false, optional = true }
 ark-relations = { version = "^0.3.0", default-features = false, optional = true }
 paste = { version = "1.0.11" }
 
-ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "r1cs", default-features = false, features = ["r1cs"], optional = true  }
-poseidon-parameters = { git = "https://github.com/penumbra-zone/poseidon377", rev = "50699746", default-features = false }
-poseidon-permutation = { git = "https://github.com/penumbra-zone/poseidon377", rev = "50699746", default-features = false }
+liminal-ark-pnbr-sponge = { version = "0.3.0", default-features = false, features = ["r1cs"], optional = true  }
+liminal-ark-pnbr-poseidon-parameters = { version = "0.1.0", default-features = false }
+liminal-ark-pnbr-poseidon-permutation = { version = "0.1.0", default-features = false }
 
 # For generation only
-poseidon-paramgen = { git = "https://github.com/penumbra-zone/poseidon377", rev = "50699746", optional = true }
+liminal-ark-pnbr-poseidon-paramgen = { version = "0.1.0", optional = true }
 
 [lib]
 name = "liminal_ark_poseidon"
@@ -39,13 +39,13 @@ std = [
     "ark-bls12-381/std",
     "ark-ff/std",
 
-    "poseidon-parameters/std",
-    "poseidon-permutation/std",
+    "liminal-ark-pnbr-poseidon-parameters/std",
+    "liminal-ark-pnbr-poseidon-permutation/std",
 ]
 circuit = [
     "ark-r1cs-std",
     "ark-relations",
-    "ark-sponge",
+    "liminal-ark-pnbr-sponge",
 ]
 circuit-std = [
     "circuit",
@@ -54,9 +54,9 @@ circuit-std = [
     "ark-r1cs-std/std",
     "ark-relations/std",
 
-    "ark-sponge/std",
+    "liminal-ark-pnbr-sponge/std",
 ]
 paramgen = [
     "std",
-    "poseidon-paramgen/std",
+    "liminal-ark-pnbr-poseidon-paramgen/std",
 ]

--- a/poseidon/src/circuit.rs
+++ b/poseidon/src/circuit.rs
@@ -1,12 +1,12 @@
 use ark_bls12_381::Fr;
 use ark_r1cs_std::prelude::AllocVar;
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-use ark_sponge::{
+use liminal_ark_pnbr_poseidon_parameters::{Alpha, PoseidonParameters};
+use liminal_ark_pnbr_sponge::{
     constraints::CryptographicSpongeVar,
     poseidon::{constraints::PoseidonSpongeVar, PoseidonParameters as ArkSpongePoseidonParameters},
 };
 use paste::paste;
-use poseidon_parameters::{Alpha, PoseidonParameters};
 
 use crate::{domain_separator, parameters::*};
 

--- a/poseidon/src/generate_parameters.rs
+++ b/poseidon/src/generate_parameters.rs
@@ -9,7 +9,7 @@ use std::{
 
 use ark_bls12_381::{Fr, FrParameters};
 use ark_ff::{fields::FpParameters, vec};
-use poseidon_paramgen::poseidon_build;
+use liminal_ark_pnbr_poseidon_paramgen::poseidon_build;
 
 fn main() {
     let security_level = match env::var("SECURITY_LEVEL") {

--- a/poseidon/src/hash.rs
+++ b/poseidon/src/hash.rs
@@ -11,7 +11,7 @@ macro_rules! n_to_one {
             #[doc = ":1 Poseidon hash of `input`."]
             pub fn [<$n_as_word _to_one_hash>] (input: [Fr; $n]) -> Fr {
                 let parameters = [<rate_ $n>]::<Fr>();
-                let mut state = poseidon_permutation::Instance::new(&parameters);
+                let mut state = liminal_ark_pnbr_poseidon_permutation::Instance::new(&parameters);
                 state.n_to_1_fixed_hash([ark_ff::vec![domain_separator()], input.to_vec()].concat())
             }
         }

--- a/poseidon/src/parameters.rs
+++ b/poseidon/src/parameters.rs
@@ -1,7 +1,7 @@
 //! This file was generated using `generate_parameters.rs`, do not edit it manually!
 
 use ark_ff::{vec, PrimeField};
-use poseidon_parameters::{
+use liminal_ark_pnbr_poseidon_parameters::{
     Alpha, ArcMatrix, Matrix, MatrixOperations, MdsMatrix, OptimizedArcMatrix,
     OptimizedMdsMatrices, PoseidonParameters, RoundNumbers, SquareMatrix,
 };

--- a/relations/Cargo.lock
+++ b/relations/Cargo.lock
@@ -275,24 +275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-sponge"
-version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/sponge?branch=r1cs#113469aef48a9c5f458dbf523a509d4769affbf2"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-nonnative-field",
- "ark-r1cs-std",
- "ark-relations",
- "ark-serialize",
- "ark-std",
- "derivative",
- "digest",
- "rand_chacha",
- "tracing",
-]
-
-[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +621,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "liminal-ark-pnbr-poseidon-parameters"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8723da56ab98f2182cbd27b9c510ca3c7f7bd616a56ca0e6b8f1b4bbc2c5f2ee"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "num-integer",
+]
+
+[[package]]
+name = "liminal-ark-pnbr-poseidon-permutation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0419b780a13b09a1ed2db09c6c61752f24e5f341f77a93719cd8bc963b72d3"
+dependencies = [
+ "ark-ff",
+ "ark-std",
+ "liminal-ark-pnbr-poseidon-parameters",
+]
+
+[[package]]
+name = "liminal-ark-pnbr-sponge"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c178b0470950ac7fb73646df0f6ef60452d7b0fb0819e41dbe66674abc622f"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-nonnative-field",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest",
+ "rand_chacha",
+ "tracing",
+]
+
+[[package]]
 name = "liminal-ark-poseidon"
 version = "0.1.0"
 dependencies = [
@@ -646,10 +669,10 @@ dependencies = [
  "ark-ff",
  "ark-r1cs-std",
  "ark-relations",
- "ark-sponge",
+ "liminal-ark-pnbr-poseidon-parameters",
+ "liminal-ark-pnbr-poseidon-permutation",
+ "liminal-ark-pnbr-sponge",
  "paste",
- "poseidon-parameters",
- "poseidon-permutation",
 ]
 
 [[package]]
@@ -820,26 +843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "poseidon-parameters"
-version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?rev=50699746#50699746c031a915d5434088a1240f4b568d9ee8"
-dependencies = [
- "anyhow",
- "ark-ff",
- "num-integer",
-]
-
-[[package]]
-name = "poseidon-permutation"
-version = "0.1.1"
-source = "git+https://github.com/penumbra-zone/poseidon377?rev=50699746#50699746c031a915d5434088a1240f4b568d9ee8"
-dependencies = [
- "ark-ff",
- "ark-std",
- "poseidon-parameters",
 ]
 
 [[package]]


### PR DESCRIPTION
Change `poseidon` dependencies from git-based to crates.io.