### PR TITLE
bumped rust to `nightly-2022-10-30` in nix/versions.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -140,7 +140,10 @@ with nixpkgs; naersk.buildPackage rec {
   postConfigure = ''
       ${nixpkgs.lib.optionalString providedCargoHome
          ''
-           export CARGO_HOME=${cargoHome}
+           # TODO this may cause the two-step build process of naersk (deps only -> whole project with prebuild deps) to fail, i.e. building everything twice.
+           # Unfortunately, new cargo is trying to write inside of git repositories of some of our dependencies, so we need a copy with write access.
+           cp -r ${cargoHome} .cargo_home
+           export CARGO_HOME=.cargo_home
          ''
        }
   '';

--- a/nix/nix-build.sh
+++ b/nix/nix-build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 NIX_FILE=${NIX_FILE:-"default.nix"}
 DYNAMIC_LINKER_PATH=${DYNAMIC_LINKER_PATH:-"/lib64/ld-linux-x86-64.so.2"}
 CRATES=${CRATES:-'{ "aleph-node" = []; }'}
-SINGLE_STEP=${SINGLE_STEP:-false}
+SINGLE_STEP=${SINGLE_STEP:-true}
 RUSTFLAGS=${RUSTFLAGS:-"-C target-cpu=generic"}
 CARGO_HOME=${CARGO_HOME:-"$(realpath ~/.cargo)"}
 PATH_TO_FIX=${PATH_TO_FIX:-""}

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -3,7 +3,7 @@ rec {
   rustToolchain =
     let
       # use Rust toolchain declared by the rust-toolchain file
-      rustToolchain = with nixpkgs; overrideRustTarget ( rustChannelOf { date = "2022-08-12"; channel = "nightly"; } );
+      rustToolchain = with nixpkgs; overrideRustTarget ( rustChannelOf { date = "2022-10-30"; channel = "nightly"; } );
 
       overrideRustTarget = rustChannel: rustChannel // {
         rust = rustChannel.rust.override {


### PR DESCRIPTION
# Description

bumped version of rust-toolchain in nix/versions.nix. Previous version was responsible for failing the docker-based build procedure.

https://github.com/Cardinal-Cryptography/aleph-node/issues/1052

## Type of change

hot-fix

## How to test it

```bash
sudo docker build -t aleph-build -f nix/Dockerfile.build .
sudo docker run -ti --volume=$(pwd):/node/build aleph-build
```
Result should be stored at `$(project_dir)/result/`.
