### PR TITLE
Update OBCE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5372,7 +5372,7 @@ dependencies = [
 [[package]]
 name = "obce"
 version = "0.1.0"
-source = "git+https://github.com/727-Ventures/obce?branch=aleph-v0.9.38#a225752f05ed9c368e6bca3cfdce0579bf46eaa6"
+source = "git+https://github.com/727-Ventures/obce?rev=5e3da417c2189ddd4e9ef82cd586f8ec94b8952a#5e3da417c2189ddd4e9ef82cd586f8ec94b8952a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5390,9 +5390,10 @@ dependencies = [
 [[package]]
 name = "obce-codegen"
 version = "0.1.0"
-source = "git+https://github.com/727-Ventures/obce?branch=aleph-v0.9.38#a225752f05ed9c368e6bca3cfdce0579bf46eaa6"
+source = "git+https://github.com/727-Ventures/obce?rev=5e3da417c2189ddd4e9ef82cd586f8ec94b8952a#5e3da417c2189ddd4e9ef82cd586f8ec94b8952a"
 dependencies = [
  "blake2 0.10.6",
+ "darling",
  "itertools",
  "proc-macro2",
  "quote",
@@ -5403,12 +5404,9 @@ dependencies = [
 [[package]]
 name = "obce-macro"
 version = "0.1.0"
-source = "git+https://github.com/727-Ventures/obce?branch=aleph-v0.9.38#a225752f05ed9c368e6bca3cfdce0579bf46eaa6"
+source = "git+https://github.com/727-Ventures/obce?rev=5e3da417c2189ddd4e9ef82cd586f8ec94b8952a#5e3da417c2189ddd4e9ef82cd586f8ec94b8952a"
 dependencies = [
  "obce-codegen",
- "proc-macro2",
- "syn",
- "synstructure",
 ]
 
 [[package]]

--- a/baby-liminal-extension/Cargo.toml
+++ b/baby-liminal-extension/Cargo.toml
@@ -14,7 +14,7 @@ ink = { version = "~4.0.1", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
-obce = { git = "https://github.com/727-Ventures/obce", branch = "aleph-v0.9.38", default-features = false }
+obce = { git = "https://github.com/727-Ventures/obce", rev = "5e3da417c2189ddd4e9ef82cd586f8ec94b8952a", default-features = false }
 
 pallet-baby-liminal = { path = "../pallets/baby-liminal", default-features = false, optional = true }
 primitives = { path = "../primitives", default-features = false, optional = true }

--- a/baby-liminal-extension/README.md
+++ b/baby-liminal-extension/README.md
@@ -2,7 +2,9 @@
 
 This crate is an implementation of BabyLiminal chain extension, with both ink! and Substrate counterparts available.
 
-## ink! usage
+## ink!
+
+### Usage
 
 To use `baby-liminal-extension` with ink!, include it as a dependency and activate `ink-std` 
 feature when `std` feature of your contract is enabled:
@@ -27,6 +29,14 @@ use baby_liminal_extension::{ink::Extension, BabyLiminalExtension};
 
 Extension.store_key(...);
 ```
+
+### Testing
+
+To test chain extension with `ink` features enabled, you have to ensure that you removed any other mention of `baby-liminal-extension`
+with `substrate` feature enabled, otherwise `rustc` will emit errors related to duplicated items.
+
+For example, you can comment out `baby-liminal-extension` mentions from `runtime` crate, then try to run
+the necessary checks/tests in `baby-liminal-extension` directory.
 
 ## Substrate
 

--- a/baby-liminal-extension/src/ink.rs
+++ b/baby-liminal-extension/src/ink.rs
@@ -1,4 +1,4 @@
-use ink::{env::Environment, ChainExtensionInstance};
+use ink::env::Environment;
 
 /// ink!'s chain extension counterpart.
 ///
@@ -8,15 +8,8 @@ use ink::{env::Environment, ChainExtensionInstance};
     feature = "std",
     derive(scale_info::TypeInfo, ink::storage::traits::StorageLayout)
 )]
+#[obce::ink_lang::extension]
 pub struct Extension;
-
-impl ChainExtensionInstance for Extension {
-    type Instance = Extension;
-
-    fn instantiate() -> Self::Instance {
-        Extension
-    }
-}
 
 impl crate::BabyLiminalExtension for Extension {}
 

--- a/baby-liminal-extension/src/lib.rs
+++ b/baby-liminal-extension/src/lib.rs
@@ -10,10 +10,9 @@ pub mod substrate;
 pub mod executor;
 
 #[cfg(feature = "ink")]
-use ::ink::prelude::vec::Vec;
-use obce::substrate::sp_runtime::AccountId32;
+use ::ink::{prelude::vec::Vec, primitives::AccountId as AccountId32};
 #[cfg(feature = "substrate")]
-use obce::substrate::sp_std::vec::Vec;
+use obce::substrate::{sp_runtime::AccountId32, sp_std::vec::Vec};
 use scale::{Decode, Encode};
 #[cfg(feature = "std")]
 use scale_info::TypeInfo;


### PR DESCRIPTION
# Description

This PR updates OBCE version to use newer commit, that mirrors OBCE's main branch while including Aleph Zero-specific Substrate fork.

Also, this PR fixes compilation error when building with `ink` feature enabled in `baby-liminal-extension` and adds a documentation on how to test that the crate builds for ink!.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have created new documentation
