### PR TITLE
A0-2175: Bump version of download-artifact version from 2 to 3

### DIFF
--- a/.github/workflows/_build-test-node-and-e2e-client-image.yml
+++ b/.github/workflows/_build-test-node-and-e2e-client-image.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download test artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: aleph-test-node
           path: target/release/

--- a/.github/workflows/_check-runtime-determimism.yml
+++ b/.github/workflows/_check-runtime-determimism.yml
@@ -23,7 +23,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Download production runtime from artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: aleph-release-runtime
 

--- a/.github/workflows/deploy-feature-envs.yaml
+++ b/.github/workflows/deploy-feature-envs.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/get-branch
 
       - name: Download artifact with built aleph-node binary from PR
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: aleph-release-node
           path: target/release/

--- a/.github/workflows/on-main-or-release-branch-commit.yml
+++ b/.github/workflows/on-main-or-release-branch-commit.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/get-ref-properties
 
       - name: Download node production binary from artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: aleph-release-node
           path: target/release/

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -476,7 +476,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: local-tests/
 
@@ -505,7 +505,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: local-tests/
 


### PR DESCRIPTION
_With v2 and v3, when an artifact is specified by the name input, there is no longer an extra directory that is created if the path input is not provided. All the contents are downloaded to the current working directory._

We update from v2 to v3 so all these should be fine.  I have reviewed all entries.  Note that, few entries are left with v2 because they are updated within another PR for nightly-pipeline.  I do not want to get any merge conflicts.