### PR TITLE
A0-2074: Enforce that all PRs start from Jira task number

### DIFF
--- a/.github/actions/check-pr-title/action.yml
+++ b/.github/actions/check-pr-title/action.yml
@@ -1,0 +1,32 @@
+---
+Name: Check Pull Request title
+description: 
+  Checks if PR has number of Jira ticket at very beginning of its title in proper format
+
+inputs:
+  pr-title:
+    description: "The title of Pull Request"
+    type: string
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name:
+      shell: bash
+      env:
+        PR_TITLE: ${{ inputs.pr-title }}
+      run: |
+        #!/bin/bash
+        if [[ -n "$PR_TITLE" ]]; then
+          if ! echo "$PR_TITLE" | grep -Eq "^A0-[0-9]+: .*$"; then
+            echo -e "The PR title is wrong \n \
+            Please follow this pattern:\nA0-[ticket-number]: Short description\n\
+            Example: \"A0-1337: Adding h4x0r l33t code\""
+            exit 1
+          fi
+        else
+          echo "PR_TITLE is empty"
+          exit 1
+        fi
+

--- a/.github/workflows/on-pull-request-check.yml
+++ b/.github/workflows/on-pull-request-check.yml
@@ -1,0 +1,22 @@
+---
+name: Check PR
+
+on:
+  pull_request:
+    - opened
+    - edited
+    - reopened
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    name: Check PR title
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check PR title
+        uses: ./.github/actions/check-pr-title
+        with:
+          pr-title: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
# Description

I have added an action that will block PR from merging is the PR title is not following this pattern: `^A0-[0-9]+: .*$`

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
