### PR TITLE
A0-2206: Use get-ref-properties in deploy to mainnet and testnet workflows

### DIFF
--- a/.github/actions/get-ref-properties/action.yml
+++ b/.github/actions/get-ref-properties/action.yml
@@ -48,7 +48,7 @@ runs:
         echo name-for-argo=$(echo ${HEAD_REF#refs/heads/} \
           | tr / - | tr '[:upper:]' '[:lower:]' | tr -c '[a-z0-9-.]' '-') >> $GITHUB_OUTPUT
 
-    - name: Get branch name if release or pre-release was createed
+    - name: Get branch name if release or pre-release was created
       if: ${{ !startsWith(github.ref, 'refs/') }}
       id: release
       shell: bash

--- a/.github/actions/get-ref-properties/action.yml
+++ b/.github/actions/get-ref-properties/action.yml
@@ -2,8 +2,8 @@
 name: Get ref git properties
 description:
   Returns basic git ref properties for the commit it runs on, such as tag, branch or commit SHA.
-  This actions is intended to be triggerd either via pull request, tag push or direct push to
-  a release branch.
+  This actions is intended to be triggerd either via pull request, tag push, direct push to
+  a tag used when creating a GitHub Release or a Pre-release
 
 outputs:
   branch:
@@ -17,7 +17,7 @@ outputs:
     value: ${{ steps.branch.outputs.name-for-argo }}
   tag:
     description: Tag name
-    value: ${{ steps.tag.outputs.name }}
+    value: ${{ steps.tag.outputs.name || steps.release.outputs.ref }}
   sha:
     description: Unique commit SHA
     value: ${{ steps.commit.outputs.sha }}
@@ -47,6 +47,13 @@ runs:
         echo name-flattened=$(echo ${HEAD_REF#refs/heads/} | tr / -) >> $GITHUB_OUTPUT
         echo name-for-argo=$(echo ${HEAD_REF#refs/heads/} \
           | tr / - | tr '[:upper:]' '[:lower:]' | tr -c '[a-z0-9-.]' '-') >> $GITHUB_OUTPUT
+
+    - name: Get branch name if release or pre-release was createed
+      if: ${{ !startsWith(github.ref, 'refs/') }}
+      id: release
+      shell: bash
+      run: |
+        echo "ref=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
     - name: Get commit properties
       id: commit

--- a/.github/workflows/deploy-to-mainnet.yml
+++ b/.github/workflows/deploy-to-mainnet.yml
@@ -54,8 +54,10 @@ jobs:
         uses: ./.github/actions/build-and-push-dockerhub-image
         if: secrets.DOCKERHUB_USERNAME != "" && secrets.DOCKERHUB_PASSWORD != ""
         with:
-          source-image: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.tag }}
-          target-image: cardinalcryptography/aleph-zero:mainnet-${{ steps.get-ref-properties.outputs.tag }}
+          source-image:
+            public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.tag }}
+          target-image:
+            cardinalcryptography/aleph-zero:mainnet-${{ steps.get-ref-properties.outputs.tag }}
           additional-image: cardinalcryptography/aleph-zero:mainnet-latest
           dockerhub-username: "${{ secrets.DOCKERHUB_USERNAME }}"
           dockerhub-password: "${{ secrets.DOCKERHUB_PASSWORD }}"

--- a/.github/workflows/deploy-to-mainnet.yml
+++ b/.github/workflows/deploy-to-mainnet.yml
@@ -1,31 +1,27 @@
 ---
-name: Deploy to Testnet
+name: Deploy to Mainnet
 
 on:
   release:
-    types: [prereleased]
+    types: [released]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
 
 jobs:
-  deploy-testnet:
-    name: Deploy new aleph-node image to Testnet EKS
+  deploy-mainnet:
+    name: Deploy new aleph-node image to Mainnet EKS
     runs-on: ubuntu-20.04
-    environment:
-      name: testnet
+    environment: 'mainnet'
     env:
       AWS_REGION: us-east-1  # this region is used by all public ECR repos
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v3
 
-      - name: GIT | Get branch info & current commit sha.
-        id: vars
-        shell: bash
-        run: |
-          echo "branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Call action get-ref-properties
+        id: get-ref-properties
+        uses: ./.github/actions/get-ref-properties
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -41,23 +37,17 @@ jobs:
           registry: public.ecr.aws
           username: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
-
-      - name: Tag and push image for Testnet
         env:
-          DEVNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.sha_short }}
-          TESTNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
-        run: |
-          export image_not_exist=$(docker manifest inspect ${{ env.DEVNET_IMAGE }} \
-          &> /dev/null ; echo $?)
+          AWS_REGION: us-east-1
 
+      - name: Verify aleph-node image existance
+        env:
+          IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.tag }}
+        run: |
+          export image_not_exist=$(docker manifest inspect ${{ env.IMAGE }} &> /dev/null ; echo $?)
           if [ $image_not_exist -eq 1 ]; then
-            echo "::error title=Wrong docker image tag::Docker image ${{ env.DEVNET_IMAGE }} \
-              doesn't exist"
+            echo "::error title=Wrong docker image tag::Docker image ${{ env.IMAGE }} doesn't exist"
             exit 1
-          else
-            docker pull ${{ env.DEVNET_IMAGE }}
-            docker tag ${{ env.DEVNET_IMAGE }} ${{ env.TESTNET_IMAGE }}
-            docker push ${{ env.TESTNET_IMAGE }}
           fi
 
       - name: Login to Docker Hub
@@ -67,26 +57,36 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Tag and push image of Testnet to DockerHub
+      - name: Tag and push image of Mainnet to DockerHub
         env:
-          TESTNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
-          DOCKERHUB_TESTNET_IMAGE:
-            cardinalcryptography/aleph-zero:testnet-${{ steps.vars.outputs.branch }}
-          DOCKERHUB_TESTNET_LATEST_IMAGE: cardinalcryptography/aleph-zero:testnet-latest
+          MAINNET_IMAGE:
+            public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.tag }}
+          DOCKERHUB_MAINNET_IMAGE:
+            cardinalcryptography/aleph-zero:mainnet-${{ steps.get-ref-properties.outputs.tag }}
+          DOCKERHUB_MAINNET_LATEST_IMAGE: cardinalcryptography/aleph-zero:mainnet-latest
         run: |
-          echo "FROM ${{ env.TESTNET_IMAGE }}" > Dockerfile.dockerhub
+          echo "FROM ${{ env.MAINNET_IMAGE }}" > Dockerfile.dockerhub
           echo 'ENTRYPOINT ["/usr/local/bin/aleph-node"]' >> Dockerfile.dockerhub
-          docker build -t ${{ env.DOCKERHUB_TESTNET_IMAGE }} -f Dockerfile.dockerhub .
-          docker tag ${{ env.DOCKERHUB_TESTNET_IMAGE }} ${{ env.DOCKERHUB_TESTNET_LATEST_IMAGE }}
-          docker push ${{ env.DOCKERHUB_TESTNET_IMAGE }}
-          docker push ${{ env.DOCKERHUB_TESTNET_LATEST_IMAGE }}
+          docker build -t ${{ env.DOCKERHUB_MAINNET_IMAGE }} -f Dockerfile.dockerhub .
+          docker tag ${{ env.DOCKERHUB_MAINNET_IMAGE }} ${{ env.DOCKERHUB_MAINNET_LATEST_IMAGE }}
+          docker push ${{ env.DOCKERHUB_MAINNET_IMAGE }}
+          docker push ${{ env.DOCKERHUB_MAINNET_LATEST_IMAGE }}
+
+      - name: S3 CI | Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        env:
+          AWS_REGION: us-east-1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: S3 CI | Download release runtime from S3 bucket
         shell: bash
         env:
           # yamllint disable-line rule:line-length
-          S3BUCKET_URL: s3://${{ secrets.CI_MAINNET_S3BUCKET_NAME }}/builds/aleph-node/commits/${{ steps.vars.outputs.sha_short }}/aleph-runtime
-          S3BUCKET_FILE: aleph-runtime-${{ steps.vars.outputs.sha_short }}.tar.gz
+          S3BUCKET_URL: s3://${{ secrets.CI_MAINNET_S3BUCKET_NAME }}/builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/aleph-runtime
+          S3BUCKET_FILE: aleph-runtime-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
         run: |
           aws s3 cp ${{ env.S3BUCKET_URL }}/${{ env.S3BUCKET_FILE }} ${{ env.S3BUCKET_FILE }}
 
@@ -95,12 +95,12 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            aleph-runtime-${{ steps.vars.outputs.sha_short }}.tar.gz
+            aleph-runtime-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
 
       - name: GIT | Checkout aleph-apps repo
         uses: actions/checkout@v3
         with:
-          ref: testnet
+          ref: mainnet
           repository: Cardinal-Cryptography/aleph-apps
           token: ${{ secrets.CI_GH_TOKEN }}
           path: "aleph-apps"
@@ -110,23 +110,24 @@ jobs:
         with:
           kustomize-version: "3.8.6"
 
-      - name: Update aleph-node docker image and trigger ArgoCD deploy for Testnet
+      - name: Update aleph-node docker image and trigger ArgoCD deploy for Mainnet
         env:
-          TESTNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
+          MAINNET_IMAGE:
+            public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.tag }}
           REGIONS_AWS: 'eu-central-1,eu-west-1,eu-west-2,us-east-1,us-east-2'
         run: |
           IFS="," read -a region_array <<< ${{ env.REGIONS_AWS }}
           export aleph_path=$(pwd)
           for i in "${region_array[@]}"; do
             # Deploy new image version for archivist
-            cd ${aleph_path}/aleph-apps/aleph-node-archivists/overlays/testnet/${i}
+            cd ${aleph_path}/aleph-apps/aleph-node-archivists/overlays/mainnet/${i}
             kustomize edit set image \
-              "aleph-node-archivist-image-placeholder=${{ env.TESTNET_IMAGE }}"
+              "aleph-node-archivist-image-placeholder=${{ env.MAINNET_IMAGE }}"
 
             # Deploy new image version for validator
-            cd ${aleph_path}/aleph-apps/aleph-node-validators/overlays/testnet/${i}
+            cd ${aleph_path}/aleph-apps/aleph-node-validators/overlays/mainnet/${i}
             kustomize edit set image \
-              "aleph-node-validator-image-placeholder=${{ env.TESTNET_IMAGE }}"
+              "aleph-node-validator-image-placeholder=${{ env.MAINNET_IMAGE }}"
           done
 
       - name: GIT | Commit changes to aleph-apps repository.
@@ -134,15 +135,15 @@ jobs:
         with:
           author_name: AlephZero Automation
           author_email: alephzero@10clouds.com
-          message:
-            "Updating Testnet docker image tag for pre-release: ${{ steps.vars.outputs.branch }}"
+          # yamllint disable-line rule:line-length
+          message: "Updating Mainnet docker image tag for release: ${{ steps.get-ref-properties.outputs.tag }}"
           add: "*.yaml"
           cwd: "aleph-apps"
 
   slack:
     name: Slack notification
     runs-on: ubuntu-20.04
-    needs: [deploy-testnet]
+    needs: [deploy-mainnet]
     if: always()
     steps:
       - name: Checkout repository
@@ -151,6 +152,6 @@ jobs:
       - name: Send Slack message
         uses: ./.github/actions/slack-notification
         with:
-          notify-on: "failure"
+          notify-on: "always"
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-testnet.yml
+++ b/.github/workflows/deploy-to-testnet.yml
@@ -1,30 +1,28 @@
 ---
-name: Deploy to Mainnet
+name: Deploy to Testnet
 
 on:
   release:
-    types: [released]
+    types: [prereleased]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
 
 jobs:
-  deploy-mainnet:
-    name: Deploy new aleph-node image to Mainnet EKS
+  deploy-testnet:
+    name: Deploy new aleph-node image to Testnet EKS
     runs-on: ubuntu-20.04
-    environment: 'mainnet'
+    environment:
+      name: testnet
     env:
       AWS_REGION: us-east-1  # this region is used by all public ECR repos
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v3
 
-      - name: GIT | Get branch info & current commit sha.
-        id: vars
-        shell: bash
-        run: |
-          echo "branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Call action get-ref-properties
+        id: get-ref-properties
+        uses: ./.github/actions/get-ref-properties
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -40,17 +38,25 @@ jobs:
           registry: public.ecr.aws
           username: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
-        env:
-          AWS_REGION: us-east-1
 
-      - name: Verify aleph-node image existance
+      - name: Tag and push image for Testnet
         env:
-          IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
+          DEVNET_IMAGE:
+            public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.sha }}
+          TESTNET_IMAGE:
+            public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.tag }}
         run: |
-          export image_not_exist=$(docker manifest inspect ${{ env.IMAGE }} &> /dev/null ; echo $?)
+          export image_not_exist=$(docker manifest inspect ${{ env.DEVNET_IMAGE }} \
+          &> /dev/null ; echo $?)
+
           if [ $image_not_exist -eq 1 ]; then
-            echo "::error title=Wrong docker image tag::Docker image ${{ env.IMAGE }} doesn't exist"
+            echo "::error title=Wrong docker image tag::Docker image ${{ env.DEVNET_IMAGE }} \
+              doesn't exist"
             exit 1
+          else
+            docker pull ${{ env.DEVNET_IMAGE }}
+            docker tag ${{ env.DEVNET_IMAGE }} ${{ env.TESTNET_IMAGE }}
+            docker push ${{ env.TESTNET_IMAGE }}
           fi
 
       - name: Login to Docker Hub
@@ -60,35 +66,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Tag and push image of Mainnet to DockerHub
+      - name: Tag and push image of Testnet to DockerHub
         env:
-          MAINNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
-          DOCKERHUB_MAINNET_IMAGE:
-            cardinalcryptography/aleph-zero:mainnet-${{ steps.vars.outputs.branch }}
-          DOCKERHUB_MAINNET_LATEST_IMAGE: cardinalcryptography/aleph-zero:mainnet-latest
+          TESTNET_IMAGE:
+            public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.tag }}
+          DOCKERHUB_TESTNET_IMAGE:
+            cardinalcryptography/aleph-zero:testnet-${{ steps.get-ref-properties.outputs.tag }}
+          DOCKERHUB_TESTNET_LATEST_IMAGE: cardinalcryptography/aleph-zero:testnet-latest
         run: |
-          echo "FROM ${{ env.MAINNET_IMAGE }}" > Dockerfile.dockerhub
+          echo "FROM ${{ env.TESTNET_IMAGE }}" > Dockerfile.dockerhub
           echo 'ENTRYPOINT ["/usr/local/bin/aleph-node"]' >> Dockerfile.dockerhub
-          docker build -t ${{ env.DOCKERHUB_MAINNET_IMAGE }} -f Dockerfile.dockerhub .
-          docker tag ${{ env.DOCKERHUB_MAINNET_IMAGE }} ${{ env.DOCKERHUB_MAINNET_LATEST_IMAGE }}
-          docker push ${{ env.DOCKERHUB_MAINNET_IMAGE }}
-          docker push ${{ env.DOCKERHUB_MAINNET_LATEST_IMAGE }}
-
-      - name: S3 CI | Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        env:
-          AWS_REGION: us-east-1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          docker build -t ${{ env.DOCKERHUB_TESTNET_IMAGE }} -f Dockerfile.dockerhub .
+          docker tag ${{ env.DOCKERHUB_TESTNET_IMAGE }} ${{ env.DOCKERHUB_TESTNET_LATEST_IMAGE }}
+          docker push ${{ env.DOCKERHUB_TESTNET_IMAGE }}
+          docker push ${{ env.DOCKERHUB_TESTNET_LATEST_IMAGE }}
 
       - name: S3 CI | Download release runtime from S3 bucket
         shell: bash
         env:
           # yamllint disable-line rule:line-length
-          S3BUCKET_URL: s3://${{ secrets.CI_MAINNET_S3BUCKET_NAME }}/builds/aleph-node/commits/${{ steps.vars.outputs.sha_short }}/aleph-runtime
-          S3BUCKET_FILE: aleph-runtime-${{ steps.vars.outputs.sha_short }}.tar.gz
+          S3BUCKET_URL: s3://${{ secrets.CI_MAINNET_S3BUCKET_NAME }}/builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/aleph-runtime
+          S3BUCKET_FILE: aleph-runtime-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
         run: |
           aws s3 cp ${{ env.S3BUCKET_URL }}/${{ env.S3BUCKET_FILE }} ${{ env.S3BUCKET_FILE }}
 
@@ -97,12 +95,12 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            aleph-runtime-${{ steps.vars.outputs.sha_short }}.tar.gz
+            aleph-runtime-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
 
       - name: GIT | Checkout aleph-apps repo
         uses: actions/checkout@v3
         with:
-          ref: mainnet
+          ref: testnet
           repository: Cardinal-Cryptography/aleph-apps
           token: ${{ secrets.CI_GH_TOKEN }}
           path: "aleph-apps"
@@ -112,23 +110,24 @@ jobs:
         with:
           kustomize-version: "3.8.6"
 
-      - name: Update aleph-node docker image and trigger ArgoCD deploy for Mainnet
+      - name: Update aleph-node docker image and trigger ArgoCD deploy for Testnet
         env:
-          MAINNET_IMAGE: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.vars.outputs.branch }}
+          TESTNET_IMAGE:
+            public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.tag }}
           REGIONS_AWS: 'eu-central-1,eu-west-1,eu-west-2,us-east-1,us-east-2'
         run: |
           IFS="," read -a region_array <<< ${{ env.REGIONS_AWS }}
           export aleph_path=$(pwd)
           for i in "${region_array[@]}"; do
             # Deploy new image version for archivist
-            cd ${aleph_path}/aleph-apps/aleph-node-archivists/overlays/mainnet/${i}
+            cd ${aleph_path}/aleph-apps/aleph-node-archivists/overlays/testnet/${i}
             kustomize edit set image \
-              "aleph-node-archivist-image-placeholder=${{ env.MAINNET_IMAGE }}"
+              "aleph-node-archivist-image-placeholder=${{ env.TESTNET_IMAGE }}"
 
             # Deploy new image version for validator
-            cd ${aleph_path}/aleph-apps/aleph-node-validators/overlays/mainnet/${i}
+            cd ${aleph_path}/aleph-apps/aleph-node-validators/overlays/testnet/${i}
             kustomize edit set image \
-              "aleph-node-validator-image-placeholder=${{ env.MAINNET_IMAGE }}"
+              "aleph-node-validator-image-placeholder=${{ env.TESTNET_IMAGE }}"
           done
 
       - name: GIT | Commit changes to aleph-apps repository.
@@ -136,14 +135,15 @@ jobs:
         with:
           author_name: AlephZero Automation
           author_email: alephzero@10clouds.com
-          message: "Updating Mainnet docker image tag for release: ${{ steps.vars.outputs.branch }}"
+          # yamllint disable-line rule:line-length
+          message: "Updating Testnet docker image tag for pre-release: ${{ steps.get-ref-properties.outputs.tag }}"
           add: "*.yaml"
           cwd: "aleph-apps"
 
   slack:
     name: Slack notification
     runs-on: ubuntu-20.04
-    needs: [deploy-mainnet]
+    needs: [deploy-testnet]
     if: always()
     steps:
       - name: Checkout repository
@@ -152,6 +152,6 @@ jobs:
       - name: Send Slack message
         uses: ./.github/actions/slack-notification
         with:
-          notify-on: "always"
+          notify-on: "failure"
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-testnet.yml
+++ b/.github/workflows/deploy-to-testnet.yml
@@ -63,8 +63,10 @@ jobs:
         uses: ./.github/actions/build-and-push-dockerhub-image
         if: secrets.DOCKERHUB_USERNAME != "" && secrets.DOCKERHUB_PASSWORD != ""
         with:
-          source-image: public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.tag }}
-          target-image: cardinalcryptography/aleph-zero:testnet-${{ steps.get-ref-properties.outputs.tag }}
+          source-image:
+            public.ecr.aws/p6e8q1z1/aleph-node:${{ steps.get-ref-properties.outputs.tag }}
+          target-image:
+            cardinalcryptography/aleph-zero:testnet-${{ steps.get-ref-properties.outputs.tag }}
           additional-image: cardinalcryptography/aleph-zero:testnet-latest
           dockerhub-username: "${{ secrets.DOCKERHUB_USERNAME }}"
           dockerhub-password: "${{ secrets.DOCKERHUB_PASSWORD }}"

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -38,7 +38,7 @@ jobs:
           image-path: aleph-release-synthetic-docker
           node-image: aleph-node:syntheticnet
           compose-file: docker/docker-compose.synthetic-network.yml
-        timeout-minutes: 40
+        timeout-minutes: 60
 
   run-e2e-no-quorum-without-high-out-latency:
     needs: [build-production-node-and-e2e-client-image]
@@ -55,7 +55,7 @@ jobs:
           image-path: aleph-release-synthetic-docker
           node-image: aleph-node:syntheticnet
           compose-file: docker/docker-compose.synthetic-network.yml
-        timeout-minutes: 25
+        timeout-minutes: 60
 
   check-e2e-test-suite-completion:
     needs: [


### PR DESCRIPTION
# Description

* Use `get-ref-properties` in mainnet and testnet workflows 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->
