### PR TITLE
A0-2240: refactor aleph node rpc

### DIFF
--- a/bin/node/src/rpc.rs
+++ b/bin/node/src/rpc.rs
@@ -7,35 +7,30 @@
 
 use std::sync::Arc;
 
-use aleph_primitives::BlockNumber;
 use aleph_runtime::{opaque::Block, AccountId, Balance, Index};
 use finality_aleph::JustificationNotificationFor;
 use futures::channel::mpsc;
 use jsonrpsee::RpcModule;
 pub use sc_rpc_api::DenyUnsafe;
 use sc_transaction_pool_api::TransactionPool;
-use sp_api::{BlockT, HeaderT, ProvideRuntimeApi};
+use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 
 /// Full client dependencies.
-pub struct FullDeps<B, C, P>
-where
-    B: BlockT,
-    B::Header: HeaderT<Number = BlockNumber>,
-{
+pub struct FullDeps<C, P> {
     /// The client instance to use.
     pub client: Arc<C>,
     /// Transaction pool instance.
     pub pool: Arc<P>,
     /// Whether to deny unsafe calls
     pub deny_unsafe: DenyUnsafe,
-    pub import_justification_tx: mpsc::UnboundedSender<JustificationNotificationFor<B>>,
+    pub import_justification_tx: mpsc::UnboundedSender<JustificationNotificationFor<Block>>,
 }
 
 /// Instantiate all full RPC extensions.
-pub fn create_full<B, C, P>(
-    deps: FullDeps<B, C, P>,
+pub fn create_full<C, P>(
+    deps: FullDeps<C, P>,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
 where
     C: ProvideRuntimeApi<Block>,
@@ -45,8 +40,6 @@ where
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
-    B: BlockT,
-    B::Header: HeaderT<Number = BlockNumber>,
 {
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
     use substrate_frame_rpc_system::{System, SystemApiServer};
@@ -64,7 +57,7 @@ where
     module.merge(TransactionPayment::new(client).into_rpc())?;
 
     use crate::aleph_node_rpc::{AlephNode, AlephNodeApiServer};
-    module.merge(AlephNode::<B>::new(import_justification_tx).into_rpc())?;
+    module.merge(AlephNode::new(import_justification_tx).into_rpc())?;
 
     Ok(module)
 }

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -257,7 +257,7 @@ fn setup(
         let pool = transaction_pool.clone();
 
         Box::new(move |deny_unsafe, _| {
-            let deps = crate::rpc::FullDeps::<Block, _, _> {
+            let deps = crate::rpc::FullDeps {
                 client: client.clone(),
                 pool: pool.clone(),
                 deny_unsafe,


### PR DESCRIPTION
# Description

Aleph Node Rpc does not need to be dependent on `B: Block` and also some other stuff. It is based on https://github.com/Cardinal-Cryptography/aleph-node/pull/1101. Only commit that matters is `refactor aleph_node_rpc`.

## Type of change

- Refactor