### PR TITLE
A0-2267: Translator should not fail on already existing justification

### DIFF
--- a/finality-aleph/src/sync/substrate/translator.rs
+++ b/finality-aleph/src/sync/substrate/translator.rs
@@ -17,7 +17,6 @@ use crate::{
 pub enum Error<B: Block> {
     ChainStatus(ChainStatusError<B>),
     NoBlock,
-    AlreadyJustified,
 }
 
 impl<B: Block> Display for Error<B> {
@@ -28,7 +27,6 @@ impl<B: Block> Display for Error<B> {
                 write!(f, "error retrieving block status: {}", e)
             }
             NoBlock => write!(f, "block not present"),
-            AlreadyJustified => write!(f, "block already justified"),
         }
     }
 }
@@ -55,7 +53,10 @@ where
         use BlockStatus::*;
         let block_id = BlockId::new(hash, number);
         match self.status_of(block_id)? {
-            Justified(_) => Err(Error::AlreadyJustified),
+            Justified(justification) => Ok(Justification::aleph_justification(
+                justification.header,
+                aleph_justification,
+            )),
             Unknown => Err(Error::NoBlock),
             Present(header) => Ok(Justification::aleph_justification(
                 header,

--- a/finality-aleph/src/sync/substrate/translator.rs
+++ b/finality-aleph/src/sync/substrate/translator.rs
@@ -53,15 +53,10 @@ where
         use BlockStatus::*;
         let block_id = BlockId::new(hash, number);
         match self.status_of(block_id)? {
-            Justified(justification) => Ok(Justification::aleph_justification(
-                justification.header,
-                aleph_justification,
-            )),
+            Justified(Justification { header, .. }) | Present(header) => Ok(
+                Justification::aleph_justification(header, aleph_justification),
+            ),
             Unknown => Err(Error::NoBlock),
-            Present(header) => Ok(Justification::aleph_justification(
-                header,
-                aleph_justification,
-            )),
         }
     }
 }


### PR DESCRIPTION
# Description

Basically remove `Error::AlreadyJustified`, as it’s not an error.
The duplicate justification should simply be handled (ignored) by the `Forest`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)