### PR TITLE
A0-2207: Re-factor featurenet workflows

### DIFF
--- a/.github/actions/build-featurenet-chainspec/action.yml
+++ b/.github/actions/build-featurenet-chainspec/action.yml
@@ -80,18 +80,11 @@ runs:
       shell: bash
       # yamllint disable rule:line-length
       run: |
-        # well-known accounts
-        ALICE=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-        BOB=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
-        CHARLIE=5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y
-        EVE=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw
-
         docker run -v $(pwd)/data:/data --env RUST_BACKTRACE=1 \
           --entrypoint "/usr/local/bin/aleph-node" $ALEPH_NODE_IMAGE bootstrap-chain --raw \
           --base-path /data --chain-id a0fenet \
           --account-ids 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y,5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy,5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw \
-          --sudo-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY \
-          --rich-accounts $ALICE,$BOB,$CHARLIE,$EVE > chainspec.json
+          --sudo-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY > chainspec.json
       # yamllint enable rule:line-length
 
     - name: Save data to S3 bucket

--- a/.github/actions/build-featurenet-chainspec/action.yml
+++ b/.github/actions/build-featurenet-chainspec/action.yml
@@ -1,0 +1,113 @@
+---
+name: Build featurenet chainspec
+description: Builds chainspec for featurenet
+
+inputs:
+  base-net:
+    description: "Base network to use, either 'testnet' or 'mainnet'"
+    required: true
+  ecr-public-registry:
+    description: "ECR public registry, with slash at the end, eg. 'public.ecr.aws/something/'"
+    required: true
+  aws-access-key-id:
+    description: 'AWS Access Key ID to be used in the action'
+    required: true
+  aws-secret-access-key:
+    description: 'AWS Secret Access Key to be used in the action'
+    required: true
+  featurenet-keys-s3bucket-name:
+    description: 'S3 bucket name with featurenet keys'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get branch name and commit SHA
+      id: get-ref-properties
+      uses: ./.github/actions/get-ref-properties
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: us-east-1
+
+    - name: Get aleph-node image tag from testnet
+      if: inputs.base-net == 'testnet'
+      shell: bash
+      run: |
+        COMMIT_ID=$(curl -s -H "Content-Type: application/json" \
+          -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' https://rpc.test.azero.dev \
+          | jq -r '.result' | cut -d "-" -f 2 | head -c 7)
+        echo $COMMIT_ID
+        echo "ALEPH_NODE_IMAGE=${{ inputs.ecr-public-registry }}aleph-node:$COMMIT_ID" >> $GITHUB_ENV
+
+    - name: Get aleph-node image tag from mainnet
+      if: inputs.base-net == 'mainnet'
+      shell: bash
+      run: |
+        SYSTEM_VERSION=$(curl -s -H "Content-Type: application/json" \
+          -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' https://rpc.test.azero.dev \
+          | jq -r '.result')
+        SUFFIX="-x86_64-linux-gnu"
+        LONG_COMMIT_ID=${SYSTEM_VERSION/%$SUFFIX}
+        COMMIT_ID=${LONG_COMMIT_ID: -7}
+        echo $COMMIT_ID
+        echo "ALEPH_NODE_IMAGE=${{ inputs.ecr-public-registry }}aleph-node:$COMMIT_ID" >> $GITHUB_ENV
+
+    - name: Generate data dir
+      shell: bash
+      # yamllint disable rule:line-length
+      run: |
+        # sync all validator's keystores from S3
+        aws s3 cp s3://${{ inputs.featurenet-keys-s3bucket-name }}/data data --recursive
+
+        # rename validator paths
+        declare -A \
+          NAMES=([aleph-node-validator-0]=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY \
+          [aleph-node-validator-1]=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty \
+          [aleph-node-validator-2]=5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y \
+          [aleph-node-validator-3]=5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy \
+          [aleph-node-validator-4]=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw)
+
+        for NAME in "${!NAMES[@]}"; do
+          mv -v data/$NAME data/${NAMES[$NAME]}
+        done
+      # yamllint enable rule:line-length
+
+    - name: Generate chainspec from testnet
+      if: inputs.base-net == 'testnet'
+      shell: bash
+      # yamllint disable rule:line-length
+      run: |
+        docker run -v $(pwd)/data:/data --env RUST_BACKTRACE=1 \
+          --entrypoint "/usr/local/bin/aleph-node" $ALEPH_NODE_IMAGE bootstrap-chain --raw \
+          --base-path /data --chain-id a0fenet \
+          --account-ids 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y,5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy,5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw \
+          --sudo-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY \
+          --faucet-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY > chainspec.json
+      # yamllint enable rule:line-length
+
+    - name: Generate chainspec from mainnet
+      if: inputs.base-net == 'mainnet'
+      shell: bash
+      # yamllint disable rule:line-length
+      run: |
+        docker run -v $(pwd)/data:/data --env RUST_BACKTRACE=1 \
+          --entrypoint "/usr/local/bin/aleph-node" $ALEPH_NODE_IMAGE bootstrap-chain --raw \
+          --base-path /data --chain-id a0fenet \
+          --account-ids 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y,5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy,5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw \
+          --sudo-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY > chainspec.json
+      # yamllint enable rule:line-length
+
+    - name: Save data to S3 bucket
+      shell: bash
+      run: |
+        aws s3 cp \
+          chainspec.json \
+          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch }}/chainspec.json
+        aws s3 cp \
+          s3://${{ inputs.featurenet-keys-s3bucket-name }}/data/ \
+          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch }}/data/ \
+          --recursive

--- a/.github/actions/build-featurenet-chainspec/action.yml
+++ b/.github/actions/build-featurenet-chainspec/action.yml
@@ -41,7 +41,8 @@ runs:
           -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' https://rpc.test.azero.dev \
           | jq -r '.result' | cut -d "-" -f 2 | head -c 7)
         echo $COMMIT_ID
-        echo "ALEPH_NODE_IMAGE=${{ inputs.ecr-public-registry }}aleph-node:$COMMIT_ID" >> $GITHUB_ENV
+        echo "ALEPH_NODE_IMAGE=${{ inputs.ecr-public-registry }}aleph-node:$COMMIT_ID" \
+          >> $GITHUB_ENV
 
     - name: Get aleph-node image tag from mainnet
       if: inputs.base-net == 'mainnet'
@@ -54,7 +55,8 @@ runs:
         LONG_COMMIT_ID=${SYSTEM_VERSION/%$SUFFIX}
         COMMIT_ID=${LONG_COMMIT_ID: -7}
         echo $COMMIT_ID
-        echo "ALEPH_NODE_IMAGE=${{ inputs.ecr-public-registry }}aleph-node:$COMMIT_ID" >> $GITHUB_ENV
+        echo "ALEPH_NODE_IMAGE=${{ inputs.ecr-public-registry }}aleph-node:$COMMIT_ID" \
+          >> $GITHUB_ENV
 
     - name: Generate data dir
       shell: bash
@@ -103,6 +105,7 @@ runs:
 
     - name: Save data to S3 bucket
       shell: bash
+      # yamllint disable rule:line-length
       run: |
         aws s3 cp \
           chainspec.json \
@@ -111,3 +114,4 @@ runs:
           s3://${{ inputs.featurenet-keys-s3bucket-name }}/data/ \
           s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch }}/data/ \
           --recursive
+      # yamllint enable rule:line-length

--- a/.github/actions/build-featurenet-chainspec/action.yml
+++ b/.github/actions/build-featurenet-chainspec/action.yml
@@ -109,9 +109,9 @@ runs:
       run: |
         aws s3 cp \
           chainspec.json \
-          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch-name-flattened }}/chainspec.json
+          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}/chainspec.json
         aws s3 cp \
           s3://${{ inputs.featurenet-keys-s3bucket-name }}/data/ \
-          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch-name-flattened }}/data/ \
+          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}/data/ \
           --recursive
       # yamllint enable rule:line-length

--- a/.github/actions/build-featurenet-chainspec/action.yml
+++ b/.github/actions/build-featurenet-chainspec/action.yml
@@ -109,9 +109,9 @@ runs:
       run: |
         aws s3 cp \
           chainspec.json \
-          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch }}/chainspec.json
+          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch-name-flattened }}/chainspec.json
         aws s3 cp \
           s3://${{ inputs.featurenet-keys-s3bucket-name }}/data/ \
-          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch }}/data/ \
+          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ steps.get-ref-properties.outputs.branch-name-flattened }}/data/ \
           --recursive
       # yamllint enable rule:line-length

--- a/.github/actions/build-featurenet-chainspec/action.yml
+++ b/.github/actions/build-featurenet-chainspec/action.yml
@@ -49,7 +49,7 @@ runs:
       shell: bash
       run: |
         SYSTEM_VERSION=$(curl -s -H "Content-Type: application/json" \
-          -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' https://rpc.test.azero.dev \
+          -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' https://rpc.azero.dev \
           | jq -r '.result')
         SUFFIX="-x86_64-linux-gnu"
         LONG_COMMIT_ID=${SYSTEM_VERSION/%$SUFFIX}
@@ -60,7 +60,6 @@ runs:
 
     - name: Generate data dir
       shell: bash
-      # yamllint disable rule:line-length
       run: |
         # sync all validator's keystores from S3
         aws s3 cp s3://${{ inputs.featurenet-keys-s3bucket-name }}/data data --recursive
@@ -76,31 +75,23 @@ runs:
         for NAME in "${!NAMES[@]}"; do
           mv -v data/$NAME data/${NAMES[$NAME]}
         done
-      # yamllint enable rule:line-length
 
-    - name: Generate chainspec from testnet
-      if: inputs.base-net == 'testnet'
+    - name: Generate chainspec
       shell: bash
       # yamllint disable rule:line-length
       run: |
+        # well-known accounts
+        ALICE=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        BOB=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
+        CHARLIE=5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y
+        EVE=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw
+
         docker run -v $(pwd)/data:/data --env RUST_BACKTRACE=1 \
           --entrypoint "/usr/local/bin/aleph-node" $ALEPH_NODE_IMAGE bootstrap-chain --raw \
           --base-path /data --chain-id a0fenet \
           --account-ids 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y,5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy,5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw \
           --sudo-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY \
-          --faucet-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY > chainspec.json
-      # yamllint enable rule:line-length
-
-    - name: Generate chainspec from mainnet
-      if: inputs.base-net == 'mainnet'
-      shell: bash
-      # yamllint disable rule:line-length
-      run: |
-        docker run -v $(pwd)/data:/data --env RUST_BACKTRACE=1 \
-          --entrypoint "/usr/local/bin/aleph-node" $ALEPH_NODE_IMAGE bootstrap-chain --raw \
-          --base-path /data --chain-id a0fenet \
-          --account-ids 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y,5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy,5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw \
-          --sudo-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY > chainspec.json
+          --rich-accounts $ALICE,$BOB,$CHARLIE,$EVE > chainspec.json
       # yamllint enable rule:line-length
 
     - name: Save data to S3 bucket

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -47,25 +47,25 @@ runs:
       id: get-ref-properties
       uses: ./.github/actions/get-ref-properties
 
-#    - name: Build chainspec for testnet FE and send it to S3
-#      if: inputs.aleph-node-image == 'testnet'
-#      uses: ./.github/actions/build-featurenet-chainspec
-#      with:
-#        base-net: testnet
-#        ecr-public-registry: ${{ inputs.ecr-public-registry }}
-#        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-#        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-#        featurenet-keys-s3bucket-name: ${{ inputs.featurenet-keys-s3bucket-name }}
-#
-#    - name: Build chainspec for Hotnet FE and send it to S3
-#      if: inputs.aleph-node-image == 'mainnet'
-#      uses: ./.github/actions/build-featurenet-chainspec
-#      with:
-#        base-net: mainnet
-#        ecr-public-registry: ${{ inputs.ecr-public-registry }}
-#        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-#        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-#        featurenet-keys-s3bucket-name: ${{ inputs.featurenet-keys-s3bucket-name }}
+    - name: Build chainspec for testnet FE and send it to S3
+      if: inputs.aleph-node-image == 'testnet'
+      uses: ./.github/actions/build-featurenet-chainspec
+      with:
+        base-net: testnet
+        ecr-public-registry: ${{ inputs.ecr-public-registry }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        featurenet-keys-s3bucket-name: ${{ inputs.featurenet-keys-s3bucket-name }}
+
+    - name: Build chainspec for Hotnet FE and send it to S3
+      if: inputs.aleph-node-image == 'mainnet'
+      uses: ./.github/actions/build-featurenet-chainspec
+      with:
+        base-net: mainnet
+        ecr-public-registry: ${{ inputs.ecr-public-registry }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        featurenet-keys-s3bucket-name: ${{ inputs.featurenet-keys-s3bucket-name }}
 
     - name: Checkout argocd apps repo
       uses: actions/checkout@v3

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -86,7 +86,7 @@ runs:
       run: |
         cd "${{ inputs.repo-apps-name }}"
         pr_image_tag="fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
-        pr_image="${{ vars.ECR_PUBLIC_REGISTRY }}feature-env-aleph-node:${pr_image_tag}"
+        pr_image="${{ inputs.ecr-public-registry }}feature-env-aleph-node:${pr_image_tag}"
         image_arg="${{ inputs.aleph-node-image }}"
         if [[ -z "${{ inputs.aleph-node-image }}" ]]; then
           image_arg="${pr_image}"

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -40,11 +40,6 @@ inputs:
     required: false
     default: 'false'
 
-outputs:
-  deployment-name:
-    description: 'Deployment name for working with deployments'
-    value: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
-
 runs:
   using: "composite"
   steps:

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -93,8 +93,6 @@ runs:
         ./Ops.sh create-featurenet \
           "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}" \
           "${image_arg}"
-        git status
-        cat argocd/overlays/devnet/fe-apps/fe-a0-2207-change-featurenet-workflows-to-use-script-from-apps-repo.yaml
 
     - name: Commit featurenet change
       uses: EndBug/add-and-commit@v9.1.1

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -81,7 +81,6 @@ runs:
         ref: A0-2207-add-makefile-with-featurenet-commands
 
     - name: Start featurenet
-      if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOY)
       shell: bash
       run: |
         cd "${{ inputs.repo-apps-name }}"

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -96,17 +96,17 @@ runs:
         git status
         cat argocd/overlays/devnet/fe-apps/fe-a0-2207-change-featurenet-workflows-to-use-script-from-apps-repo.yaml
 
-#    - name: Commit featurenet change
-#      uses: EndBug/add-and-commit@v9.1.1
-#      env:
-#        APP_NAME: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-#      with:
-#        author_name: AlephZero Automation
-#        author_email: alephzero@10clouds.com
-#        # yamllint disable-line rule:line-length
-#        message: "${{ inputs.aleph-node-image != '' && 'Create' || 'Update' }} featurenet ${{ env.APP_NAME }} with image: ${{ inputs.aleph-node-image }}"
-#        add: "*.yaml"
-#        cwd: "${{ inputs.repo-apps-name }}"
+    - name: Commit featurenet change
+      uses: EndBug/add-and-commit@v9.1.1
+      env:
+        APP_NAME: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
+      with:
+        author_name: AlephZero Automation
+        author_email: alephzero@10clouds.com
+        # yamllint disable-line rule:line-length
+        message: "${{ inputs.aleph-node-image != '' && 'Create' || 'Update' }} featurenet ${{ env.APP_NAME }} with image: ${{ inputs.aleph-node-image }}"
+        add: "*.yaml"
+        cwd: "${{ inputs.repo-apps-name }}"
 #
 #    - name: Refresh Argo and wait for the deletion to be finished
 #      if: inputs.no-refresh != 'true'

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -73,7 +73,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-apps-name }}"
-        ref: A0-2207-add-makefile-with-featurenet-commands
+        ref: main
 
     - name: Start featurenet
       shell: bash

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -1,0 +1,84 @@
+---
+name: Create featurenet
+description: Creates featurenet
+
+inputs:
+  gh-ci-token:
+    description: 'GH token to be used in the action'
+    required: true
+  repo-apps-name:
+    description: 'Name of the repository containing apps definitions'
+    required: true
+  argo-host:
+    description: 'ArgoCD host'
+    required: true
+  argo-sync-user-token:
+    description: 'ArgoCD user token to be used in the action'
+    required: true
+  no-refresh:
+    description: "Set to 'true' if ArgoCD should not be called to refresh"
+    required: false
+    default: 'false'
+  aleph-node-image:
+    description: 'aleph-node image to be started'
+    required: false
+    default: ''
+  create-hook:
+    description: "Set to 'true' to create a hook"
+    required: false
+    default: 'false'
+
+outputs:
+  deployment-name:
+    description: 'Deployment name for working with deployments'
+    value: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
+runs:
+  using: "composite"
+  steps:
+    - name: Get branch name and commit SHA
+      id: get-ref-properties
+      uses: ./.github/actions/get-ref-properties
+
+    - name: Checkout argocd apps repo
+      uses: actions/checkout@v3
+      with:
+        repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
+        token: ${{ inputs.gh-ci-token }}
+        path: "${{ inputs.repo-apps-name }}"
+        ref: A0-2207-add-makefile-with-featurenet-commands
+
+    - name: Start featurenet
+      if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOY)
+      run: |
+        cd "${{ inputs.repo-apps-name }}"
+        pr_image_tag="fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
+        pr_image="${{ vars.ECR_PUBLIC_REGISTRY }}feature-env-aleph-node:${pr_image_tag}"
+        image_arg="${{ inputs.aleph-node-image }}"
+        if [[ -z "${{ inputs.aleph-node-image }}" ]]; then
+          image_arg="${pr_image}"
+        fi
+        ./Ops.sh create-featurenet \
+          "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}" \
+          "${image_arg}"
+
+    - name: Commit featurenet change
+      uses: EndBug/add-and-commit@v9.1.1
+      env:
+        APP_NAME: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
+      with:
+        author_name: AlephZero Automation
+        author_email: alephzero@10clouds.com
+        # yamllint disable-line rule:line-length
+        message: "${{ inputs.aleph-node-image != '' && 'Create' || 'Update' }} featurenet ${{ env.APP_NAME }} with image: ${{ inputs.aleph-node-image }}"
+        add: "*.yaml"
+        cwd: "${{ inputs.repo-apps-name }}"
+
+    - name: Refresh Argo and wait for the deletion to be finished
+      if: inputs.no-refresh != 'true'
+      shell: bash
+      run: |
+        cd "${{ inputs.repo-apps-name }}"
+        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
+          "${{ inputs.argo-sync-user-token }}" \
+          "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}" \
+          "${{ inputs.create-hook }}"

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -94,6 +94,7 @@ runs:
           "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}" \
           "${image_arg}"
         git status
+        cat argocd/overlays/devnet/fe-apps/fe-a0-2207-change-featurenet-workflows-to-use-script-from-apps-repo.yaml
 
 #    - name: Commit featurenet change
 #      uses: EndBug/add-and-commit@v9.1.1

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -52,25 +52,25 @@ runs:
       id: get-ref-properties
       uses: ./.github/actions/get-ref-properties
 
-    - name: Build chainspec for testnet FE and send it to S3
-      if: inputs.aleph-node-image == 'testnet'
-      uses: ./.github/actions/build-featurenet-chainspec
-      with:
-        base-net: testnet
-        ecr-public-registry: ${{ inputs.ecr-public-registry }}
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        featurenet-keys-s3bucket-name: ${{ inputs.featurenet-keys-s3bucket-name }}
-
-    - name: Build chainspec for Hotnet FE and send it to S3
-      if: inputs.aleph-node-image == 'mainnet'
-      uses: ./.github/actions/build-featurenet-chainspec
-      with:
-        base-net: mainnet
-        ecr-public-registry: ${{ inputs.ecr-public-registry }}
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        featurenet-keys-s3bucket-name: ${{ inputs.featurenet-keys-s3bucket-name }}
+#    - name: Build chainspec for testnet FE and send it to S3
+#      if: inputs.aleph-node-image == 'testnet'
+#      uses: ./.github/actions/build-featurenet-chainspec
+#      with:
+#        base-net: testnet
+#        ecr-public-registry: ${{ inputs.ecr-public-registry }}
+#        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+#        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+#        featurenet-keys-s3bucket-name: ${{ inputs.featurenet-keys-s3bucket-name }}
+#
+#    - name: Build chainspec for Hotnet FE and send it to S3
+#      if: inputs.aleph-node-image == 'mainnet'
+#      uses: ./.github/actions/build-featurenet-chainspec
+#      with:
+#        base-net: mainnet
+#        ecr-public-registry: ${{ inputs.ecr-public-registry }}
+#        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+#        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+#        featurenet-keys-s3bucket-name: ${{ inputs.featurenet-keys-s3bucket-name }}
 
     - name: Checkout argocd apps repo
       uses: actions/checkout@v3
@@ -93,25 +93,26 @@ runs:
         ./Ops.sh create-featurenet \
           "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}" \
           "${image_arg}"
+        git status
 
-    - name: Commit featurenet change
-      uses: EndBug/add-and-commit@v9.1.1
-      env:
-        APP_NAME: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-      with:
-        author_name: AlephZero Automation
-        author_email: alephzero@10clouds.com
-        # yamllint disable-line rule:line-length
-        message: "${{ inputs.aleph-node-image != '' && 'Create' || 'Update' }} featurenet ${{ env.APP_NAME }} with image: ${{ inputs.aleph-node-image }}"
-        add: "*.yaml"
-        cwd: "${{ inputs.repo-apps-name }}"
-
-    - name: Refresh Argo and wait for the deletion to be finished
-      if: inputs.no-refresh != 'true'
-      shell: bash
-      run: |
-        cd "${{ inputs.repo-apps-name }}"
-        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
-          "${{ inputs.argo-sync-user-token }}" \
-          "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}" \
-          "${{ inputs.create-hook }}"
+#    - name: Commit featurenet change
+#      uses: EndBug/add-and-commit@v9.1.1
+#      env:
+#        APP_NAME: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
+#      with:
+#        author_name: AlephZero Automation
+#        author_email: alephzero@10clouds.com
+#        # yamllint disable-line rule:line-length
+#        message: "${{ inputs.aleph-node-image != '' && 'Create' || 'Update' }} featurenet ${{ env.APP_NAME }} with image: ${{ inputs.aleph-node-image }}"
+#        add: "*.yaml"
+#        cwd: "${{ inputs.repo-apps-name }}"
+#
+#    - name: Refresh Argo and wait for the deletion to be finished
+#      if: inputs.no-refresh != 'true'
+#      shell: bash
+#      run: |
+#        cd "${{ inputs.repo-apps-name }}"
+#        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
+#          "${{ inputs.argo-sync-user-token }}" \
+#          "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}" \
+#          "${{ inputs.create-hook }}"

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -100,13 +100,13 @@ runs:
         message: "${{ inputs.aleph-node-image != '' && 'Create' || 'Update' }} featurenet ${{ env.APP_NAME }} with image: ${{ inputs.aleph-node-image }}"
         add: "*.yaml"
         cwd: "${{ inputs.repo-apps-name }}"
-#
-#    - name: Refresh Argo and wait for the deletion to be finished
-#      if: inputs.no-refresh != 'true'
-#      shell: bash
-#      run: |
-#        cd "${{ inputs.repo-apps-name }}"
-#        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
-#          "${{ inputs.argo-sync-user-token }}" \
-#          "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}" \
-#          "${{ inputs.create-hook }}"
+
+    - name: Refresh Argo and wait for the deletion to be finished
+      if: inputs.no-refresh != 'true'
+      shell: bash
+      run: |
+        cd "${{ inputs.repo-apps-name }}"
+        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
+          "${{ inputs.argo-sync-user-token }}" \
+          "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}" \
+          "${{ inputs.create-hook }}"

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -15,6 +15,18 @@ inputs:
   argo-sync-user-token:
     description: 'ArgoCD user token to be used in the action'
     required: true
+  ecr-public-registry:
+    description: "ECR public registry, with slash at the end, eg. 'public.ecr.aws/something/'"
+    required: true
+  aws-access-key-id:
+    description: 'AWS Access Key ID to be used in the action'
+    required: true
+  aws-secret-access-key:
+    description: 'AWS Secret Access Key to be used in the action'
+    required: true
+  featurenet-keys-s3bucket-name:
+    description: 'S3 bucket name with featurenet keys'
+    required: true
   no-refresh:
     description: "Set to 'true' if ArgoCD should not be called to refresh"
     required: false
@@ -39,6 +51,26 @@ runs:
     - name: Get branch name and commit SHA
       id: get-ref-properties
       uses: ./.github/actions/get-ref-properties
+
+    - name: Build chainspec for testnet FE and send it to S3
+      if: inputs.aleph-node-image == 'testnet'
+      uses: ./.github/actions/build-featurenet-chainspec
+      with:
+        base-net: testnet
+        ecr-public-registry: ${{ inputs.ecr-public-registry }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        featurenet-keys-s3bucket-name: ${{ inputs.featurenet-keys-s3bucket-name }}
+
+    - name: Build chainspec for Hotnet FE and send it to S3
+      if: inputs.aleph-node-image == 'mainnet'
+      uses: ./.github/actions/build-featurenet-chainspec
+      with:
+        base-net: mainnet
+        ecr-public-registry: ${{ inputs.ecr-public-registry }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        featurenet-keys-s3bucket-name: ${{ inputs.featurenet-keys-s3bucket-name }}
 
     - name: Checkout argocd apps repo
       uses: actions/checkout@v3

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -32,6 +32,7 @@ outputs:
   deployment-name:
     description: 'Deployment name for working with deployments'
     value: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
+
 runs:
   using: "composite"
   steps:

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -82,6 +82,7 @@ runs:
 
     - name: Start featurenet
       if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOY)
+      shell: bash
       run: |
         cd "${{ inputs.repo-apps-name }}"
         pr_image_tag="fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -77,7 +77,7 @@ runs:
     - name: Clean S3 storage
       shell: bash
       env:
-        BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
+        APP_NAME: ${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
       run: |
         aws s3 rm --recursive \
-          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ env.BRANCH_NAME }}
+          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ env.APP_NAME }}

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -53,6 +53,7 @@ runs:
         ./Ops.sh delete-featurenet \
           "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}"
         git status
+        ls -al argocd/overlays/devnet/fe-apps/
 
 #    - name: Commit deletion of the feature environment.
 #      uses: EndBug/add-and-commit@v9.1.1

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -52,29 +52,30 @@ runs:
         cd "${{ inputs.repo-apps-name }}"
         ./Ops.sh delete-featurenet \
           "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}"
+        git status
 
-    - name: Commit deletion of the feature environment.
-      uses: EndBug/add-and-commit@v9.1.1
-      env:
-        APP_NAME: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-      with:
-        author_name: AlephZero Automation
-        author_email: alephzero@10clouds.com
-        message: "Delete featurenet ${{ env.APP_NAME }}"
-        add: "*.yaml"
-        cwd: "${{ inputs.repo-apps-name }}"
-
-    - name: Refresh Argo and wait for the deletion to be finished
-      shell: bash
-      run: |
-        cd "${{ inputs.repo-apps-name }}"
-        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
-          "${{ inputs.argo-sync-user-token }}"
-
-    - name: Clean S3 storage
-      shell: bash
-      env:
-        BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
-      run: |
-        aws s3 rm --recursive \
-          s3://fe-alephzero-devnet-eu-central-1-keys-bucket/fe-${{ env.BRANCH_NAME }}
+#    - name: Commit deletion of the feature environment.
+#      uses: EndBug/add-and-commit@v9.1.1
+#      env:
+#        APP_NAME: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
+#      with:
+#        author_name: AlephZero Automation
+#        author_email: alephzero@10clouds.com
+#        message: "Delete featurenet ${{ env.APP_NAME }}"
+#        add: "*.yaml"
+#        cwd: "${{ inputs.repo-apps-name }}"
+#
+#    - name: Refresh Argo and wait for the deletion to be finished
+#      shell: bash
+#      run: |
+#        cd "${{ inputs.repo-apps-name }}"
+#        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
+#          "${{ inputs.argo-sync-user-token }}"
+#
+#    - name: Clean S3 storage
+#      shell: bash
+#      env:
+#        BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
+#      run: |
+#        aws s3 rm --recursive \
+#          s3://fe-alephzero-devnet-eu-central-1-keys-bucket/fe-${{ env.BRANCH_NAME }}

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -15,6 +15,9 @@ inputs:
   aws-secret-access-key:
     description: 'AWS Secret Access Key to be used in the action'
     required: true
+  featurenet-keys-s3bucket-name:
+    description: 'S3 bucket name with featurenet keys'
+    required: true
   argo-host:
     description: 'ArgoCD host'
     required: true
@@ -71,10 +74,10 @@ runs:
         ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
           "${{ inputs.argo-sync-user-token }}"
 
-#    - name: Clean S3 storage
-#      shell: bash
-#      env:
-#        BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
-#      run: |
-#        aws s3 rm --recursive \
-#          s3://fe-alephzero-devnet-eu-central-1-keys-bucket/fe-${{ env.BRANCH_NAME }}
+    - name: Clean S3 storage
+      shell: bash
+      env:
+        BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
+      run: |
+        aws s3 rm --recursive \
+          s3://${{ inputs.featurenet-keys-s3bucket-name }}/fe-${{ env.BRANCH_NAME }}

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -1,10 +1,13 @@
 ---
-name: 'Destroy Feature Environment'
-description: 'Action used for feature environment deletion'
+name: Delete featurenet
+description: Deletes featurenet
 
 inputs:
   gh-ci-token:
     description: 'GH token to be used in the action'
+    required: true
+  repo-apps-name:
+    description: 'Name of the repository containing apps definitions'
     required: true
   aws-access-key:
     description: 'AWS Access Key ID to be used in the action'
@@ -12,19 +15,16 @@ inputs:
   aws-secret-access-key:
     description: 'AWS Secret Access Key to be used in the action'
     required: true
-  argo-sync-user-token:
-    description: 'ArgoCD user token to be used in the action'
-    required: true
-  repo-apps-name:
-    description: 'Name of the repository containing apps definitions'
-    required: true
   argo-host:
     description: 'ArgoCD host'
+    required: true
+  argo-sync-user-token:
+    description: 'ArgoCD user token to be used in the action'
     required: true
 
 outputs:
   deployment-name:
-    description: 'Output with a deployment name for working with deployments'
+    description: 'Deployment name for working with deployments'
     value: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
 runs:
   using: "composite"
@@ -39,7 +39,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-apps-name }}"
-        ref: main
+        ref: A0-2207-add-makefile-with-featurenet-commands
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v2
@@ -52,14 +52,10 @@ runs:
 
     - name: Destroy feature branch
       shell: bash
-      env:
-        APP_NAME: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
       run: |
-        CWD_PATH=$(pwd)
-        APPS_NAME=${{ inputs.repo-apps-name }}
-
-        ## Delete FE application for argo to delete it automatically
-        rm -rf $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
+        cd "${{ inputs.repo-apps-name }}"
+        ./Ops.sh delete-featurenet \
+          "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}"
 
     - name: Commit deletion of the feature environment.
       uses: EndBug/add-and-commit@v9.1.1
@@ -68,24 +64,16 @@ runs:
       with:
         author_name: AlephZero Automation
         author_email: alephzero@10clouds.com
-        message: "Feature Environment: ${{ env.APP_NAME }} has been deleted"
+        message: "Delete featurenet ${{ env.APP_NAME }}"
         add: "*.yaml"
         cwd: "${{ inputs.repo-apps-name }}"
 
     - name: Refresh Argo and wait for the deletion to be finished
       shell: bash
-      env:
-        ARGOCD_URL: ${{ inputs.argo-host }}
       run: |
-        ## Install argocd CLI tool
-        curl -sSL -o argocd \
-          https://github.com/argoproj/argo-cd/releases/download/v2.3.3/argocd-linux-amd64
-        chmod +x argocd && mv argocd /usr/local/bin/
-
-        /usr/local/bin/argocd app get fe-root-application --hard-refresh \
-          --auth-token ${{ inputs.argo-sync-user-token }} --server ${{ env.ARGOCD_URL }}
-        /usr/local/bin/argocd app wait fe-root-application --auth-token \
-          ${{ inputs.argo-sync-user-token }} --server ${{ env.ARGOCD_URL }}
+        cd "${{ inputs.repo-apps-name }}"
+        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
+          "${{ inputs.argo-sync-user-token }}"
 
     - name: Clean S3 storage
       shell: bash

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -52,19 +52,17 @@ runs:
         cd "${{ inputs.repo-apps-name }}"
         ./Ops.sh delete-featurenet \
           "fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}"
-        git status
-        ls -al argocd/overlays/devnet/fe-apps/
 
-#    - name: Commit deletion of the feature environment.
-#      uses: EndBug/add-and-commit@v9.1.1
-#      env:
-#        APP_NAME: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-#      with:
-#        author_name: AlephZero Automation
-#        author_email: alephzero@10clouds.com
-#        message: "Delete featurenet ${{ env.APP_NAME }}"
-#        add: "*.yaml"
-#        cwd: "${{ inputs.repo-apps-name }}"
+    - name: Commit deletion of the feature environment.
+      uses: EndBug/add-and-commit@v9.1.1
+      env:
+        APP_NAME: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
+      with:
+        author_name: AlephZero Automation
+        author_email: alephzero@10clouds.com
+        message: "Delete featurenet ${{ env.APP_NAME }}"
+        add: "*.yaml"
+        cwd: "${{ inputs.repo-apps-name }}"
 #
 #    - name: Refresh Argo and wait for the deletion to be finished
 #      shell: bash

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -63,14 +63,14 @@ runs:
         message: "Delete featurenet ${{ env.APP_NAME }}"
         add: "*.yaml"
         cwd: "${{ inputs.repo-apps-name }}"
-#
-#    - name: Refresh Argo and wait for the deletion to be finished
-#      shell: bash
-#      run: |
-#        cd "${{ inputs.repo-apps-name }}"
-#        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
-#          "${{ inputs.argo-sync-user-token }}"
-#
+
+    - name: Refresh Argo and wait for the deletion to be finished
+      shell: bash
+      run: |
+        cd "${{ inputs.repo-apps-name }}"
+        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
+          "${{ inputs.argo-sync-user-token }}"
+
 #    - name: Clean S3 storage
 #      shell: bash
 #      env:

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -9,7 +9,7 @@ inputs:
   repo-apps-name:
     description: 'Name of the repository containing apps definitions'
     required: true
-  aws-access-key:
+  aws-access-key-id:
     description: 'AWS Access Key ID to be used in the action'
     required: true
   aws-secret-access-key:
@@ -22,10 +22,6 @@ inputs:
     description: 'ArgoCD user token to be used in the action'
     required: true
 
-outputs:
-  deployment-name:
-    description: 'Deployment name for working with deployments'
-    value: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
 runs:
   using: "composite"
   steps:
@@ -46,7 +42,7 @@ runs:
       env:
         AWS_REGION: us-east-1
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -38,7 +38,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-apps-name }}"
-        ref: A0-2207-add-makefile-with-featurenet-commands
+        ref: main
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v2

--- a/.github/actions/get-ref-properties/action.yml
+++ b/.github/actions/get-ref-properties/action.yml
@@ -49,7 +49,8 @@ runs:
         echo name=$(echo ${HEAD_REF#refs/heads/}) >> $GITHUB_OUTPUT
         echo name-flattened=$(echo ${HEAD_REF#refs/heads/} | tr / -) >> $GITHUB_OUTPUT
         echo name-for-argo=$(printf ${HEAD_REF#refs/heads/} \
-          | tr / - | tr '[:upper:]' '[:lower:]' | tr -c '[a-z0-9-.]' '-') >> $GITHUB_OUTPUT
+          | tr / - | tr '[:upper:]' '[:lower:]' | tr -c '[a-z0-9-.]' '-' \
+          | cut -c1-52 | sed 's|-$||g') >> $GITHUB_OUTPUT
 
     - name: Get branch name if release or pre-release was created
       if: ${{ !startsWith(github.ref, 'refs/') }}

--- a/.github/actions/get-ref-properties/action.yml
+++ b/.github/actions/get-ref-properties/action.yml
@@ -50,7 +50,7 @@ runs:
         echo name-flattened=$(echo ${HEAD_REF#refs/heads/} | tr / -) >> $GITHUB_OUTPUT
         echo name-for-argo=$(printf ${HEAD_REF#refs/heads/} \
           | tr / - | tr '[:upper:]' '[:lower:]' | tr -c '[a-z0-9-.]' '-' \
-          | cut -c1-52 | sed 's|-$||g') >> $GITHUB_OUTPUT
+          | cut -c1-40 | sed 's|-$||g') >> $GITHUB_OUTPUT
 
     - name: Get branch name if release or pre-release was created
       if: ${{ !startsWith(github.ref, 'refs/') }}

--- a/.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
+++ b/.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
@@ -1,0 +1,50 @@
+---
+#  This workflow builds aleph-node docker image from pull request commit
+#  and pushes it to featurenet registry.
+name: Build and push PR image to featurenets
+on:
+  workflow_call:
+
+jobs:
+  main:
+    name: Build and push image
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout aleph-node
+        uses: actions/checkout@v3
+
+      - name: Call action get-ref-properties
+        id: get-ref-properties
+        uses: ./.github/actions/get-ref-properties
+
+      - name: Download artifact with built aleph-node binary from PR
+        uses: actions/download-artifact@v3
+        with:
+          name: aleph-release-node
+          path: target/release/
+
+      - name: Build docker image with PR aleph-node binary
+        env:
+          # yamllint disable-line rule:line-length
+          IMAGE_TAG: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}
+        run: |
+          chmod +x target/release/aleph-node
+          ls -alh target/release/
+          ls -alh ./docker/
+          docker build \
+            --tag ${{ vars.ECR_PUBLIC_REGISTRY }}feature-env-aleph-node:${{ env.IMAGE_TAG }} \
+            -f ./docker/Dockerfile .
+
+      - name: Login to ECR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ vars.ECR_PUBLIC_HOST }}
+          username: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
+
+      - name: Push image to the featurenet registry
+        env:
+          # yamllint disable-line rule:line-length
+          IMAGE_TAG: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}
+        run: |
+          docker push ${{ vars.ECR_PUBLIC_REGISTRY }}feature-env-aleph-node:${{ env.IMAGE_TAG }}

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -217,7 +217,7 @@ jobs:
     if: >
       (github.event.label.name == 'trigger:create-featurenet') ||
       (github.event.label.name == 'trigger:create-hot-featurenet')
-    needs: [push-pr-image, deploy-feature-env]
+    needs: [push-pr-image, create-featurenet]
     name: Update featurenet to the latest PR aleph-node image
     runs-on: ubuntu-20.04
     steps:
@@ -235,7 +235,7 @@ jobs:
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
-          create_hook: 'true'
+          create-hook: 'true'
 
       - name: Remove testnet deployment request label if exists
         if: contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet')

--- a/.github/workflows/deploy-feature-envs.yml
+++ b/.github/workflows/deploy-feature-envs.yml
@@ -1,26 +1,11 @@
 ---
-name: Deploy Feature Environment
+name: Deploy featurenet
 
 on:
   pull_request:
     types: [labeled, closed]
 
 env:
-  LABEL_DEPLOY: '[AZERO] DEPLOY-FEATURE-ENV'
-  LABEL_DEPLOY_HOT: '[AZERO] DEPLOY-HOT-FEATURE-ENV'
-  LABEL_DELETE: '[AZERO] DELETE-FEATURE-ENV'
-  LABEL_DESTROYED: 'DESTROYED'
-  LABEL_DEPLOYED: 'DEPLOYED'
-  LABEL_DEPLOYED_CONTRACTS: 'DEPLOYED-CONTRACTS'
-  REGISTRY_HOST: ${{ vars.ECR_PUBLIC_HOST }}
-  FE_ALEPHNODE_REGISTRY: ${{ vars.ECR_PUBLIC_REGISTRY }}feature-env-aleph-node
-  FE_ALEPHNODE_REGISTRY_ESCAPED: 'public.ecr.aws\/p6e8q1z1\/feature-env-aleph-node'
-  FE_IMAGETAG_PREFIX: 'fe-'
-  FE_APP_PREFIX: 'fe-'
-  PUBLIC_ALEPHNODE_REGISTRY: ${{ vars.ECR_PUBLIC_REGISTRY }}aleph-node
-  PUBLIC_ALEPHNODE_REGISTRY_ESCAPED: 'public.ecr.aws\/p6e8q1z1\/aleph-node'
-  FE_KEYS_S3BUCKET: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
-  FE_KEYS_S3PATH_PREFIX: 'fe-'
   RPC_TESTNET_URL: https://rpc.test.azero.dev
   WSS_TESTNET_URL: wss://ws.test.azero.dev
   RPC_MAINNET_URL: https://rpc.azero.dev
@@ -36,8 +21,8 @@ jobs:
   build-aleph-node-binary:
     needs: [check-vars-and-secrets]
     if: >
-      (github.event.label.name == '[AZERO] DEPLOY-FEATURE-ENV') ||
-      (github.event.label.name == '[AZERO] DEPLOY-HOT-FEATURE-ENV')
+      (github.event.label.name == 'trigger:create-featurenet') ||
+      (github.event.label.name == 'trigger:create-hot-featurenet')
     name: Build production artifacts
     uses: ./.github/workflows/_build-production-node-and-runtime.yml
     secrets: inherit
@@ -45,65 +30,27 @@ jobs:
   store-aleph-node-binary:
     needs: [build-aleph-node-binary]
     if: >
-      (github.event.label.name == '[AZERO] DEPLOY-FEATURE-ENV') ||
-      (github.event.label.name == '[AZERO] DEPLOY-HOT-FEATURE-ENV')
+      (github.event.label.name == 'trigger:create-featurenet') ||
+      (github.event.label.name == 'trigger:create-hot-featurenet')
     name: Store production artifacts
     uses: ./.github/workflows/_store-production-node-and-runtime.yml
     secrets: inherit
 
   push-pr-image:
-    if: >
-      (github.event.label.name == '[AZERO] DEPLOY-FEATURE-ENV') ||
-      (github.event.label.name == '[AZERO] DEPLOY-HOT-FEATURE-ENV')
     needs: [build-aleph-node-binary]
-    name: Build, prepare and push aleph-node image from PR to ECR
-    runs-on: ubuntu-20.04
-    steps:
-      - name: checkout repo
-        uses: actions/checkout@v3
+    if: >
+      (github.event.label.name == 'trigger:create-featurenet') ||
+      (github.event.label.name == 'trigger:create-hot-featurenet')
+    name: Build and push PR docker image to featurenet registry
+    uses: ./.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
+    secrets: inherit
 
-      - name: Call action get-ref-properties
-        id: get-ref-properties
-        uses: ./.github/actions/get-ref-properties
-
-      - name: Download artifact with built aleph-node binary from PR
-        uses: actions/download-artifact@v3
-        with:
-          name: aleph-release-node
-          path: target/release/
-
-      - name: Build docker image with PR aleph-node binary
-        env:
-          # yamllint disable-line rule:line-length
-          IMAGE_TAG: ${{ env.FE_IMAGETAG_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}
-        run: |
-          chmod +x target/release/aleph-node
-          ls -alh target/release/
-          ls -alh ./docker/
-          docker build --tag ${{ env.FE_ALEPHNODE_REGISTRY }}:${{ env.IMAGE_TAG }} \
-            -f ./docker/Dockerfile .
-
-      - name: Login to ECR
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY_HOST }}
-          username: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
-
-      - name: Push FE aleph-node image to the feature-env-aleph-node registry
-        env:
-          # yamllint disable-line rule:line-length
-          IMAGE_TAG: ${{ env.FE_IMAGETAG_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}
-        run: |
-          docker push ${{ env.FE_ALEPHNODE_REGISTRY }}:${{ env.IMAGE_TAG }}
-
-
-  deploy-feature-env:
+  create-featurenet:
     needs: [check-vars-and-secrets]
     if: >
-      (github.event.label.name == '[AZERO] DEPLOY-FEATURE-ENV') ||
-      (github.event.label.name == '[AZERO] DEPLOY-HOT-FEATURE-ENV')
-    name: Deploy feature environment based on the PR
+      (github.event.label.name == 'trigger:create-featurenet') ||
+      (github.event.label.name == 'trigger:create-hot-featurenet')
+    name: Create featurenet based on the PR
     runs-on: ubuntu-20.04
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
@@ -111,9 +58,9 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v3
 
-      - name: Delete old FE when redeploying
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOYED)
-        uses: ./.github/actions/delete-feature-environment
+      - name: Delete old featurenet when re-deploying
+        if: contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
+        uses: ./.github/actions/delete-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           aws-access-key: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
@@ -156,7 +103,7 @@ jobs:
           AWS_REGION: us-east-1
 
       - name: Build chainspec for testnet FE and send it to S3
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOY)
+        if: contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet')
         env:
           BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch }}
           CHAIN_ID: a0fenet
@@ -166,10 +113,10 @@ jobs:
             -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' ${{ env.RPC_TESTNET_URL }} \
             | jq -r '.result' | cut -d "-" -f 2 | head -c 7)
           echo $COMMIT_ID
-          TESTNET_IMAGE="${{ env.PUBLIC_ALEPHNODE_REGISTRY }}:$COMMIT_ID"
+          TESTNET_IMAGE="${{ vars.ECR_PUBLIC_REGISTRY }}aleph-node:$COMMIT_ID"
 
           # sync all validator's keystores from S3
-          aws s3 cp s3://${{ env.FE_KEYS_S3BUCKET }}/data data --recursive
+          aws s3 cp s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/data data --recursive
 
           # rename validator paths
           declare -A \
@@ -192,15 +139,15 @@ jobs:
             --faucet-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY > chainspec.json
 
           aws s3 cp chainspec.json \
-            s3://${{ env.FE_KEYS_S3BUCKET }}/${{ env.FE_KEYS_S3PATH_PREFIX }}${{ env.BRANCH_NAME }}/chainspec.json
+            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/fe-${{ env.BRANCH_NAME }}/chainspec.json
           aws s3 cp \
-            s3://${{ env.FE_KEYS_S3BUCKET }}/data/ \
-            s3://${{ env.FE_KEYS_S3BUCKET }}/${{ env.FE_KEYS_S3PATH_PREFIX }}${{ env.BRANCH_NAME }}/data/ \
+            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/data/ \
+            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/fe-${{ env.BRANCH_NAME }}/data/ \
             --recursive
         # yamllint enable rule:line-length
 
       - name: Build chainspec for Hotnet FE and send it to S3
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOY_HOT)
+        if: contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet')
         env:
           BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch }}
           CHAIN_ID: a0fenet
@@ -213,10 +160,10 @@ jobs:
           LONG_COMMIT_ID=${SYSTEM_VERSION/%$SUFFIX}
           COMMIT_ID=${LONG_COMMIT_ID: -7}
           echo $COMMIT_ID
-          MAINNET_IMAGE="${{ env.PUBLIC_ALEPHNODE_REGISTRY }}:$COMMIT_ID"
+          MAINNET_IMAGE="${{ vars.ECR_PUBLIC_REGISTRY }}aleph-node:$COMMIT_ID"
 
           # sync all validator's keystores from S3
-          aws s3 cp s3://${{ env.FE_KEYS_S3BUCKET }}/data data --recursive
+          aws s3 cp s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/data data --recursive
 
           # rename validator paths
           declare -A \
@@ -241,152 +188,37 @@ jobs:
           # docker run -v $(pwd):/app --env RUST_LOG=info ${{ env.FORKOFF_IMAGE }} --ws-rpc-endpoint=${{ env.RPC_MAINNET_URL }} --initial-spec-path=chainspec.skeleton.json --combined-spec-path=chainspec.json
           aws s3 cp \
             chainspec.json \
-            s3://${{ env.FE_KEYS_S3BUCKET }}/${{ env.FE_KEYS_S3PATH_PREFIX }}${{ env.BRANCH_NAME }}/chainspec.json
+            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/fe-${{ env.BRANCH_NAME }}/chainspec.json
           aws s3 cp \
-            s3://${{ env.FE_KEYS_S3BUCKET }}/data/ \
-            s3://${{ env.FE_KEYS_S3BUCKET }}/${{ env.FE_KEYS_S3PATH_PREFIX }}${{ env.BRANCH_NAME }}/data/ \
+            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/data/ \
+            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/fe-${{ env.BRANCH_NAME }}/data/ \
             --recursive
       # yamllint enable rule:line-length
 
-      - name: GIT | Checkout argocd apps repo
-        uses: actions/checkout@v3
+      - name: Create featurenet in argocd apps
+        if: >
+          contains(github.event.pull_request.labels.*.name, "trigger:create-featurenet") |
+          contains(github.event.pull_request.labels.*.name, "trigger:create-hot-featurenet")
+        uses: ./.github/actions/create-featurenet
         with:
-          repository: Cardinal-Cryptography/${{ secrets.REPO_ARGOCD_APPS_NAME }}
-          token: ${{ secrets.CI_GH_TOKEN }}
-          path: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
-          ref: main
-
-      - name: Start testnet image on feature environment
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOY)
-        env:
-          BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch }}
-          APP_NAME:
-            ${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-          NAMESPACE:
-            ${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-          CREATE_HOOK: false
-        run: |
-          # Set up envs
-          COMMIT_ID=$(curl -s -H "Content-Type: application/json" \
-            -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' ${{ env.RPC_TESTNET_URL }} \
-            | jq -r '.result' | cut -d "-" -f 2 | head -c 7)
-          TESTNET_IMAGE="${{ env.PUBLIC_ALEPHNODE_REGISTRY_ESCAPED }}:$COMMIT_ID"
-          CWD_PATH=$(pwd)
-          APPS_NAME=${{ secrets.REPO_ARGOCD_APPS_NAME }}
-
-          # Create application manifest from template
-
-          sed "s/APP_NAME/${{ env.APP_NAME }}/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/app-template/app-template.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-          sed "s/CREATE_HOOK/${{ env.CREATE_HOOK  }}/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp && \
-            mv $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-          sed "s/NAMESPACE/${{ env.NAMESPACE }}/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp && \
-            mv $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-          sed "s/NODE_IMAGE/$TESTNET_IMAGE/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp && \
-            mv $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-      - name: Start mainnet image on feature environment
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOY_HOT)
-        env:
-          BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch }}
-          APP_NAME:
-            ${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-          NAMESPACE:
-            ${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-          CREATE_HOOK: false
-        run: |
-          # Set up envs
-          SYSTEM_VERSION=$(curl -s -H "Content-Type: application/json" \
-           -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' ${{ env.RPC_MAINNET_URL }} | \
-           jq -r '.result')
-          SUFFIX="-x86_64-linux-gnu"
-          LONG_COMMIT_ID=${SYSTEM_VERSION/%$SUFFIX}
-          COMMIT_ID=${LONG_COMMIT_ID: -7}
-          MAINNET_IMAGE="${{ env.PUBLIC_ALEPHNODE_REGISTRY_ESCAPED }}:$COMMIT_ID"
-          CWD_PATH=$(pwd)
-          APPS_NAME=${{ secrets.REPO_ARGOCD_APPS_NAME }}
-
-          # Create application manifest from template
-
-          sed "s/APP_NAME/${{ env.APP_NAME }}/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/app-template/app-template.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-          sed "s/CREATE_HOOK/${{ env.CREATE_HOOK  }}/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp && \
-            mv $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-          sed "s/NAMESPACE/${{ env.NAMESPACE }}/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp && \
-            mv $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-          sed "s/NODE_IMAGE/$MAINNET_IMAGE/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp && \
-            mv $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-      - name: GIT | Commit changes to argocd apps repository.
-        uses: EndBug/add-and-commit@v9.1.1
-        env:
-          APP_NAME:
-            ${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-        with:
-          author_name: ${{ secrets.AUTOCOMMIT_AUTHOR }}
-          author_email: ${{ secrets.AUTOCOMMIT_EMAIL }}
-          message: "New Feature Environment Deployment with name: ${{ env.APP_NAME }}"
-          add: "*.yaml"
-          cwd: "${{ secrets.REPO_ARGOCD_APPS_NAME }}"
-
-      - name: Refresh Argo and wait for the testnet image deployment to be finished
-        env:
-          APP_NAME:
-            ${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-          ARGOCD_URL: argocd.dev.azero.dev
-        run: |
-          ## Install argocd CLI tool
-          curl -sSL -o argocd \
-            https://github.com/argoproj/argo-cd/releases/download/v2.3.3/argocd-linux-amd64
-          chmod +x argocd && mv argocd /usr/local/bin/
-
-          ## Sync argo to start deployment
-          /usr/local/bin/argocd app get fe-root-application --hard-refresh --auth-token \
-            ${{ secrets.ARGO_SYNC_USER_TOKEN }} --server ${{ env.ARGOCD_URL }}
-
-          ## Wait for the app to be deployed
-          /usr/local/bin/argocd app wait fe-root-application --auth-token \
-            ${{ secrets.ARGO_SYNC_USER_TOKEN }} --server ${{ env.ARGOCD_URL }}
-          /usr/local/bin/argocd app wait ${{ env.APP_NAME }} --auth-token \
-            ${{ secrets.ARGO_SYNC_USER_TOKEN }} --server ${{ env.ARGOCD_URL }}
+          gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
+          argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
+          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
+          argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
+          # yamllint disable-line rule:line-length
+          aleph-node-image: ${{ contains(github.event.pull_request.labels.*.name, "trigger:create-hot-featurenet") && 'mainnet' || 'testnet' }}
 
       - name: Wait for the testnet aleph-node binary to accept some blocks
         uses: juliangruber/sleep-action@v2.0.0
         with:
           time: 5m
 
-  update-feature-env-image:
+  update-featurenet-image:
     if: >
-      (github.event.label.name == '[AZERO] DEPLOY-FEATURE-ENV') ||
-      (github.event.label.name == '[AZERO] DEPLOY-HOT-FEATURE-ENV')
+      (github.event.label.name == 'trigger:create-featurenet') ||
+      (github.event.label.name == 'trigger:create-hot-featurenet')
     needs: [push-pr-image, deploy-feature-env]
-    name: Update feature environment to the latest PR aleph-node image
+    name: Update featurenet to the latest PR aleph-node image
     runs-on: ubuntu-20.04
     steps:
       - name: checkout repo
@@ -396,114 +228,40 @@ jobs:
         id: get-ref-properties
         uses: ./.github/actions/get-ref-properties
 
-      - name: GIT | Checkout argocd apps repo
-        uses: actions/checkout@v3
+      - name: Update featurenet in argocd apps
+        uses: ./.github/actions/create-featurenet
         with:
-          repository: Cardinal-Cryptography/${{ secrets.REPO_ARGOCD_APPS_NAME }}
-          token: ${{ secrets.CI_GH_TOKEN }}
-          path: "${{ secrets.REPO_ARGOCD_APPS_NAME }}"
-          ref: main
-
-      - name: Update feature environment to the latest PR image
-        env:
-          # yamllint disable-line rule:line-length
-          IMAGE_TAG: ${{ env.FE_IMAGETAG_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}
-          APP_NAME:
-            ${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-          ARGOCD_URL: argocd.dev.azero.dev
-          NAMESPACE:
-            ${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-          CREATE_HOOK: true
-        run: |
-          # Set up envs
-          PR_IMAGE="${{ env.FE_ALEPHNODE_REGISTRY_ESCAPED }}\:${{ env.IMAGE_TAG }}"
-          CWD_PATH=$(pwd)
-          APPS_NAME=${{ secrets.REPO_ARGOCD_APPS_NAME }}
-
-          sed "s/APP_NAME/${{ env.APP_NAME }}/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/app-template/app-template.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-          sed "s/CREATE_HOOK/${{ env.CREATE_HOOK  }}/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp && \
-            mv $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-          sed "s/NAMESPACE/${{ env.NAMESPACE }}/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp && \
-            mv $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-          sed "s/NODE_IMAGE/$PR_IMAGE/g" \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml > \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp && \
-            mv $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml.temp \
-            $CWD_PATH/$APPS_NAME/argocd/overlays/devnet/fe-apps/${{ env.APP_NAME }}.yaml
-
-      - name: GIT | Commit changes to argocd apps repository.
-        uses: EndBug/add-and-commit@v9.1.1
-        env:
-          # yamllint disable-line rule:line-length
-          IMAGE_TAG: ${{ env.FE_IMAGETAG_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}
-          APP_NAME:
-            ${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-        with:
-          author_name: ${{ secrets.AUTOCOMMIT_AUTHOR }}
-          author_email: ${{ secrets.AUTOCOMMIT_EMAIL }}
-          message:
-            "Image changed for the feature environment to:
-            ${{ env.FE_ALEPHNODE_REGISTRY }}:${{ env.IMAGE_TAG }}"
-          add: "*.yaml"
-          cwd: "${{ secrets.REPO_ARGOCD_APPS_NAME }}"
-
-      - name: Refresh Argo and wait for the PR image deployment to be finished
-        env:
-          APP_NAME:
-            ${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}
-          ARGOCD_URL: argocd.dev.azero.dev
-        run: |
-          ## Install argocd CLI tool
-          curl -sSL -o argocd \
-            https://github.com/argoproj/argo-cd/releases/download/v2.3.3/argocd-linux-amd64
-          chmod +x argocd && mv argocd /usr/local/bin/
-
-          ## Sync argo to start deployment
-          /usr/local/bin/argocd app get fe-root-application --hard-refresh \
-            --auth-token ${{ secrets.ARGO_SYNC_USER_TOKEN }} --server ${{ env.ARGOCD_URL }}
-
-          ## Wait for the app to be deployed
-          /usr/local/bin/argocd app wait fe-root-application \
-            --auth-token ${{ secrets.ARGO_SYNC_USER_TOKEN }} --server ${{ env.ARGOCD_URL }}
-          /usr/local/bin/argocd app wait ${{ env.APP_NAME }} \
-            --auth-token ${{ secrets.ARGO_SYNC_USER_TOKEN }} --server ${{ env.ARGOCD_URL }}
+          gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
+          argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
+          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
+          argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
+          create_hook: 'true'
 
       - name: Remove testnet deployment request label if exists
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOY)
+        if: contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet')
         uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
-          labels: ${{ env.LABEL_DEPLOY }}
+          labels: 'trigger:create-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
       - name: Remove mainnet deployment request label if exists
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOY_HOT)
+        if: contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet')
         uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
-          labels: ${{ env.LABEL_DEPLOY_HOT }}
+          labels: 'trigger:create-hot-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
-      - name: Remove destroyed label if present
+      - name: Remove deleted label if present
         uses: actions-ecosystem/action-remove-labels@v1.3.0
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DESTROYED)
+        if: contains(github.event.pull_request.labels.*.name, 'state:deleted-featurenet')
         with:
-          labels: ${{ env.LABEL_DESTROYED }}
+          labels: 'state:deleted-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
-      - name: Add label to mark that feature branch has been deployed
+      - name: Add label to mark that featurenet has been created
         uses: actions-ecosystem/action-add-labels@v1.1.0
         with:
-          labels: ${{ env.LABEL_DEPLOYED }}
+          labels: 'state:created-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
       - name: Finish Feature Env Deployment
@@ -516,84 +274,26 @@ jobs:
           env: ${{ steps.get-ref-properties.outputs.branch }}
           deployment_id: ${{ needs.deploy-feature-env.outputs.deployment-id }}
           # yamllint disable-line rule:line-length
-          env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-${{ env.FE_APP_PREFIX }}${{ steps.get-ref-properties.outputs.branch-name-for-argo }}.dev.azero.dev#/explorer
+          env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}.dev.azero.dev#/explorer
           ref: ${{ github.head_ref }}
 
-  destroy-feature-env:
-    needs: [check-vars-and-secrets]
-    if: github.event.label.name == '[AZERO] DELETE-FEATURE-ENV'
-    name: Destroy feature env
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Delete FE
-        uses: ./.github/actions/delete-feature-environment
-        id: delete_fe
-        with:
-          gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          aws-access-key: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
-          argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
-          argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
-
-      - name: Remove labels
-        uses: actions-ecosystem/action-remove-labels@v1.3.0
-        with:
-          labels: ${{ env.LABEL_DELETE }}
-          github_token: ${{ secrets.CI_GH_TOKEN }}
-
-      - name: Remove "DEPLOYED" label if present
-        uses: actions-ecosystem/action-remove-labels@v1.3.0
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOYED)
-        with:
-          labels: ${{ env.LABEL_DEPLOYED }}
-          github_token: ${{ secrets.CI_GH_TOKEN }}
-
-      - name: Remove "DEPLOYED-CONTRACTS" label if present
-        uses: actions-ecosystem/action-remove-labels@v1.3.0
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOYED_CONTRACTS)
-        with:
-          labels: ${{ env.LABEL_DEPLOYED_CONTRACTS }}
-          github_token: ${{ secrets.CI_GH_TOKEN }}
-
-      - name: Add label to mark that feature branch has been destroyed
-        uses: actions-ecosystem/action-add-labels@v1.1.0
-        with:
-          labels: ${{ env.LABEL_DESTROYED }}
-          github_token: ${{ secrets.CI_GH_TOKEN }}
-
-      - name: Deactivate deployed environment
-        uses: bobheadxi/deployments@v1
-        with:
-          step: deactivate-env
-          token: ${{ secrets.CI_GH_TOKEN }}
-          env: ${{ steps.delete_fe.outputs.deployment-name }}
-          desc: Environment was deleted
-          debug: true
-
-      - name: Delete environment and deployments
-        uses: strumwolf/delete-deployment-environment@v2
-        with:
-          token: ${{ secrets.CI_GH_TOKEN }}
-          environment: ${{ steps.delete_fe.outputs.deployment-name }}
-
-  destroy-feature-env-on-close:
+  delete-featurenet:
     needs: [check-vars-and-secrets]
     if: >
-      github.event.action == 'closed' &&
-      !contains(github.event.pull_request.labels.*.name, 'DESTROYED') &&
-      contains(github.event.pull_request.labels.*.name, 'DEPLOYED')
-    name: Destroy feature env when PR closed
+      (github.event.label.name == 'trigger:delete-featurenet') ||
+      (
+        github.event.action == 'closed' &&
+        !contains(github.event.pull_request.labels.*.name, 'state:deleted-featurenet') &&
+        contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
+      )
+    name: Delete featurenet
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Delete FE
-        uses: ./.github/actions/delete-feature-environment
+      - name: Delete featurenet in argocd apps
+        uses: ./.github/actions/delete-featurenet
         id: delete_fe
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
@@ -606,27 +306,20 @@ jobs:
       - name: Remove labels
         uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
-          labels: ${{ env.LABEL_DELETE }}
+          labels: 'trigger:delete-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
-      - name: Remove "DEPLOYED" label if present
+      - name: Remove deployed label if present
         uses: actions-ecosystem/action-remove-labels@v1.3.0
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOYED)
+        if: contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
         with:
-          labels: ${{ env.LABEL_DEPLOYED }}
+          labels: 'state:created-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
-      - name: Remove "DEPLOYED-CONTRACTS" label if present
-        uses: actions-ecosystem/action-remove-labels@v1.3.0
-        if: contains( github.event.pull_request.labels.*.name, env.LABEL_DEPLOYED_CONTRACTS)
-        with:
-          labels: ${{ env.LABEL_DEPLOYED_CONTRACTS }}
-          github_token: ${{ secrets.CI_GH_TOKEN }}
-
-      - name: Add label to mark that feature branch has been destroyed
+      - name: Add label to mark that featurenet has been deleted
         uses: actions-ecosystem/action-add-labels@v1.1.0
         with:
-          labels: ${{ env.LABEL_DESTROYED }}
+          labels: 'state:deleted-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
       - name: Deactivate deployed environment
@@ -643,3 +336,4 @@ jobs:
         with:
           token: ${{ secrets.CI_GH_TOKEN }}
           environment: ${{ steps.delete_fe.outputs.deployment-name }}
+

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -25,7 +25,7 @@ jobs:
     needs: [check-vars-and-secrets]
     if: >
       (github.event.label.name == 'trigger:create-featurenet') ||
-      (github.event.label.name == 'trigger:create-hot-featurenet')
+      (github.event.label.name == 'trigger:create-hotfix-featurenet')
     name: Build production artifacts
     uses: ./.github/workflows/_build-production-node-and-runtime.yml
     secrets: inherit
@@ -34,7 +34,7 @@ jobs:
     needs: [build-aleph-node-binary]
     if: >
       (github.event.label.name == 'trigger:create-featurenet') ||
-      (github.event.label.name == 'trigger:create-hot-featurenet')
+      (github.event.label.name == 'trigger:create-hotfix-featurenet')
     name: Store production artifacts
     uses: ./.github/workflows/_store-production-node-and-runtime.yml
     secrets: inherit
@@ -43,7 +43,7 @@ jobs:
     needs: [build-aleph-node-binary]
     if: >
       (github.event.label.name == 'trigger:create-featurenet') ||
-      (github.event.label.name == 'trigger:create-hot-featurenet')
+      (github.event.label.name == 'trigger:create-hotfix-featurenet')
     name: Build and push PR docker image to featurenet registry
     uses: ./.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
     secrets: inherit
@@ -52,7 +52,7 @@ jobs:
     needs: [check-vars-and-secrets]
     if: >
       (github.event.label.name == 'trigger:create-featurenet') ||
-      (github.event.label.name == 'trigger:create-hot-featurenet')
+      (github.event.label.name == 'trigger:create-hotfix-featurenet')
     name: Create featurenet based on the PR
     runs-on: ubuntu-20.04
     outputs:
@@ -90,7 +90,7 @@ jobs:
       - name: Create featurenet data, app and deploy it
         if: >
           contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet') ||
-          contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet')
+          contains(github.event.pull_request.labels.*.name, 'trigger:create-hotfix-featurenet')
         uses: ./.github/actions/create-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           # yamllint disable-line rule:line-length
-          aleph-node-image: ${{ contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet') && 'mainnet' || 'testnet' }}
+          aleph-node-image: ${{ contains(github.event.pull_request.labels.*.name, 'trigger:create-hotfix-featurenet') && 'mainnet' || 'testnet' }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
@@ -112,7 +112,7 @@ jobs:
   update-featurenet-image:
     if: >
       (github.event.label.name == 'trigger:create-featurenet') ||
-      (github.event.label.name == 'trigger:create-hot-featurenet')
+      (github.event.label.name == 'trigger:create-hotfix-featurenet')
     needs: [push-pr-image, create-featurenet]
     name: Update featurenet to the latest PR aleph-node image
     runs-on: ubuntu-20.04
@@ -145,10 +145,10 @@ jobs:
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
       - name: Remove mainnet deployment request label if exists
-        if: contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet')
+        if: contains(github.event.pull_request.labels.*.name, 'trigger:create-hotfix-featurenet')
         uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
-          labels: 'trigger:create-hot-featurenet'
+          labels: 'trigger:create-hotfix-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
       - name: Remove deleted label if present

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -55,8 +55,6 @@ jobs:
       (github.event.label.name == 'trigger:create-hot-featurenet')
     name: Create featurenet based on the PR
     runs-on: ubuntu-20.04
-    outputs:
-      deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
       - name: checkout repo
         uses: actions/checkout@v3
@@ -78,11 +76,10 @@ jobs:
 
       - name: Start featurenet Deployment
         uses: bobheadxi/deployments@v1.1.0
-        id: deployment
         with:
           step: start
           token: ${{ secrets.CI_GH_TOKEN }}
-          env: ${{ steps.get-ref-properties.outputs.branch }}
+          env: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
           ref: ${{ github.head_ref }}
           override: true
 
@@ -171,7 +168,7 @@ jobs:
           token: ${{ secrets.CI_GH_TOKEN }}
           status: ${{ job.status }}
           env: ${{ steps.get-ref-properties.outputs.branch }}
-          deployment_id: ${{ needs.deploy-feature-env.outputs.deployment-id }}
+          deployment_id: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
           # yamllint disable-line rule:line-length
           env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}.dev.azero.dev#/explorer
           ref: ${{ github.head_ref }}
@@ -191,9 +188,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Call action get-ref-properties
+        id: get-ref-properties
+        uses: ./.github/actions/get-ref-properties
+
       - name: Delete featurenet in argocd apps
         uses: ./.github/actions/delete-featurenet
-        id: delete_fe
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
@@ -226,7 +226,7 @@ jobs:
         with:
           step: deactivate-env
           token: ${{ secrets.CI_GH_TOKEN }}
-          env: ${{ steps.delete_fe.outputs.deployment-name }}
+          env: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
           desc: Environment was deleted
           debug: true
 
@@ -234,5 +234,5 @@ jobs:
         uses: strumwolf/delete-deployment-environment@v2
         with:
           token: ${{ secrets.CI_GH_TOKEN }}
-          environment: ${{ steps.delete_fe.outputs.deployment-name }}
+          environment: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
 

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -83,36 +83,6 @@ jobs:
           ref: ${{ github.head_ref }}
           override: true
 
-      - name: Login to Public Amazon ECR
-        id: login-public-ecr
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ vars.ECR_PUBLIC_HOST }}
-          username: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
-        env:
-          AWS_REGION: us-east-1
-
-      - name: Build chainspec for testnet FE and send it to S3
-        if: contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet')
-        uses: ./.github/actions/build-featurenet-chainspec
-        with:
-          base-net: testnet
-          ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
-          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
-          featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
-
-      - name: Build chainspec for Hotnet FE and send it to S3
-        if: contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet')
-        uses: ./.github/actions/build-featurenet-chainspec
-        with:
-          base-net: mainnet
-          ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
-          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
-          featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
-
       - name: Create featurenet in argocd apps
         if: >
           contains(github.event.pull_request.labels.*.name, "trigger:create-featurenet") |
@@ -125,6 +95,10 @@ jobs:
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           # yamllint disable-line rule:line-length
           aleph-node-image: ${{ contains(github.event.pull_request.labels.*.name, "trigger:create-hot-featurenet") && 'mainnet' || 'testnet' }}
+          ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
+          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
+          featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
 
       - name: Wait for the testnet aleph-node binary to accept some blocks
         uses: juliangruber/sleep-action@v2.0.0
@@ -154,6 +128,10 @@ jobs:
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           create-hook: 'true'
+          ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
+          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
+          featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
 
       - name: Remove testnet deployment request label if exists
         if: contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet')
@@ -182,7 +160,7 @@ jobs:
           labels: 'state:created-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
-      - name: Finish Feature Env Deployment
+      - name: Finish featurenet Deployment
         uses: bobheadxi/deployments@v1
         if: always()
         with:

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -61,7 +61,7 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v3
 
-      - name: Delete old featurenet when re-deploying
+      - name: Delete old featurenet app and data
         if: contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
         uses: ./.github/actions/delete-featurenet
         with:
@@ -196,7 +196,7 @@ jobs:
         id: get-ref-properties
         uses: ./.github/actions/get-ref-properties
 
-      - name: Delete featurenet in argocd apps
+      - name: Delete featurenet app and data
         uses: ./.github/actions/delete-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -55,6 +55,8 @@ jobs:
       (github.event.label.name == 'trigger:create-hot-featurenet')
     name: Create featurenet based on the PR
     runs-on: ubuntu-20.04
+    outputs:
+      deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
       - name: checkout repo
         uses: actions/checkout@v3
@@ -76,6 +78,7 @@ jobs:
 
       - name: Start featurenet Deployment
         uses: bobheadxi/deployments@v1.1.0
+        id: deployment
         with:
           step: start
           token: ${{ secrets.CI_GH_TOKEN }}
@@ -167,8 +170,8 @@ jobs:
           step: finish
           token: ${{ secrets.CI_GH_TOKEN }}
           status: ${{ job.status }}
-          env: ${{ steps.get-ref-properties.outputs.branch }}
-          deployment_id: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
+          env: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
+          deployment_id: ${{ needs.create-featurenet.outputs.deployment-id }}
           # yamllint disable-line rule:line-length
           env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}.dev.azero.dev#/explorer
           ref: ${{ github.head_ref }}

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -71,6 +71,7 @@ jobs:
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
+          featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
 
       - name: Call action get-ref-properties
         id: get-ref-properties
@@ -204,6 +205,7 @@ jobs:
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
+          featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
 
       - name: Remove labels
         uses: actions-ecosystem/action-remove-labels@v1.3.0

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -11,6 +11,9 @@ env:
   RPC_MAINNET_URL: https://rpc.azero.dev
   FORKOFF_IMAGE: ${{ vars.ECR_PUBLIC_REGISTRY }}fork-off:latest
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+
 jobs:
   check-vars-and-secrets:
     name: Check vars and secrets

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -63,7 +63,7 @@ jobs:
         uses: ./.github/actions/delete-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          aws-access-key: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
+          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
@@ -73,7 +73,7 @@ jobs:
         id: get-ref-properties
         uses: ./.github/actions/get-ref-properties
 
-      - name: Start Feature Env Deployment
+      - name: Start featurenet Deployment
         uses: bobheadxi/deployments@v1.1.0
         id: deployment
         with:
@@ -82,15 +82,6 @@ jobs:
           env: ${{ steps.get-ref-properties.outputs.branch }}
           ref: ${{ github.head_ref }}
           override: true
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        env:
-          AWS_REGION: us-east-1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Public Amazon ECR
         id: login-public-ecr
@@ -104,96 +95,23 @@ jobs:
 
       - name: Build chainspec for testnet FE and send it to S3
         if: contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet')
-        env:
-          BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch }}
-          CHAIN_ID: a0fenet
-        # yamllint disable rule:line-length
-        run: |
-          COMMIT_ID=$(curl -s -H "Content-Type: application/json" \
-            -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' ${{ env.RPC_TESTNET_URL }} \
-            | jq -r '.result' | cut -d "-" -f 2 | head -c 7)
-          echo $COMMIT_ID
-          TESTNET_IMAGE="${{ vars.ECR_PUBLIC_REGISTRY }}aleph-node:$COMMIT_ID"
-
-          # sync all validator's keystores from S3
-          aws s3 cp s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/data data --recursive
-
-          # rename validator paths
-          declare -A \
-            NAMES=([aleph-node-validator-0]=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY \
-            [aleph-node-validator-1]=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty \
-            [aleph-node-validator-2]=5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y \
-            [aleph-node-validator-3]=5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy \
-            [aleph-node-validator-4]=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw)
-
-          for NAME in "${!NAMES[@]}"; do
-            mv -v data/$NAME data/${NAMES[$NAME]}
-          done
-
-          # Generate chainspec skeleton, it will reuse keys from the synced keystore
-          docker run -v $(pwd)/data:/data --env RUST_BACKTRACE=1 \
-            --entrypoint "/usr/local/bin/aleph-node" $TESTNET_IMAGE bootstrap-chain --raw \
-            --base-path /data --chain-id $CHAIN_ID \
-            --account-ids 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y,5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy,5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw \
-            --sudo-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY \
-            --faucet-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY > chainspec.json
-
-          aws s3 cp chainspec.json \
-            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/fe-${{ env.BRANCH_NAME }}/chainspec.json
-          aws s3 cp \
-            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/data/ \
-            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/fe-${{ env.BRANCH_NAME }}/data/ \
-            --recursive
-        # yamllint enable rule:line-length
+        uses: ./.github/actions/build-featurenet-chainspec
+        with:
+          base-net: testnet
+          ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
+          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
+          featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
 
       - name: Build chainspec for Hotnet FE and send it to S3
         if: contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet')
-        env:
-          BRANCH_NAME: ${{ steps.get-ref-properties.outputs.branch }}
-          CHAIN_ID: a0fenet
-        # yamllint disable rule:line-length
-        run: |
-          SYSTEM_VERSION=$(curl -s -H "Content-Type: application/json" \
-            -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' ${{ env.RPC_MAINNET_URL }} \
-            | jq -r '.result')
-          SUFFIX="-x86_64-linux-gnu"
-          LONG_COMMIT_ID=${SYSTEM_VERSION/%$SUFFIX}
-          COMMIT_ID=${LONG_COMMIT_ID: -7}
-          echo $COMMIT_ID
-          MAINNET_IMAGE="${{ vars.ECR_PUBLIC_REGISTRY }}aleph-node:$COMMIT_ID"
-
-          # sync all validator's keystores from S3
-          aws s3 cp s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/data data --recursive
-
-          # rename validator paths
-          declare -A \
-            NAMES=([aleph-node-validator-0]=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY \
-            [aleph-node-validator-1]=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty \
-            [aleph-node-validator-2]=5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y \
-            [aleph-node-validator-3]=5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy \
-            [aleph-node-validator-4]=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw)
-
-          for NAME in "${!NAMES[@]}"; do
-            mv -v data/$NAME data/${NAMES[$NAME]}
-          done
-
-          # Generate chainspec skeleton, it will reuse keys from the synced keystore
-          docker run -v $(pwd)/data:/data --env RUST_BACKTRACE=1 \
-            --entrypoint "/usr/local/bin/aleph-node" $MAINNET_IMAGE bootstrap-chain --raw \
-            --base-path /data --chain-id $CHAIN_ID \
-            --account-ids 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y,5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy,5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw \
-            --sudo-account-id 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY > chainspec.json
-
-          # Generate chainspec from skeleton
-          # docker run -v $(pwd):/app --env RUST_LOG=info ${{ env.FORKOFF_IMAGE }} --ws-rpc-endpoint=${{ env.RPC_MAINNET_URL }} --initial-spec-path=chainspec.skeleton.json --combined-spec-path=chainspec.json
-          aws s3 cp \
-            chainspec.json \
-            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/fe-${{ env.BRANCH_NAME }}/chainspec.json
-          aws s3 cp \
-            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/data/ \
-            s3://${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}/fe-${{ env.BRANCH_NAME }}/data/ \
-            --recursive
-      # yamllint enable rule:line-length
+        uses: ./.github/actions/build-featurenet-chainspec
+        with:
+          base-net: mainnet
+          ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
+          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
+          featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
 
       - name: Create featurenet in argocd apps
         if: >
@@ -297,7 +215,7 @@ jobs:
         id: delete_fe
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          aws-access-key: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
+          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -1,5 +1,5 @@
 ---
-name: Deploy featurenet
+name: PR Featurenet
 
 on:
   pull_request:
@@ -309,7 +309,7 @@ jobs:
           labels: 'trigger:delete-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
-      - name: Remove deployed label if present
+      - name: Remove created label if present
         uses: actions-ecosystem/action-remove-labels@v1.3.0
         if: contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
         with:

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -83,7 +83,7 @@ jobs:
           ref: ${{ github.head_ref }}
           override: true
 
-      - name: Create featurenet in argocd apps
+      - name: Create featurenet data, app and deploy it
         if: >
           contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet') ||
           contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet')
@@ -120,7 +120,7 @@ jobs:
         id: get-ref-properties
         uses: ./.github/actions/get-ref-properties
 
-      - name: Update featurenet in argocd apps
+      - name: Update featurenet app and re-deploy it
         uses: ./.github/actions/create-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -85,8 +85,8 @@ jobs:
 
       - name: Create featurenet in argocd apps
         if: >
-          contains(github.event.pull_request.labels.*.name, "trigger:create-featurenet") |
-          contains(github.event.pull_request.labels.*.name, "trigger:create-hot-featurenet")
+          contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet') |
+          contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet')
         uses: ./.github/actions/create-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
@@ -94,7 +94,7 @@ jobs:
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           # yamllint disable-line rule:line-length
-          aleph-node-image: ${{ contains(github.event.pull_request.labels.*.name, "trigger:create-hot-featurenet") && 'mainnet' || 'testnet' }}
+          aleph-node-image: ${{ contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet') && 'mainnet' || 'testnet' }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}

--- a/.github/workflows/on-pull-request-featurenet-labels.yml
+++ b/.github/workflows/on-pull-request-featurenet-labels.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Create featurenet in argocd apps
         if: >
-          contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet') |
+          contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet') ||
           contains(github.event.pull_request.labels.*.name, 'trigger:create-hot-featurenet')
         uses: ./.github/actions/create-featurenet
         with:


### PR DESCRIPTION
Changes:

- everything apart from argocd apps and s3 buckets is now renamed from `feature env` to `featurenet` to make it consistent with other -nets and ADR about environments
- instead of `deploy` and `destroy` verbs, we have `create` and `delete`
- both creating (with updating which essentially almost the same) and deleting are now extracted to actions
- building chainspec is extracted to a separate action as well
- previously there was some inconsistency between s3 bucket name and argocd app name that led to featurenet not working in some cases - this is now fixed
- workflow name has been changed from `deploy-feature-envs` to `on-pull-request-featurenet-labels`
- label names are changed to the ones agreed in the naming convention ADR
- `branch-name-for-argo` output of `get-ref-properties` action has been tweaked to limit to 40 characters
- overall, featurenet workflow has been minimized from ~650 to ~240 lines
- changes in the argocd apps' YAML files are now moved to a bash script called Ops.sh in the argocd apps repository, so no more these bash snippets here

Creating and deleting featurenets using labels have been tested and it works.

Before this PR is merged, we have to go through all existing feature environments and either remove them (and then re-create) or... remember to remove them later manually (remove argocd app definition and call argocd to refresh [although this is done by any other featurenet anyway], remove data from s3 bucket) 