### PR TITLE
A0-2273: Various remaining improvements to sync

### DIFF
--- a/finality-aleph/src/sync/handler.rs
+++ b/finality-aleph/src/sync/handler.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::VecDeque,
-    fmt::{Display, Error as FmtError, Formatter},
+    fmt::{Debug, Display, Error as FmtError, Formatter},
 };
 
 use log::warn;
@@ -41,10 +41,6 @@ pub enum SyncAction<J: Justification> {
 }
 
 impl<J: Justification> SyncAction<J> {
-    fn noop() -> Self {
-        SyncAction::Noop
-    }
-
     fn state_broadcast_response(
         justification: J::Unverified,
         other_justification: Option<J::Unverified>,
@@ -57,10 +53,6 @@ impl<J: Justification> SyncAction<J> {
 
     fn request_response(justifications: Vec<J::Unverified>) -> Self {
         SyncAction::Response(NetworkData::RequestResponse(justifications))
-    }
-
-    fn task(id: BlockIdFor<J>) -> Self {
-        SyncAction::Task(id)
     }
 }
 
@@ -128,7 +120,6 @@ impl<I: PeerId, J: Justification, CS: ChainStatus<J>, V: Verifier<J>, F: Finaliz
         Ok(handler)
     }
 
-    /// TODO: Remove after completing the sync rewrite.
     /// Move the code to `Self::new` to initialize the `Forest` properly.
     pub fn refresh_forest(&mut self) -> Result<(), Error<J, CS, V, F>> {
         let top_finalized = self

--- a/finality-aleph/src/sync/handler.rs
+++ b/finality-aleph/src/sync/handler.rs
@@ -120,7 +120,7 @@ impl<I: PeerId, J: Justification, CS: ChainStatus<J>, V: Verifier<J>, F: Finaliz
         Ok(handler)
     }
 
-    /// Move the code to `Self::new` to initialize the `Forest` properly.
+    // TODO(A0-1758): Move the code to `Self::new` to initialize the `Forest` properly.
     pub fn refresh_forest(&mut self) -> Result<(), Error<J, CS, V, F>> {
         let top_finalized = self
             .chain_status

--- a/finality-aleph/src/sync/mock/backend.rs
+++ b/finality-aleph/src/sync/mock/backend.rs
@@ -45,7 +45,6 @@ struct BackendStorage {
     blockchain: HashMap<MockIdentifier, MockBlock>,
     finalized: Vec<MockIdentifier>,
     best_block: MockIdentifier,
-    genesis_block: MockIdentifier,
 }
 
 #[derive(Clone, Debug)]
@@ -98,8 +97,7 @@ impl Backend {
             session_period,
             blockchain: HashMap::from([(id.clone(), block)]),
             finalized: vec![id.clone()],
-            best_block: id.clone(),
-            genesis_block: id,
+            best_block: id,
         }));
 
         Self {

--- a/finality-aleph/src/sync/mock/mod.rs
+++ b/finality-aleph/src/sync/mock/mod.rs
@@ -4,7 +4,7 @@ use codec::{Decode, Encode};
 use sp_core::H256;
 
 use crate::{
-    sync::{BlockStatus, ChainStatusNotification, Header, Justification as JustificationT},
+    sync::{ChainStatusNotification, Header, Justification as JustificationT},
     BlockIdentifier,
 };
 
@@ -49,10 +49,6 @@ pub struct MockHeader {
 }
 
 impl MockHeader {
-    fn new(id: MockIdentifier, parent: Option<MockIdentifier>) -> Self {
-        MockHeader { id, parent }
-    }
-
     pub fn random_parentless(number: MockNumber) -> Self {
         let id = MockIdentifier::new_random(number);
         MockHeader { id, parent: None }
@@ -110,13 +106,6 @@ impl MockJustification {
             is_correct: true,
         }
     }
-
-    pub fn for_header_incorrect(header: MockHeader) -> Self {
-        Self {
-            header,
-            is_correct: false,
-        }
-    }
 }
 
 impl Header for MockJustification {
@@ -145,4 +134,3 @@ impl JustificationT for MockJustification {
 }
 
 type MockNotification = ChainStatusNotification<MockHeader>;
-type MockBlockStatus = BlockStatus<MockJustification>;

--- a/finality-aleph/src/sync/mod.rs
+++ b/finality-aleph/src/sync/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
+    marker::Send,
 };
 
 use codec::Codec;
@@ -11,11 +12,15 @@ mod handler;
 #[cfg(test)]
 mod mock;
 mod service;
-mod substrate;
+pub mod substrate;
 mod task_queue;
 mod ticker;
 
-pub use substrate::SessionVerifier;
+pub use service::Service;
+pub use substrate::{
+    Justification as SubstrateJustification, JustificationTranslator, SessionVerifier,
+    SubstrateChainStatus, SubstrateChainStatusNotifier, SubstrateFinalizationInfo, VerifierCache,
+};
 
 use crate::BlockIdentifier;
 
@@ -44,7 +49,7 @@ pub trait Header: Clone + Codec + Send + Sync + 'static {
 }
 
 /// The verified justification of a block, including a header.
-pub trait Justification: Clone + Send + Sync + 'static {
+pub trait Justification: Clone + Send + Sync + Debug + 'static {
     type Header: Header;
     /// The implementation has to behave as if the header here is identical to the one returned by
     /// the `header` method after successful verification.
@@ -107,7 +112,7 @@ pub enum BlockStatus<J: Justification> {
 }
 
 /// The knowledge about the chain status.
-pub trait ChainStatus<J: Justification> {
+pub trait ChainStatus<J: Justification>: Clone + Send + Sync + 'static {
     type Error: Display;
 
     /// The status of the block.

--- a/finality-aleph/src/sync/substrate/mod.rs
+++ b/finality-aleph/src/sync/substrate/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt::Display,
+    fmt::{Debug, Display},
     hash::{Hash, Hasher},
 };
 
@@ -18,7 +18,10 @@ mod status_notifier;
 mod translator;
 mod verification;
 
-pub use verification::SessionVerifier;
+pub use chain_status::SubstrateChainStatus;
+pub use status_notifier::SubstrateChainStatusNotifier;
+pub use translator::Error as TranslateError;
+pub use verification::{SessionVerifier, SubstrateFinalizationInfo, VerifierCache};
 
 /// An identifier uniquely specifying a block and its height.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
@@ -126,8 +129,8 @@ impl<H: SubstrateHeader<Number = BlockNumber>> JustificationT for Justification<
 }
 
 /// Translates raw aleph justifications into ones acceptable to sync.
-pub trait JustificationTranslator<H: SubstrateHeader<Number = BlockNumber>> {
-    type Error: Display;
+pub trait JustificationTranslator<H: SubstrateHeader<Number = BlockNumber>>: Send + Sync {
+    type Error: Display + Debug;
 
     fn translate(
         &self,

--- a/finality-aleph/src/sync/substrate/status_notifier.rs
+++ b/finality-aleph/src/sync/substrate/status_notifier.rs
@@ -42,7 +42,7 @@ impl<B> SubstrateChainStatusNotifier<B>
 where
     B: BlockT,
 {
-    fn new(
+    pub fn new(
         finality_notifications: FinalityNotifications<B>,
         import_notifications: ImportNotifications<B>,
     ) -> Self {

--- a/finality-aleph/src/sync/substrate/translator.rs
+++ b/finality-aleph/src/sync/substrate/translator.rs
@@ -14,6 +14,7 @@ use crate::{
     },
 };
 
+#[derive(Debug)]
 pub enum Error<B: Block> {
     ChainStatus(ChainStatusError<B>),
     NoBlock,


### PR DESCRIPTION
# Description

Some leftover changes in the `sync` module needed after we found some problems during testing and figured out which parts of the code weren't actually used (thanks compiler). Some more detailed changes:

* simplified the logic of "highest_justified" in forest
* better detection and handling of genesis blocks
* more requirements in some traits that turn out to be necessary in practice
* more logs
* more patient stall detection
* additional user justifications (a workaround needed until we have our own block sync)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- I have added tests
- I have made corresponding changes to the existing documentation
- I have created new documentation