### PR TITLE
A0-2287: Don't submit call after dry-run failure

### DIFF
--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "2.15.0"
+version = "2.15.1"
 edition = "2021"
 license = "Apache 2.0"
 

--- a/aleph-client/src/contract/mod.rs
+++ b/aleph-client/src/contract/mod.rs
@@ -252,6 +252,8 @@ impl ContractInstance {
             );
         }
 
+        // For dry run, failed transactions don't return `Err` but `Ok(_)`
+        // and we have to inspect flags manually.
         if let Ok(res) = &contract_read_result.result {
             if res.did_revert() {
                 return Err(anyhow!("Dry-run call reverted"));

--- a/aleph-client/src/contract/mod.rs
+++ b/aleph-client/src/contract/mod.rs
@@ -50,7 +50,7 @@ use std::fmt::{Debug, Formatter};
 use anyhow::{anyhow, Context, Result};
 use contract_transcode::ContractMessageTranscoder;
 pub use convertible_value::ConvertibleValue;
-use log::{error, info};
+use log::info;
 use pallet_contracts_primitives::ContractExecResult;
 
 use crate::{
@@ -254,9 +254,7 @@ impl ContractInstance {
 
         if let Ok(res) = &contract_read_result.result {
             if res.did_revert() {
-                // For dry run, failed transactions don't return `Err` but `Ok(_)`
-                // and we have to inspect flags manually.
-                error!("Dry-run call reverted");
+                return Err(anyhow!("Dry-run call reverted"));
             }
         }
 

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.15.0"
+version = "2.15.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.15.0"
+version = "2.15.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/src/test/adder.rs
+++ b/e2e-tests/src/test/adder.rs
@@ -6,6 +6,7 @@ use aleph_client::{
         ContractInstance,
     },
     contract_transcode::Value,
+    pallets::system::SystemApi,
     AccountId, ConnectionApi, SignedConnectionApi, TxInfo,
 };
 use anyhow::{anyhow, Context, Result};
@@ -102,6 +103,38 @@ pub async fn adder_fetching_events() -> Result<()> {
         .set_name(&account.sign(&conn), Some(new_name))
         .await?;
     assert!(contract.get_name(&conn).await? == Some(new_name.to_string()));
+
+    Ok(())
+}
+
+/// This test ensures that `aleph-client` won't submit call if dry-run fails.
+#[tokio::test]
+pub async fn adder_dry_run_failure() -> Result<()> {
+    let config = setup_test();
+
+    let (conn, _authority, account) = basic_test_context(config).await?;
+
+    let contract = AdderInstance::new(
+        &config.test_case_params.adder,
+        &config.test_case_params.adder_metadata,
+    )?;
+
+    // Make the counter value non-zero to enable overflow during next call.
+    contract.add(&account.sign(&conn), 1).await?;
+
+    let caller_balance_before = conn
+        .get_free_balance(account.account_id().clone(), None)
+        .await;
+
+    // Should fail due to the overflow check in contract.
+    let result = contract.add(&account.sign(&conn), u32::MAX).await;
+    assert!(result.is_err());
+
+    let caller_balance_after = conn
+        .get_free_balance(account.account_id().clone(), None)
+        .await;
+
+    assert_eq!(caller_balance_before, caller_balance_after);
 
     Ok(())
 }


### PR DESCRIPTION
# Description

`aleph-client` shouldn't submit a contract call after dry-run failure.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

- I have added tests
- I have bumped aleph-client version if relevant
