### PR TITLE
A0-2321: Fix invalid workflow name

### DIFF
--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -1,5 +1,5 @@
 ---
-name: UpdateNet Create
+name: UpdateNet Update
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Fixes invalid workflow title for the updatenet-update.yaml that should be "Update" not "Create"