### PR TITLE
A0-2240: Refactor aleph node RPC

### DIFF
--- a/bin/node/src/aleph_node_rpc.rs
+++ b/bin/node/src/aleph_node_rpc.rs
@@ -6,9 +6,7 @@ use jsonrpsee::{
     proc_macros::rpc,
     types::error::{CallError, ErrorObject},
 };
-use serde::Serialize;
-use sp_api::BlockT;
-use sp_runtime::traits::{Header, NumberFor};
+use sp_runtime::traits::Header;
 
 /// System RPC errors.
 #[derive(Debug, thiserror::Error)]
@@ -70,28 +68,22 @@ pub trait AlephNodeApi<Hash, Number> {
 }
 
 /// Aleph Node API implementation
-pub struct AlephNode<B, JT>
+pub struct AlephNode<H, JT>
 where
-    B: BlockT,
-    B::Header: Header<Number = BlockNumber>,
-    B::Hash: Serialize + for<'de> serde::Deserialize<'de>,
-    NumberFor<B>: Serialize + for<'de> serde::Deserialize<'de>,
-    JT: JustificationTranslator<B::Header> + Send + Sync + Clone + 'static,
+    H: Header<Number = BlockNumber>,
+    JT: JustificationTranslator<H> + Send + Sync + Clone + 'static,
 {
-    import_justification_tx: mpsc::UnboundedSender<Justification<B::Header>>,
+    import_justification_tx: mpsc::UnboundedSender<Justification<H>>,
     justification_translator: JT,
 }
 
-impl<B, JT> AlephNode<B, JT>
+impl<H, JT> AlephNode<H, JT>
 where
-    B: BlockT,
-    B::Header: Header<Number = BlockNumber>,
-    B::Hash: Serialize + for<'de> serde::Deserialize<'de>,
-    NumberFor<B>: Serialize + for<'de> serde::Deserialize<'de>,
-    JT: JustificationTranslator<B::Header> + Send + Sync + Clone + 'static,
+    H: Header<Number = BlockNumber>,
+    JT: JustificationTranslator<H> + Send + Sync + Clone + 'static,
 {
     pub fn new(
-        import_justification_tx: mpsc::UnboundedSender<Justification<B::Header>>,
+        import_justification_tx: mpsc::UnboundedSender<Justification<H>>,
         justification_translator: JT,
     ) -> Self {
         AlephNode {
@@ -101,19 +93,16 @@ where
     }
 }
 
-impl<B, JT> AlephNodeApiServer<B::Hash, NumberFor<B>> for AlephNode<B, JT>
+impl<H, JT> AlephNodeApiServer<H::Hash, BlockNumber> for AlephNode<H, JT>
 where
-    B: BlockT,
-    B::Header: Header<Number = BlockNumber>,
-    B::Hash: Serialize + for<'de> serde::Deserialize<'de>,
-    NumberFor<B>: Serialize + for<'de> serde::Deserialize<'de>,
-    JT: JustificationTranslator<B::Header> + Send + Sync + Clone + 'static,
+    H: Header<Number = BlockNumber>,
+    JT: JustificationTranslator<H> + Send + Sync + Clone + 'static,
 {
     fn aleph_node_emergency_finalize(
         &self,
         justification: Vec<u8>,
-        hash: B::Hash,
-        number: NumberFor<B>,
+        hash: H::Hash,
+        number: BlockNumber,
     ) -> RpcResult<()> {
         let justification: AlephJustification =
             AlephJustification::EmergencySignature(justification.try_into().map_err(|_| {

--- a/bin/node/src/rpc.rs
+++ b/bin/node/src/rpc.rs
@@ -7,7 +7,6 @@
 
 use std::sync::Arc;
 
-use aleph_primitives::BlockNumber;
 use aleph_runtime::{opaque::Block, AccountId, Balance, Index};
 use finality_aleph::{Justification, JustificationTranslator};
 use futures::channel::mpsc;
@@ -17,28 +16,22 @@ use sc_transaction_pool_api::TransactionPool;
 use sp_api::{BlockT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
-use sp_runtime::traits::Header;
 
 /// Full client dependencies.
-pub struct FullDeps<B, C, P, JT>
-where
-    B: BlockT,
-    B::Header: Header<Number = BlockNumber>,
-    JT: JustificationTranslator<B::Header> + Send + Sync + Clone + 'static,
-{
+pub struct FullDeps<C, P, JT> {
     /// The client instance to use.
     pub client: Arc<C>,
     /// Transaction pool instance.
     pub pool: Arc<P>,
     /// Whether to deny unsafe calls
     pub deny_unsafe: DenyUnsafe,
-    pub import_justification_tx: mpsc::UnboundedSender<Justification<B::Header>>,
+    pub import_justification_tx: mpsc::UnboundedSender<Justification<<Block as BlockT>::Header>>,
     pub justification_translator: JT,
 }
 
 /// Instantiate all full RPC extensions.
-pub fn create_full<B, C, P, JT>(
-    deps: FullDeps<B, C, P, JT>,
+pub fn create_full<C, P, JT>(
+    deps: FullDeps<C, P, JT>,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
 where
     C: ProvideRuntimeApi<Block>,
@@ -48,9 +41,7 @@ where
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
-    B: BlockT,
-    B::Header: Header<Number = BlockNumber>,
-    JT: JustificationTranslator<B::Header> + Send + Sync + Clone + 'static,
+    JT: JustificationTranslator<<Block as BlockT>::Header> + Send + Sync + Clone + 'static,
 {
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
     use substrate_frame_rpc_system::{System, SystemApiServer};
@@ -69,9 +60,7 @@ where
     module.merge(TransactionPayment::new(client).into_rpc())?;
 
     use crate::aleph_node_rpc::{AlephNode, AlephNodeApiServer};
-    module.merge(
-        AlephNode::<B, JT>::new(import_justification_tx, justification_translator).into_rpc(),
-    )?;
+    module.merge(AlephNode::new(import_justification_tx, justification_translator).into_rpc())?;
 
     Ok(module)
 }

--- a/bin/node/src/rpc.rs
+++ b/bin/node/src/rpc.rs
@@ -7,13 +7,16 @@
 
 use std::sync::Arc;
 
-use aleph_runtime::{opaque::Block, AccountId, Balance, Index};
+use aleph_runtime::{
+    opaque::{Block, Header},
+    AccountId, Balance, Index,
+};
 use finality_aleph::{Justification, JustificationTranslator};
 use futures::channel::mpsc;
 use jsonrpsee::RpcModule;
 pub use sc_rpc_api::DenyUnsafe;
 use sc_transaction_pool_api::TransactionPool;
-use sp_api::{BlockT, ProvideRuntimeApi};
+use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 
@@ -25,7 +28,7 @@ pub struct FullDeps<C, P, JT> {
     pub pool: Arc<P>,
     /// Whether to deny unsafe calls
     pub deny_unsafe: DenyUnsafe,
-    pub import_justification_tx: mpsc::UnboundedSender<Justification<<Block as BlockT>::Header>>,
+    pub import_justification_tx: mpsc::UnboundedSender<Justification<Header>>,
     pub justification_translator: JT,
 }
 
@@ -41,7 +44,7 @@ where
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
-    JT: JustificationTranslator<<Block as BlockT>::Header> + Send + Sync + Clone + 'static,
+    JT: JustificationTranslator<Header> + Send + Sync + Clone + 'static,
 {
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
     use substrate_frame_rpc_system::{System, SystemApiServer};

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -31,8 +31,10 @@ use sp_runtime::{
 };
 
 use crate::{
-    aleph_cli::AlephCli, chain_spec::DEFAULT_BACKUP_FOLDER, executor::AlephExecutor,
-    rpc::FullDeps as RpcFullDeps,
+    aleph_cli::AlephCli,
+    chain_spec::DEFAULT_BACKUP_FOLDER,
+    executor::AlephExecutor,
+    rpc::{create_full as create_full_rpc, FullDeps as RpcFullDeps},
 };
 
 type FullClient = sc_service::TFullClient<Block, RuntimeApi, AlephExecutor>;
@@ -264,7 +266,7 @@ fn setup(
         let client = client.clone();
         let pool = transaction_pool.clone();
         Box::new(move |deny_unsafe, _| {
-            let deps: RpcFullDeps<Block, _, _, _> = crate::rpc::FullDeps {
+            let deps = RpcFullDeps {
                 client: client.clone(),
                 pool: pool.clone(),
                 deny_unsafe,
@@ -272,7 +274,7 @@ fn setup(
                 justification_translator: chain_status.clone(),
             };
 
-            Ok(crate::rpc::create_full(deps)?)
+            Ok(create_full_rpc(deps)?)
         })
     };
 


### PR DESCRIPTION
# Description

Aleph Node Rpc does not need to be dependent on `B: Block`. This replaces and is heavily based on #1102, which got sufficiently obsoleted by other changes that it was simpler to write it from scratch.

## Type of change

Refactor