### PR TITLE
A0-2442: Remove last traces of `NumberFor`

### DIFF
--- a/finality-aleph/src/data_io/chain_info.rs
+++ b/finality-aleph/src/data_io/chain_info.rs
@@ -4,7 +4,7 @@ use aleph_primitives::BlockNumber;
 use log::error;
 use lru::LruCache;
 use sc_client_api::HeaderBackend;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 
 use crate::{data_io::ChainInfoCacheConfig, IdentifierFor};
 
@@ -15,7 +15,7 @@ where
 {
     fn is_block_imported(&mut self, block: &IdentifierFor<B>) -> bool;
 
-    fn get_finalized_at(&mut self, number: NumberFor<B>) -> Result<IdentifierFor<B>, ()>;
+    fn get_finalized_at(&mut self, number: BlockNumber) -> Result<IdentifierFor<B>, ()>;
 
     fn get_parent_hash(&mut self, block: &IdentifierFor<B>) -> Result<B::Hash, ()>;
 

--- a/finality-aleph/src/data_io/data_interpreter.rs
+++ b/finality-aleph/src/data_io/data_interpreter.rs
@@ -4,7 +4,7 @@ use aleph_primitives::BlockNumber;
 use futures::channel::mpsc;
 use log::{debug, error, warn};
 use sc_client_api::HeaderBackend;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor, Zero};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 
 use crate::{
     data_io::{
@@ -52,7 +52,7 @@ where
     } else {
         // We are in session 0, we take the genesis block -- it is finalized by definition.
         client
-            .get_finalized_at(NumberFor::<B>::zero())
+            .get_finalized_at(0)
             .expect("Genesis block must be available")
     }
 }

--- a/finality-aleph/src/data_io/data_provider.rs
+++ b/finality-aleph/src/data_io/data_provider.rs
@@ -7,7 +7,7 @@ use parking_lot::Mutex;
 use sc_client_api::HeaderBackend;
 use sp_consensus::SelectChain;
 use sp_runtime::{
-    traits::{Block as BlockT, Header as HeaderT, NumberFor, Zero},
+    traits::{Block as BlockT, Header as HeaderT, Zero},
     SaturatedConversion,
 };
 
@@ -18,9 +18,10 @@ use crate::{
 };
 
 // Reduce block header to the level given by num, by traversing down via parents.
-pub fn reduce_header_to_num<B, C>(client: &C, header: B::Header, num: NumberFor<B>) -> B::Header
+pub fn reduce_header_to_num<B, C>(client: &C, header: B::Header, num: BlockNumber) -> B::Header
 where
     B: BlockT,
+    B::Header: HeaderT<Number = BlockNumber>,
     C: HeaderBackend<B>,
 {
     assert!(

--- a/finality-aleph/src/data_io/data_store.rs
+++ b/finality-aleph/src/data_io/data_store.rs
@@ -18,7 +18,7 @@ use futures_timer::Delay;
 use log::{debug, error, info, trace, warn};
 use lru::LruCache;
 use sc_client_api::{BlockchainEvents, HeaderBackend};
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor, One};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 
 use crate::{
     data_io::{
@@ -46,7 +46,7 @@ where
     B::Header: HeaderT<Number = BlockNumber>,
 {
     Imported(IdentifierFor<B>),
-    Finalized(NumberFor<B>),
+    Finalized(BlockNumber),
 }
 
 // Need to be implemented manually, as deriving does not work (`BlockT` is not `Hash`).
@@ -403,10 +403,7 @@ where
         if self.highest_finalized_num < proposal.number_below_branch() {
             self.register_finality_trigger(proposal, proposal.number_below_branch());
         } else if self.highest_finalized_num < proposal.number_top_block() {
-            self.register_finality_trigger(
-                proposal,
-                self.highest_finalized_num + NumberFor::<B>::one(),
-            );
+            self.register_finality_trigger(proposal, self.highest_finalized_num + 1);
         }
     }
 

--- a/finality-aleph/src/data_io/proposal.rs
+++ b/finality-aleph/src/data_io/proposal.rs
@@ -7,7 +7,7 @@ use std::{
 use aleph_primitives::BlockNumber;
 use codec::{Decode, Encode};
 use sp_runtime::{
-    traits::{Block as BlockT, Header as HeaderT, NumberFor},
+    traits::{Block as BlockT, Header as HeaderT},
     SaturatedConversion,
 };
 
@@ -30,25 +30,25 @@ use crate::{data_io::MAX_DATA_BRANCH_LEN, IdentifierFor, SessionBoundaries};
 #[derive(Clone, Debug, Encode, Decode)]
 pub struct UnvalidatedAlephProposal<B: BlockT> {
     pub branch: Vec<B::Hash>,
-    pub number: NumberFor<B>,
+    pub number: BlockNumber,
 }
 
 /// Represents possible invalid states as described in [UnvalidatedAlephProposal].
 #[derive(Debug, PartialEq, Eq)]
-pub enum ValidationError<B: BlockT> {
+pub enum ValidationError {
     BranchEmpty,
     BranchTooLong {
         branch_size: usize,
     },
     BlockNumberOutOfBounds {
         branch_size: usize,
-        block_number: NumberFor<B>,
+        block_number: BlockNumber,
     },
     BlockOutsideSessionBoundaries {
-        session_start: NumberFor<B>,
-        session_end: NumberFor<B>,
-        top_block: NumberFor<B>,
-        bottom_block: NumberFor<B>,
+        session_start: BlockNumber,
+        session_end: BlockNumber,
+        top_block: BlockNumber,
+        bottom_block: BlockNumber,
     },
 }
 
@@ -83,7 +83,7 @@ where
     pub(crate) fn validate_bounds(
         &self,
         session_boundaries: &SessionBoundaries,
-    ) -> Result<AlephProposal<B>, ValidationError<B>> {
+    ) -> Result<AlephProposal<B>, ValidationError> {
         use ValidationError::*;
 
         if self.branch.len() > MAX_DATA_BRANCH_LEN {
@@ -127,7 +127,7 @@ where
 #[derive(Clone, Debug, Encode, Decode)]
 pub struct AlephProposal<B: BlockT> {
     branch: Vec<B::Hash>,
-    number: NumberFor<B>,
+    number: BlockNumber,
 }
 
 // Need to be implemented manually, as deriving does not work (`BlockT` is not `Hash`).


### PR DESCRIPTION
# Description

Replaces last uses of `NumberFor` (in the `data_io` module) with `BlockNumber`. 

## Type of change

Refactor