### PR TITLE
A0-1816: Fix Testnet and Mainnet deployments to reflect GitHub environments (#1168) - cherry pick on Release 11

### DIFF
--- a/.github/workflows/_update-node-image-infra.yml
+++ b/.github/workflows/_update-node-image-infra.yml
@@ -12,6 +12,8 @@ jobs:
   main:
     name: Update aleph-node image in infra
     runs-on: ubuntu-20.04
+    environment:
+      name: ${{ inputs.env }}
     steps:
       - name: Validate action inputs
         shell: bash


### PR DESCRIPTION

# Description

Cherry-pick of 66d20a2a (https://github.com/Cardinal-Cryptography/aleph-node/pull/1168).

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

