### PR TITLE
A0-2501: Jellyfier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,14 +542,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "ark-bls12-377"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
+dependencies = [
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65be532f9dd1e98ad0150b037276cde464c6f371059e6dd02c0222395761f6aa"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
+dependencies = [
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-bw6-761"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0605daf0cc5aa2034b78d008aaf159f56901d92a52ee4f6ecdfdac4f426700"
+dependencies = [
+ "ark-bls12-377",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -558,15 +604,33 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff773c0ef8c655c98071d3026a63950798a66b2f45baef22d8334c1756f1bd18"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-relations",
- "ark-serialize",
- "ark-snark",
- "ark-std",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-relations 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-snark 0.3.0",
+ "ark-std 0.3.0",
  "blake2 0.9.2",
  "derivative",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-crypto-primitives"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3a13b34da09176a8baba701233fdffbaa7c1b1192ce031a3da4e55ce1f1a56"
+dependencies = [
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-relations 0.4.0",
+ "ark-serialize 0.4.2",
+ "ark-snark 0.4.0",
+ "ark-std 0.4.0",
+ "blake2 0.10.6",
+ "derivative",
+ "digest 0.10.6",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -575,12 +639,66 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
  "num-traits",
  "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools",
+ "num-traits",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-377"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b10d901b9ac4b38f9c32beacedfadcdd64e46f8d7f8e88c1ae1060022cf6f6c6"
+dependencies = [
+ "ark-bls12-377",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6d678bb98a7e4f825bd4e332e93ac4f5a114ce2e3340dee4d7dc1c7ab5b323"
+dependencies = [
+ "ark-bls12-381 0.4.0",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-ed-on-bn254"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71892f265d01650e34988a546b37ea1d2ba1da162a639597a03d1550f26004d8"
+dependencies = [
+ "ark-bn254",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -589,10 +707,10 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
  "num-bigint",
  "num-traits",
@@ -602,10 +720,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.6",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rayon",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -624,18 +773,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ark-groth16"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f8fff7468e947130b5caf9bdd27de8b913cf30e15104b4f0cd301726b3d897"
 dependencies = [
- "ark-crypto-primitives",
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "ark-relations",
- "ark-serialize",
- "ark-std",
+ "ark-crypto-primitives 0.3.0",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-poly 0.3.0",
+ "ark-relations 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
 ]
 
 [[package]]
@@ -644,11 +806,11 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "440ad4569974910adbeb84422b7e622b79e08d27142afd113785b7fcfb446186"
 dependencies = [
- "ark-ec",
- "ark-ff",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
  "ark-r1cs-std",
- "ark-relations",
- "ark-std",
+ "ark-relations 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
  "num-bigint",
  "num-integer",
@@ -662,11 +824,25 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0f78f47537c2f15706db7e98fe64cc1711dbf9def81218194e17239e53e5aa"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
  "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "hashbrown 0.13.2",
+ "rayon",
 ]
 
 [[package]]
@@ -675,10 +851,10 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e8fdacb1931f238a0d866ced1e916a49d36de832fd8b83dc916b718ae72893"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-relations",
- "ark-std",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-relations 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
  "num-bigint",
  "num-traits",
@@ -691,10 +867,21 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cba4c1c99792a6834bd97f7fd76578ec2cd58d2afc5139a17e1d1bec65b38f6"
 dependencies = [
- "ark-ff",
- "ark-std",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+ "tracing",
 ]
 
 [[package]]
@@ -703,9 +890,21 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.3.0",
+ "ark-std 0.3.0",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive 0.4.2",
+ "ark-std 0.4.0",
+ "digest 0.10.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -720,14 +919,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ark-snark"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc3dff1a5f67a9c0b34df32b079752d8dd17f1e9d06253da0453db6c1b7cc8a"
 dependencies = [
- "ark-ff",
- "ark-relations",
- "ark-std",
+ "ark-ff 0.3.0",
+ "ark-relations 0.3.0",
+ "ark-std 0.3.0",
+]
+
+[[package]]
+name = "ark-snark"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d3cc6833a335bb8a600241889ead68ee89a3cf8448081fb7694c0fe503da63"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-relations 0.4.0",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -738,6 +960,17 @@ checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "rayon",
 ]
 
 [[package]]
@@ -1166,6 +1399,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "blst"
+version = "0.3.10"
+source = "git+https://github.com/EspressoSystems/blst.git?branch=no-std#faefc7fcb21864aaf4f6f443636ce8924108fcbd"
+dependencies = [
+ "cc",
+ "glob",
+ "zeroize",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,15 +1568,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
  "aead 0.4.3",
- "chacha20",
+ "chacha20 0.8.2",
  "cipher 0.3.0",
- "poly1305",
+ "poly1305 0.7.2",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
@@ -1391,6 +1658,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1660,6 +1928,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc-any"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774646b687f63643eb0f4bf13dc263cb581c8c9e57973b6ddf78bda3994d88df"
+
+[[package]]
 name = "crc-catalog"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +2038,21 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.7",
  "subtle",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd26c32de5307fd08aac445a75c43472b14559d5dccdfba8022dbcd075838ebc"
+dependencies = [
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "chacha20poly1305 0.10.1",
+ "salsa20",
+ "x25519-dalek 1.1.1",
+ "xsalsa20poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -2122,6 +2411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +2620,11 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "espresso-systems-common"
+version = "0.4.0"
+source = "git+https://github.com/espressosystems/espresso-systems-common?tag=0.4.0#5abd890f79014a86db31286e1f3a529f161e69de"
 
 [[package]]
 name = "event-listener"
@@ -3763,6 +4063,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jellyfier"
+version = "0.0.0"
+dependencies = [
+ "ark-bls12-381 0.4.0",
+ "ark-serialize 0.4.2",
+ "jf-plonk",
+ "parity-scale-codec",
+ "sp-runtime-interface",
+]
+
+[[package]]
+name = "jf-plonk"
+version = "0.3.0"
+source = "git+https://github.com/EspressoSystems/jellyfish#45328b802dd7d28d278ca364d54df0a9c6f337cc"
+dependencies = [
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "displaydoc",
+ "downcast-rs",
+ "dyn-clone",
+ "espresso-systems-common",
+ "hashbrown 0.13.2",
+ "itertools",
+ "jf-primitives",
+ "jf-relation",
+ "jf-utils",
+ "merlin 3.0.0",
+ "num-bigint",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "sha3",
+ "tagged-base64",
+]
+
+[[package]]
+name = "jf-primitives"
+version = "0.3.0"
+source = "git+https://github.com/EspressoSystems/jellyfish#45328b802dd7d28d278ca364d54df0a9c6f337cc"
+dependencies = [
+ "ark-bls12-377",
+ "ark-bls12-381 0.4.0",
+ "ark-bn254",
+ "ark-bw6-761",
+ "ark-crypto-primitives 0.4.0",
+ "ark-ec 0.4.2",
+ "ark-ed-on-bls12-377",
+ "ark-ed-on-bls12-381",
+ "ark-ed-on-bn254",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "blst",
+ "crypto_box",
+ "derivative",
+ "digest 0.10.6",
+ "displaydoc",
+ "espresso-systems-common",
+ "generic-array 0.14.7",
+ "itertools",
+ "jf-relation",
+ "jf-utils",
+ "merlin 3.0.0",
+ "num-bigint",
+ "num-traits",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "sha2 0.10.6",
+ "sha3",
+ "tagged-base64",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "jf-relation"
+version = "0.3.0"
+source = "git+https://github.com/EspressoSystems/jellyfish#45328b802dd7d28d278ca364d54df0a9c6f337cc"
+dependencies = [
+ "ark-bls12-377",
+ "ark-bls12-381 0.4.0",
+ "ark-bn254",
+ "ark-bw6-761",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "displaydoc",
+ "downcast-rs",
+ "dyn-clone",
+ "hashbrown 0.13.2",
+ "jf-utils",
+ "num-bigint",
+ "rand_chacha 0.3.1",
+ "rayon",
+]
+
+[[package]]
+name = "jf-utils"
+version = "0.3.0"
+source = "git+https://github.com/EspressoSystems/jellyfish#45328b802dd7d28d278ca364d54df0a9c6f337cc"
+dependencies = [
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "digest 0.10.6",
+ "rayon",
+ "serde",
+ "sha2 0.10.6",
+ "tagged-base64",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4617,7 +5039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8723da56ab98f2182cbd27b9c510ca3c7f7bd616a56ca0e6b8f1b4bbc2c5f2ee"
 dependencies = [
  "anyhow",
- "ark-ff",
+ "ark-ff 0.3.0",
  "num-integer",
 ]
 
@@ -4628,8 +5050,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e7de36eb888e7ba29bcc4dcd664db0df190f073e807baa230054abbbadaf6d"
 dependencies = [
  "anyhow",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
  "getrandom 0.2.9",
  "liminal-ark-pnbr-poseidon-parameters",
  "merlin 3.0.0",
@@ -4644,8 +5066,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0419b780a13b09a1ed2db09c6c61752f24e5f341f77a93719cd8bc963b72d3"
 dependencies = [
- "ark-ff",
- "ark-std",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
  "liminal-ark-pnbr-poseidon-parameters",
 ]
 
@@ -4655,13 +5077,13 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c178b0470950ac7fb73646df0f6ef60452d7b0fb0819e41dbe66674abc622f"
 dependencies = [
- "ark-ec",
- "ark-ff",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
  "ark-nonnative-field",
  "ark-r1cs-std",
- "ark-relations",
- "ark-serialize",
- "ark-std",
+ "ark-relations 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
  "digest 0.9.0",
  "rand_chacha 0.3.1",
@@ -4672,10 +5094,10 @@ dependencies = [
 name = "liminal-ark-poseidon"
 version = "0.1.0"
 dependencies = [
- "ark-bls12-381",
- "ark-ff",
+ "ark-bls12-381 0.3.0",
+ "ark-ff 0.3.0",
  "ark-r1cs-std",
- "ark-relations",
+ "ark-relations 0.3.0",
  "liminal-ark-pnbr-poseidon-parameters",
  "liminal-ark-pnbr-poseidon-paramgen",
  "liminal-ark-pnbr-poseidon-permutation",
@@ -4689,8 +5111,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ff555fb3914d246c1d478b66d248d4e59daac3784f05c24a707a55d9a6bd2b"
 dependencies = [
- "ark-bls12-381",
- "ark-ff",
+ "ark-bls12-381 0.3.0",
+ "ark-ff 0.3.0",
  "liminal-ark-pnbr-poseidon-parameters",
  "liminal-ark-pnbr-poseidon-permutation",
  "paste",
@@ -5626,11 +6048,11 @@ dependencies = [
 name = "pallet-baby-liminal"
 version = "0.1.0"
 dependencies = [
- "ark-bls12-381",
+ "ark-bls12-381 0.3.0",
  "ark-groth16",
- "ark-relations",
- "ark-serialize",
- "ark-snark",
+ "ark-relations 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-snark 0.3.0",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6327,6 +6749,17 @@ dependencies = [
  "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash 0.4.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash 0.5.0",
 ]
 
 [[package]]
@@ -7145,6 +7578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
 dependencies = [
  "rustc_version 0.2.3",
+]
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -8443,6 +8885,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "snafu"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
+dependencies = [
+ "backtrace",
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "snap"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8456,7 +8921,7 @@ checksum = "5ccba027ba85743e09d15c03296797cad56395089b832b48b5a5217880f57733"
 dependencies = [
  "aes-gcm 0.9.4",
  "blake2 0.10.6",
- "chacha20poly1305",
+ "chacha20poly1305 0.9.1",
  "curve25519-dalek 4.0.0-rc.1",
  "rand_core 0.6.4",
  "ring",
@@ -9558,6 +10023,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagged-base64"
+version = "0.3.0"
+source = "git+https://github.com/espressosystems/tagged-base64?tag=0.3.0#19381b3f14b1f94269c8c783288a63694b6dd12a"
+dependencies = [
+ "ark-serialize 0.4.2",
+ "base64 0.13.1",
+ "crc-any",
+ "serde",
+ "snafu",
+ "tagged-base64-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tagged-base64-macros"
+version = "0.3.0"
+source = "git+https://github.com/espressosystems/tagged-base64?tag=0.3.0#19381b3f14b1f94269c8c783288a63694b6dd12a"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10297,6 +10785,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -11296,6 +11786,19 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time 0.3.20",
+]
+
+[[package]]
+name = "xsalsa20poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472c385ee974833d7e59979eeb74175d56774be3768b5bcc581337e21396bda3"
+dependencies = [
+ "aead 0.5.2",
+ "poly1305 0.8.0",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,6 +4069,8 @@ dependencies = [
  "ark-bls12-381 0.4.0",
  "ark-serialize 0.4.2",
  "jf-plonk",
+ "jf-relation",
+ "jf-utils",
  "parity-scale-codec",
  "sp-runtime-interface",
 ]
@@ -4076,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "jf-plonk"
 version = "0.3.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#45328b802dd7d28d278ca364d54df0a9c6f337cc"
+source = "git+https://github.com/EspressoSystems/jellyfish?rev=45328b802dd7d28d278ca364d54df0a9c6f337cc#45328b802dd7d28d278ca364d54df0a9c6f337cc"
 dependencies = [
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
@@ -4105,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.3.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#45328b802dd7d28d278ca364d54df0a9c6f337cc"
+source = "git+https://github.com/EspressoSystems/jellyfish?rev=45328b802dd7d28d278ca364d54df0a9c6f337cc#45328b802dd7d28d278ca364d54df0a9c6f337cc"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -4146,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.3.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#45328b802dd7d28d278ca364d54df0a9c6f337cc"
+source = "git+https://github.com/EspressoSystems/jellyfish?rev=45328b802dd7d28d278ca364d54df0a9c6f337cc#45328b802dd7d28d278ca364d54df0a9c6f337cc"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -4171,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.3.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#45328b802dd7d28d278ca364d54df0a9c6f337cc"
+source = "git+https://github.com/EspressoSystems/jellyfish?rev=45328b802dd7d28d278ca364d54df0a9c6f337cc#45328b802dd7d28d278ca364d54df0a9c6f337cc"
 dependencies = [
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "bin/runtime",
     "clique",
     "finality-aleph",
+    "jellyfier",
     "pallets/aleph",
     "pallets/baby-liminal",
     "pallets/elections",

--- a/jellyfier/Cargo.toml
+++ b/jellyfier/Cargo.toml
@@ -16,7 +16,13 @@ ark-serialize = { version = "0.4.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 
 sp-runtime-interface = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.38", default-features = false }
-jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish" }
+jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", rev = "45328b802dd7d28d278ca364d54df0a9c6f337cc" }
+
+[dev-dependencies]
+jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", rev = "45328b802dd7d28d278ca364d54df0a9c6f337cc", features = ["test-srs"] }
+jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", rev = "45328b802dd7d28d278ca364d54df0a9c6f337cc" }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", rev = "45328b802dd7d28d278ca364d54df0a9c6f337cc" }
+
 
 [features]
 default = ["std"]

--- a/jellyfier/Cargo.toml
+++ b/jellyfier/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "jellyfier"
+version = "0.0.0"
+edition = "2021"
+authors = ["Cardinal"]
+documentation = "https://docs.rs/?"
+homepage = "https://alephzero.org"
+license = "Apache-2.0"
+categories = ["cryptography"]
+repository = "https://github.com/Cardinal-Cryptography/aleph-node"
+description = "Jellyfish PLONK verifier"
+
+[dependencies]
+ark-bls12-381 = { version = "0.4.0", default-features = false }
+ark-serialize = { version = "0.4.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
+
+sp-runtime-interface = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.38", default-features = false }
+jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish" }
+
+[features]
+default = ["std"]
+std = [
+    "ark-bls12-381/std",
+    "ark-serialize/std",
+    "codec/std",
+    "sp-runtime-interface/std",
+]

--- a/jellyfier/src/lib.rs
+++ b/jellyfier/src/lib.rs
@@ -1,0 +1,45 @@
+use ark_bls12_381::{Bls12_381, Fr};
+use ark_serialize::CanonicalDeserialize;
+use jf_plonk::{
+    errors::PlonkError,
+    proof_system::{
+        structs::{Proof, VerifyingKey},
+        PlonkKzgSnark, UniversalSNARK,
+    },
+    transcript::StandardTranscript,
+};
+use sp_runtime_interface::pass_by::PassByEnum;
+
+pub type Curve = Bls12_381;
+pub type CircuitField = Fr;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, codec::Encode, codec::Decode, PassByEnum)]
+pub enum VerificationError {
+    WrongProof,
+    DeserializationError,
+    OtherError,
+}
+
+#[sp_runtime_interface::runtime_interface]
+pub trait Jellyfier {
+    fn verify_proof(
+        vk: Vec<u8>,
+        public_input: Vec<u8>,
+        proof: Vec<u8>,
+    ) -> Result<(), VerificationError> {
+        let vk: VerifyingKey<Curve> = CanonicalDeserialize::deserialize_compressed(&*vk)
+            .map_err(|_| VerificationError::DeserializationError)?;
+        let public_input: Vec<CircuitField> =
+            CanonicalDeserialize::deserialize_compressed(&*public_input)
+                .map_err(|_| VerificationError::DeserializationError)?;
+        let proof: Proof<Curve> = CanonicalDeserialize::deserialize_compressed(&*proof)
+            .map_err(|_| VerificationError::DeserializationError)?;
+
+        PlonkKzgSnark::verify::<StandardTranscript>(&vk, &public_input, &proof, None).map_err(|e| {
+            match e {
+                PlonkError::WrongProof => VerificationError::WrongProof,
+                _ => VerificationError::OtherError,
+            }
+        })
+    }
+}

--- a/jellyfier/src/lib.rs
+++ b/jellyfier/src/lib.rs
@@ -43,3 +43,80 @@ pub trait Jellyfier {
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use ark_serialize::{CanonicalSerialize, Compress};
+    use jf_plonk::{
+        proof_system::{
+            structs::{Proof, VerifyingKey},
+            PlonkKzgSnark, UniversalSNARK,
+        },
+        transcript::StandardTranscript,
+    };
+    use jf_relation::{Arithmetization, Circuit, PlonkCircuit};
+
+    use crate::{CircuitField, Curve, VerificationError};
+
+    const A: u32 = 1; // public input
+    const B: u32 = 2; // private input
+    const C: u32 = 3; // constant
+
+    fn generate_circuit() -> PlonkCircuit<CircuitField> {
+        let mut circuit = PlonkCircuit::<CircuitField>::new_turbo_plonk();
+
+        let a_var = circuit.create_public_variable(A.into()).unwrap();
+        let b_var = circuit.create_variable(B.into()).unwrap();
+        let c_var = circuit.create_constant_variable(C.into()).unwrap();
+
+        circuit.add_gate(a_var, b_var, c_var).unwrap();
+
+        assert!(circuit.check_circuit_satisfiability(&[A.into()]).is_ok());
+
+        circuit.finalize_for_arithmetization().unwrap();
+
+        circuit
+    }
+
+    fn setup() -> (VerifyingKey<Curve>, Proof<Curve>) {
+        let circuit = generate_circuit();
+
+        let rng = &mut jf_utils::test_rng();
+        let srs =
+            PlonkKzgSnark::<Curve>::universal_setup_for_testing(circuit.srs_size().unwrap(), rng)
+                .unwrap();
+
+        let (pk, vk) = PlonkKzgSnark::<Curve>::preprocess(&srs, &circuit).unwrap();
+        let proof =
+            PlonkKzgSnark::<Curve>::prove::<_, _, StandardTranscript>(rng, &circuit, &pk, None)
+                .unwrap();
+
+        (vk, proof)
+    }
+
+    fn serialize<T: CanonicalSerialize>(t: &T) -> Vec<u8> {
+        let mut bytes = vec![0; t.serialized_size(Compress::Yes)];
+        t.serialize_compressed(&mut bytes[..]).unwrap();
+        bytes.to_vec()
+    }
+
+    fn do_verification(public_input: CircuitField) -> Result<(), VerificationError> {
+        let (vk, proof) = setup();
+        let vk = serialize(&vk);
+        let proof = serialize(&proof);
+        let public_input = serialize(&vec![public_input]);
+
+        // We cannot use `Jellyfier` trait directly, as it is transformed by substrate macro into
+        // a module (with private trait `Jellyfier` and public function `verify_proof`).
+        crate::jellyfier::verify_proof(vk, public_input, proof)
+    }
+
+    #[test]
+    fn verify_proof() {
+        assert!(do_verification(A.into()).is_ok());
+        assert!(matches!(
+            do_verification((A + 1).into()),
+            Err(VerificationError::WrongProof)
+        ));
+    }
+}


### PR DESCRIPTION
# Description

Since `jellyfish` is still not wasm-friendly, we implement verifier as a host function in a dedicated crate. However, it still cannot be included into the node (after adding as a dependency to the node, we get `could not compile 'curve25519-dalek' due to 1114 previous errors`). This will be put into further investigation.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have added tests
- I have made necessary updates to the Infrastructure
- I have created new documentation
