### PR TITLE
A0-2516: Always notify dev-onduty slack channel when there is a push to a release branch and build finishes

### DIFF
--- a/.github/workflows/on-main-or-release-branch-commit.yml
+++ b/.github/workflows/on-main-or-release-branch-commit.yml
@@ -89,7 +89,7 @@ jobs:
     name: Send Slack notification about workflow status
     runs-on: ubuntu-20.04
     if: always() && github.ref_name == 'main'
-    needs: [ push-node-image-to-ecr ]
+    needs: [push-node-image-to-ecr]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/on-main-or-release-branch-commit.yml
+++ b/.github/workflows/on-main-or-release-branch-commit.yml
@@ -69,11 +69,27 @@ jobs:
             docker push ${{ env.ECR_PUSH_IMAGE }}:latest
           fi
 
-  send-slack-notification:
+  send-slack-notification-release:
     name: Send Slack notification about workflow status
     runs-on: ubuntu-20.04
+    if: always() && startsWith(github.ref_name, 'release-')
     needs: [push-node-image-to-ecr]
-    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Send Slack message
+        uses: ./.github/actions/slack-notification
+        with:
+          notify-on: "always"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ONDUTY }}
+
+  send-slack-notification-main:
+    name: Send Slack notification about workflow status
+    runs-on: ubuntu-20.04
+    if: always() && github.ref_name == 'main'
+    needs: [ push-node-image-to-ecr ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/on-release-branch-commit.yml
+++ b/.github/workflows/on-release-branch-commit.yml
@@ -28,7 +28,8 @@ jobs:
         run: |
           set +e
           fail=0
-          for i in $(ls -1 .github/workflows/*.yml)
+          # compare every worflow except e2e tests as those might get added on main
+          for i in $(ls -1 .github/workflows/*.yml | grep -v on-pull-request-commit.yml)
           do
             diff -ur $i aleph-node-main/$i > $i.diff
             if [[ $(cat $i.diff | wc -l) > 0 ]]; then


### PR DESCRIPTION
# Description

* always notify dev-onduty slack channel when there is a push to a release branch and build finishes, as opposed to a current behavior in which only failures are reported. On main branch though, logic remains the same to not spam dev-onduty channel per every commit to main.
* fix workflow that compares workflows among `main` and release branches to exclude e2e workflow from comparison

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have made corresponding changes to the existing documentation
