### PR TITLE
A0-2517: Treat blocks from major sync the same as others

### DIFF
--- a/finality-aleph/src/import.rs
+++ b/finality-aleph/src/import.rs
@@ -2,11 +2,11 @@ use std::{collections::HashMap, fmt::Debug, time::Instant};
 
 use aleph_primitives::{BlockNumber, ALEPH_ENGINE_ID};
 use futures::channel::mpsc::{TrySendError, UnboundedSender};
-use log::{trace, debug, warn};
+use log::{debug, trace, warn};
 use sc_consensus::{
     BlockCheckParams, BlockImport, BlockImportParams, ImportResult, JustificationImport,
 };
-use sp_consensus::{Error as ConsensusError, BlockOrigin};
+use sp_consensus::{BlockOrigin, Error as ConsensusError};
 use sp_runtime::{
     traits::{Block as BlockT, Header},
     Justification as SubstrateJustification,

--- a/finality-aleph/src/import.rs
+++ b/finality-aleph/src/import.rs
@@ -2,11 +2,11 @@ use std::{collections::HashMap, fmt::Debug, time::Instant};
 
 use aleph_primitives::{BlockNumber, ALEPH_ENGINE_ID};
 use futures::channel::mpsc::{TrySendError, UnboundedSender};
-use log::{debug, warn};
+use log::{trace, debug, warn};
 use sc_consensus::{
     BlockCheckParams, BlockImport, BlockImportParams, ImportResult, JustificationImport,
 };
-use sp_consensus::Error as ConsensusError;
+use sp_consensus::{Error as ConsensusError, BlockOrigin};
 use sp_runtime::{
     traits::{Block as BlockT, Header},
     Justification as SubstrateJustification,
@@ -76,7 +76,8 @@ where
 }
 
 /// A wrapper around a block import that also extracts any present jsutifications and send them to
-/// our components which will process them further and possibly finalize the block.
+/// our components which will process them further and possibly finalize the block. It also makes
+/// blocks from major sync import as if they came from normal sync.
 #[derive(Clone)]
 pub struct AlephBlockImport<B, I, JT>
 where
@@ -176,6 +177,10 @@ where
         let post_hash = block.post_hash();
 
         let justifications = block.justifications.take();
+        if matches!(block.origin, BlockOrigin::NetworkInitialSync) {
+            trace!(target: "aleph-justification", "Treating block {:?} {:?} from major sync as from a normal sync.", number, block.header.hash());
+            block.origin = BlockOrigin::NetworkBroadcast;
+        }
 
         debug!(target: "aleph-justification", "Importing block {:?} {:?} {:?}", number, block.header.hash(), block.post_hash());
         let result = self.inner.import_block(block, cache).await;


### PR DESCRIPTION
# Description

If a block comes from major sync we pretend that it actually came from normal sync when importing it.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- I have made corresponding changes to the existing documentation