### PR TITLE
Fix: dockerfile nix build

### DIFF
--- a/nix/Dockerfile.build
+++ b/nix/Dockerfile.build
@@ -5,7 +5,7 @@ RUN nix-env -i patchelf && \
 
 COPY nix/ /node/nix-files/nix/
 RUN chmod +x /node/nix-files/nix/nix-build.sh
-COPY default.nix shell.nix rust-toolchain /node/nix-files/
+COPY default.nix shell.nix /node/nix-files/
 
 RUN nix-shell --pure --run 'echo installed all native pre-requisities' /node/nix-files/shell.nix
 


### PR DESCRIPTION
Removed "rust-toolchain" from the nix dockerfile.

When I try to build a docker image using command:
`sudo docker build -t aleph-build -f nix/Dockerfile.build .`

I got this error:

```
Sending build context to Docker daemon  39.82MB
Step 1/9 : FROM nixos/nix@sha256:f0c68f870c655d8d96658ca762a0704a30704de22d16b4956e762a2ddfbccb09
 ---> 7299ab3c5ae8
Step 2/9 : RUN nix-env -i patchelf &&     nix-collect-garbage -d
 ---> Using cache
 ---> 03bec67dd57f
Step 3/9 : COPY nix/ /node/nix-files/nix/
 ---> Using cache
 ---> 20f9fd6b667d
Step 4/9 : RUN chmod +x /node/nix-files/nix/nix-build.sh
 ---> Using cache
 ---> 8fd6c21d50df
Step 5/9 : COPY default.nix shell.nix rust-toolchain /node/nix-files/
COPY failed: file not found in build context or excluded by .dockerignore: stat rust-toolchain: file does not exist
```

In file: `aleph-node/nix/Dockerfile.build` I have removed "rust-toolchain" at the line
L8: `COPY default.nix shell.nix rust-toolchain.toml /node/nix-files/`

