### PR TITLE
A0-2571: Sanity check for minimum session duration.

### DIFF
--- a/finality-aleph/src/abft/common.rs
+++ b/finality-aleph/src/abft/common.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use crate::{NodeIndex, SessionId, UnitCreationDelay};
+use crate::UnitCreationDelay;
 
 pub const MAX_ROUNDS: u16 = 7000;
 
@@ -25,7 +25,6 @@ fn exponential_slowdown(
 }
 
 pub type DelaySchedule = Arc<dyn Fn(usize) -> Duration + Sync + Send + 'static>;
-pub type RecipientCountSchedule = Arc<dyn Fn(usize) -> usize + Sync + Send + 'static>;
 
 pub fn unit_creation_delay_fn(unit_creation_delay: UnitCreationDelay) -> DelaySchedule {
     Arc::new(move |t| match t {
@@ -34,94 +33,34 @@ pub fn unit_creation_delay_fn(unit_creation_delay: UnitCreationDelay) -> DelaySc
     })
 }
 
-pub struct DelayConfig {
-    pub tick_interval: Duration,
-    pub requests_interval: Duration,
-    pub unit_rebroadcast_interval_min: Duration,
-    pub unit_rebroadcast_interval_max: Duration,
-    pub unit_creation_delay: DelaySchedule,
-    pub coord_request_delay: DelaySchedule,
-    pub coord_request_recipients: RecipientCountSchedule,
-    pub parent_request_delay: DelaySchedule,
-    pub parent_request_recipients: RecipientCountSchedule,
-    pub newest_request_delay: DelaySchedule,
+// 7 days (as milliseconds)
+const SESSION_LEN_LOWER_BOUND_MS: u128 = 1000 * 60 * 60 * 24 * 7;
+
+pub fn sanity_check_round_delays(max_rounds: u16, round_delays: DelaySchedule) {
+    let delays_ok = sanity_check_round_delays_inner(max_rounds, round_delays);
+    assert!(
+        delays_ok,
+        "Incorrect setting of delays. Make sure the total AlephBFT session time is at least {}ms.",
+        SESSION_LEN_LOWER_BOUND_MS
+    );
 }
 
-pub struct AlephConfig {
-    delay_config: DelayConfig,
-    n_members: usize,
-    node_id: NodeIndex,
-    session_id: SessionId,
-}
-
-impl AlephConfig {
-    pub fn new(
-        delay_config: DelayConfig,
-        n_members: usize,
-        node_id: NodeIndex,
-        session_id: SessionId,
-    ) -> AlephConfig {
-        AlephConfig {
-            delay_config,
-            n_members,
-            node_id,
-            session_id,
-        }
+fn sanity_check_round_delays_inner(max_rounds: u16, round_delays: DelaySchedule) -> bool {
+    let mut total_delay = Duration::from_millis(0);
+    for t in 0..max_rounds {
+        total_delay += round_delays(t as usize);
     }
+    total_delay.as_millis() > SESSION_LEN_LOWER_BOUND_MS
 }
 
-impl From<DelayConfig> for legacy_aleph_bft::DelayConfig {
-    fn from(cfg: DelayConfig) -> Self {
-        Self {
-            tick_interval: cfg.tick_interval,
-            requests_interval: cfg.requests_interval,
-            unit_rebroadcast_interval_max: cfg.unit_rebroadcast_interval_max,
-            unit_rebroadcast_interval_min: cfg.unit_rebroadcast_interval_min,
-            unit_creation_delay: cfg.unit_creation_delay,
-        }
-    }
+#[test]
+fn sanity_check_fails_on_bad_config() {
+    let round_delays = unit_creation_delay_fn(UnitCreationDelay(300));
+    assert!(!sanity_check_round_delays_inner(5000, round_delays));
 }
 
-impl From<DelayConfig> for current_aleph_bft::DelayConfig {
-    fn from(cfg: DelayConfig) -> Self {
-        Self {
-            tick_interval: cfg.tick_interval,
-            unit_rebroadcast_interval_max: cfg.unit_rebroadcast_interval_max,
-            unit_rebroadcast_interval_min: cfg.unit_rebroadcast_interval_min,
-            unit_creation_delay: cfg.unit_creation_delay,
-            coord_request_delay: cfg.coord_request_delay,
-            coord_request_recipients: cfg.coord_request_recipients,
-            parent_request_delay: cfg.parent_request_delay,
-            parent_request_recipients: cfg.parent_request_recipients,
-            newest_request_delay: cfg.newest_request_delay,
-        }
-    }
-}
-
-impl From<AlephConfig> for current_aleph_bft::Config {
-    fn from(cfg: AlephConfig) -> Self {
-        let mut aleph_config = current_aleph_bft::default_config(
-            cfg.n_members.into(),
-            cfg.node_id.into(),
-            cfg.session_id.0 as u64,
-        );
-        aleph_config.max_round = MAX_ROUNDS;
-        aleph_config.delay_config = cfg.delay_config.into();
-
-        aleph_config
-    }
-}
-
-impl From<AlephConfig> for legacy_aleph_bft::Config {
-    fn from(cfg: AlephConfig) -> Self {
-        let mut aleph_config = legacy_aleph_bft::default_config(
-            cfg.n_members.into(),
-            cfg.node_id.into(),
-            cfg.session_id.0 as u64,
-        );
-        aleph_config.max_round = MAX_ROUNDS;
-        aleph_config.delay_config = cfg.delay_config.into();
-
-        aleph_config
-    }
+#[test]
+fn sanity_check_passes_on_good_config() {
+    let round_delays = unit_creation_delay_fn(UnitCreationDelay(300));
+    assert!(sanity_check_round_delays_inner(7000, round_delays));
 }

--- a/finality-aleph/src/abft/common.rs
+++ b/finality-aleph/src/abft/common.rs
@@ -47,7 +47,7 @@ pub fn sanity_check_round_delays(max_rounds: u16, round_delays: DelaySchedule) {
 
 fn sanity_check_round_delays_inner(max_rounds: u16, round_delays: DelaySchedule) -> bool {
     let mut total_delay = Duration::from_millis(0);
-    for t in 0..max_rounds {
+    for t in 0..=max_rounds {
         total_delay += round_delays(t as usize);
     }
     total_delay.as_millis() > SESSION_LEN_LOWER_BOUND_MS

--- a/finality-aleph/src/abft/current.rs
+++ b/finality-aleph/src/abft/current.rs
@@ -4,6 +4,7 @@ use network_clique::SpawnHandleT;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::{Block, Header};
 
+use super::common::sanity_check_round_delays;
 pub use crate::aleph_primitives::{BlockNumber, CURRENT_FINALITY_VERSION as VERSION};
 use crate::{
     abft::{
@@ -39,6 +40,12 @@ where
     C: HeaderBackend<B> + Send + 'static,
     ADN: Network<CurrentNetworkData<B>> + 'static,
 {
+    // Remove this check once we implement one on the AlephBFT side (A0-2583).
+    // Checks that the total time of a session is at least 7 days.
+    sanity_check_round_delays(
+        config.max_round,
+        config.delay_config.unit_creation_delay.clone(),
+    );
     let SubtaskCommon {
         spawn_handle,
         session_id,
@@ -77,5 +84,6 @@ pub fn create_aleph_config(
     let mut config = default_config(n_members.into(), node_id.into(), session_id.0 as u64);
     config.delay_config.unit_creation_delay = unit_creation_delay_fn(unit_creation_delay);
     config.max_round = MAX_ROUNDS;
+    
     config
 }

--- a/finality-aleph/src/abft/current.rs
+++ b/finality-aleph/src/abft/current.rs
@@ -84,6 +84,6 @@ pub fn create_aleph_config(
     let mut config = default_config(n_members.into(), node_id.into(), session_id.0 as u64);
     config.delay_config.unit_creation_delay = unit_creation_delay_fn(unit_creation_delay);
     config.max_round = MAX_ROUNDS;
-    
+
     config
 }

--- a/finality-aleph/src/abft/legacy.rs
+++ b/finality-aleph/src/abft/legacy.rs
@@ -4,7 +4,7 @@ use network_clique::SpawnHandleT;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::{Block, Header};
 
-use super::common::{unit_creation_delay_fn, MAX_ROUNDS};
+use super::common::{sanity_check_round_delays, unit_creation_delay_fn, MAX_ROUNDS};
 pub use crate::aleph_primitives::{BlockNumber, LEGACY_FINALITY_VERSION as VERSION};
 use crate::{
     abft::NetworkWrapper,
@@ -33,6 +33,12 @@ where
     C: HeaderBackend<B> + Send + 'static,
     ADN: Network<LegacyNetworkData<B>> + 'static,
 {
+    // Remove this check once we implement one on the AlephBFT side (A0-2583).
+    // Checks that the total time of a session is at least 7 days.
+    sanity_check_round_delays(
+        config.max_round,
+        config.delay_config.unit_creation_delay.clone(),
+    );
     let SubtaskCommon {
         spawn_handle,
         session_id,

--- a/scripts/run_nodes.sh
+++ b/scripts/run_nodes.sh
@@ -98,7 +98,6 @@ run_node() {
     --bootnodes $bootnodes \
     --node-key-file $BASE_PATH/$account_id/p2p_secret \
     --backup-path $BASE_PATH/$account_id/backup-stash \
-    --unit-creation-delay 500 \
     --execution Native \
     --rpc-cors=all \
     --no-mdns \


### PR DESCRIPTION
# Description

Note that the cherrypick for A0-2571 has already been done in https://github.com/Cardinal-Cryptography/aleph-node/pull/1221 
This is only :
- cleaning up dead code that was the main reason for this bug to appear
- adding a sanity check that will save us from a similar mistake in the future

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:
- I have added tests

