### PR TITLE
A0-2584: Use Pcg32 in all pallets

### DIFF
--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -2637,6 +2637,7 @@ dependencies = [
  "parity-scale-codec",
  "primitives",
  "rand 0.8.5",
+ "rand_pcg 0.3.1",
  "scale-info",
  "sp-core 7.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "sp-io 7.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -2995,7 +2996,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -3063,6 +3064,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5144,7 +5154,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/pallets/elections/src/impls.rs
+++ b/pallets/elections/src/impls.rs
@@ -1,6 +1,6 @@
 use primitives::{CommitteeSeats, EraValidators};
 use rand::{seq::SliceRandom, SeedableRng};
-use rand_pcg::Pcg64Mcg;
+use rand_pcg::Pcg32;
 use sp_staking::EraIndex;
 use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
 
@@ -14,7 +14,7 @@ where
     T: Config,
 {
     fn populate_next_era_validators_on_next_era_start(era: EraIndex) {
-        let mut rng = Pcg64Mcg::seed_from_u64(era as u64);
+        let mut rng = Pcg32::seed_from_u64(era as u64);
         let elected_committee = BTreeSet::from_iter(T::ValidatorProvider::elected_validators(era));
 
         let mut retain_shuffle_elected = |vals: Vec<T::AccountId>| -> Vec<T::AccountId> {


### PR DESCRIPTION
# Description

We should be using `Pcg32` everywhere.

## Type of change

- Bug fix (non-breaking change which fixes an issue)