### PR TITLE
A0-2586: Add storage version checks to migrations. Bump pallet committee manag…

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 63,
+    spec_version: 64,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 14,

--- a/pallets/committee-management/src/migration.rs
+++ b/pallets/committee-management/src/migration.rs
@@ -61,7 +61,11 @@ pub struct PrefixMigration<T>(sp_std::marker::PhantomData<T>);
 impl<T: Config> OnRuntimeUpgrade for PrefixMigration<T> {
     fn on_runtime_upgrade() -> Weight {
         if StorageVersion::get::<Pallet<T>>() != StorageVersion::new(0) {
-            return Weight::zero();
+            info!(
+                target: LOG_TARGET,
+                "Skipping migrations from STORAGE_VERSION 0 to 1 for pallet committee management"
+            );
+            return T::DbWeight::get().reads(1);
         };
 
         let pallet_name = Pallet::<T>::name();
@@ -89,7 +93,7 @@ impl<T: Config> OnRuntimeUpgrade for PrefixMigration<T> {
         move_storage_from_pallet(prefix, OLD_PREFIX.as_bytes(), pallet_name.as_bytes());
         info!(target: LOG_TARGET, "Migrated Banned");
 
-        StorageVersion::new(0).put::<Pallet<T>>();
+        StorageVersion::new(1).put::<Pallet<T>>();
 
         <T as frame_system::Config>::BlockWeights::get().max_block
     }

--- a/pallets/elections/src/migration.rs
+++ b/pallets/elections/src/migration.rs
@@ -20,6 +20,14 @@ pub mod v4 {
 
     impl<T: Config> OnRuntimeUpgrade for Migration<T> {
         fn on_runtime_upgrade() -> Weight {
+            if StorageVersion::get::<Pallet<T>>() != StorageVersion::new(3) {
+                log::info!(
+                    target: LOG_TARGET,
+                    "Skipping migrations from STORAGE_VERSION 3 to 4 for pallet elections"
+                );
+                return T::DbWeight::get().reads(1);
+            };
+
             log::info!(
                 target: LOG_TARGET,
                 "Running migration from STORAGE_VERSION 3 to 4 for pallet elections"
@@ -62,6 +70,14 @@ pub mod v5 {
 
     impl<T: Config> OnRuntimeUpgrade for Migration<T> {
         fn on_runtime_upgrade() -> Weight {
+            if StorageVersion::get::<Pallet<T>>() != StorageVersion::new(4) {
+                log::info!(
+                    target: LOG_TARGET,
+                    "Skipping migrations from STORAGE_VERSION 4 to 5 for pallet elections"
+                );
+                return T::DbWeight::get().reads(1);
+            };
+
             log::info!(
                 target: LOG_TARGET,
                 "Running migration from STORAGE_VERSION 4 to 5 for pallet elections"


### PR DESCRIPTION
# Description

In order to have the same version of the code for Testnet and Mainnet, we need to bump the storage version for pallet committee management to 1, and add if-conditions in pallet elections for storage versions This makes it possible to upload this runtime from 62 to 64, and also upload 64 alone on itself. In both cases, migrations would be run only once.

We need to bump spec_version since runtime that is in `r-11.1-rc1` has 63, so we can't upload this without spec_version bump as it will cause wasm/native conflict.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue
