### PR TITLE
A0-2609: RPC: use `sp_core::Bytes` instead of `Vec<u8>`

### DIFF
--- a/aleph-client/src/pallets/aleph.rs
+++ b/aleph-client/src/pallets/aleph.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     connections::TxInfo,
     pallet_aleph::pallet::Call::schedule_finality_version_change,
+    sp_core::Bytes,
     AccountId, AlephKeyPair, BlockHash, BlockNumber,
     Call::Aleph,
     ConnectionApi, Pair, RootConnection, SessionIndex, SudoCall, TxStatus, Version,
@@ -131,7 +132,7 @@ impl<C: ConnectionApi> AlephRpc for C {
     ) -> anyhow::Result<()> {
         let method = "alephNode_emergencyFinalize";
         let signature = key_pair.sign(&hash.encode());
-        let raw_signature: &[u8] = signature.as_ref();
+        let raw_signature = Bytes::from(signature.0.to_vec());
         let params = rpc_params![raw_signature, hash, number];
 
         let _: () = self.rpc_call_no_return(method.to_string(), params).await?;

--- a/bin/finalizer/Cargo.lock
+++ b/bin/finalizer/Cargo.lock
@@ -1384,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "ink_env"
-version = "4.1.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639a8172a9911fc6f7384623d25ff6f0834d48b16f5c21e4b0eb656b3de1f877"
+checksum = "a41c6a3f4e740e27449f805ed47f536a35fb254ebcd03d2480014589331cda3e"
 dependencies = [
  "arrayref",
  "blake2",
@@ -1403,7 +1403,7 @@ dependencies = [
  "paste",
  "rlibc",
  "scale-info",
- "secp256k1 0.27.0",
+ "secp256k1 0.26.0",
  "sha2 0.10.6",
  "sha3",
  "static_assertions",
@@ -1411,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "ink_metadata"
-version = "4.2.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af082b4c2eb246d27b358411ef950811f851c1099aa507ba4bcdd7214d40ccd"
+checksum = "5dfcfa666ada5729c7e4d3d986cd196365a2c469459fced4fa31dc6ad87c4d8f"
 dependencies = [
  "derive_more",
  "impl-serde",
@@ -1449,15 +1449,16 @@ dependencies = [
 
 [[package]]
 name = "ink_storage_traits"
-version = "4.2.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec58d70937c1e1490a00b84e2eb9a799f1a5331dd0e5cc68d550de1dbf6a8f4"
+checksum = "8c90e11b60233ae5ab877854739da2c380a337cb31b3900cb50328821c0381b6"
 dependencies = [
  "ink_metadata",
  "ink_prelude",
  "ink_primitives",
  "parity-scale-codec",
  "scale-info",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2680,6 +2681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
 dependencies = [
  "secp256k1-sys 0.6.1",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
+dependencies = [
+ "secp256k1-sys 0.8.1",
 ]
 
 [[package]]
@@ -4139,7 +4149,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/bin/node/src/aleph_node_rpc.rs
+++ b/bin/node/src/aleph_node_rpc.rs
@@ -5,6 +5,7 @@ use jsonrpsee::{
     proc_macros::rpc,
     types::error::{CallError, ErrorObject},
 };
+use sp_core::Bytes;
 use sp_runtime::traits::Header;
 
 use crate::aleph_primitives::BlockNumber;
@@ -62,7 +63,7 @@ pub trait AlephNodeApi<Hash, Number> {
     #[method(name = "alephNode_emergencyFinalize")]
     fn aleph_node_emergency_finalize(
         &self,
-        justification: Vec<u8>,
+        justification: Bytes,
         hash: Hash,
         number: Number,
     ) -> RpcResult<()>;
@@ -101,12 +102,12 @@ where
 {
     fn aleph_node_emergency_finalize(
         &self,
-        justification: Vec<u8>,
+        justification: Bytes,
         hash: H::Hash,
         number: BlockNumber,
     ) -> RpcResult<()> {
         let justification: AlephJustification =
-            AlephJustification::EmergencySignature(justification.try_into().map_err(|_| {
+            AlephJustification::EmergencySignature(justification.0.try_into().map_err(|_| {
                 Error::MalformattedJustificationArg(
                     "Provided justification cannot be converted into correct type".into(),
                 )

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -1843,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "ink_env"
-version = "4.1.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639a8172a9911fc6f7384623d25ff6f0834d48b16f5c21e4b0eb656b3de1f877"
+checksum = "a41c6a3f4e740e27449f805ed47f536a35fb254ebcd03d2480014589331cda3e"
 dependencies = [
  "arrayref",
  "blake2",
@@ -1862,7 +1862,7 @@ dependencies = [
  "paste",
  "rlibc",
  "scale-info",
- "secp256k1 0.27.0",
+ "secp256k1 0.26.0",
  "sha2 0.10.6",
  "sha3",
  "static_assertions",
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "ink_metadata"
-version = "4.2.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af082b4c2eb246d27b358411ef950811f851c1099aa507ba4bcdd7214d40ccd"
+checksum = "5dfcfa666ada5729c7e4d3d986cd196365a2c469459fced4fa31dc6ad87c4d8f"
 dependencies = [
  "derive_more",
  "impl-serde",
@@ -1908,15 +1908,16 @@ dependencies = [
 
 [[package]]
 name = "ink_storage_traits"
-version = "4.2.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec58d70937c1e1490a00b84e2eb9a799f1a5331dd0e5cc68d550de1dbf6a8f4"
+checksum = "8c90e11b60233ae5ab877854739da2c380a337cb31b3900cb50328821c0381b6"
 dependencies = [
  "ink_metadata",
  "ink_prelude",
  "ink_primitives",
  "parity-scale-codec",
  "scale-info",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3543,6 +3544,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
 dependencies = [
  "secp256k1-sys 0.6.1",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
+dependencies = [
+ "secp256k1-sys 0.8.1",
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

### What is happening?
When an RPC arg is `Vec<u8>` it is incorrectly decoded by PolkadotJS UI.

### What should be happening?
We should use `sp_core::Bytes` as every Substrate RPC endpoint (see e.g. `queryFeeDetails`).

### Is it backwards compatible?
No. Thus I changed the justification encoding part in `aleph_client`, on which `finalizer` and `cliain` depend on. 

Locally tested:
 1. `./scripts/run_nodes.sh`
 1. `cargo run -- set-emergency-finalizer --finalizer-seed //Alice` in `cliain`
 1. wait for a session/two
 1. kill two nodes
 1. in `finalizer`: `cargo run --release try-finalize --how-many 10`
 1. in `cliain`: `cargo run --release -- --node ws://127.0.0.1:9944 finalize --hash 0x0525531b89b949f999d5822b37b55837a323854205cc3780e8c9695a9d796ff4 --block 61  --finalizer-seed //Alice`
 1. in UI (to be published):
![image](https://github.com/Cardinal-Cryptography/aleph-node/assets/27450471/90e6f281-b722-459b-acc6-939051ab6c0b)


## Type of change

- Bug fix (non-breaking change which fixes an issue)
