### PR TITLE
A0-2541: Manually check dependat job statuses in check e2e job completion

### DIFF
--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -58,8 +58,11 @@ jobs:
   check-e2e-test-suite-completion:
     needs: [run-e2e-tests]
     name: Check e2e test suite completion
+    if: always()
     runs-on: ubuntu-20.04
     steps:
       - name: All e2e tests completed
         run: |
-         echo "All e2e tests completed."
+          # due to the fact GitHub treats skipped jobs as success, and when any of dependant
+          # jobs fail, this check will be skipped, we need to check status manually
+          jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'


### PR DESCRIPTION
# Description

Surprisingly GitHub treats skipped jobs status as success, despite those skipped jobs are Required Checks. With the introduction of Merge Queues, this has a danger to sneak in a change that fails one of e2e tests. See all compiled info in this [answer](https://github.com/orgs/community/discussions/46757#discussioncomment-5831752)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

* Tested this change in testing repo https://github.com/gen64/repo-for-testing/pull/28/files

