### PR TITLE
A0-2629: Add 'large' label to self-hosted runners in workflows

### DIFF
--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -103,9 +103,9 @@ runs:
           exit 1
         fi
         if [[
-          "${{ inputs.expiration-hours }}" != "" && \
-          ! "${{ inputs.expiration-hours }}" =~ ^[0-9]{1,6}h$ && \
-          "${{ inputs.expiration-hours }}" != "never"
+          "${{ inputs.expiration }}" != "" && \
+          ! "${{ inputs.expiration }}" =~ ^[0-9]{1,6}h$ && \
+          "${{ inputs.expiration }}" != "never"
         ]]
         then
           echo "!!! Invalid expiration"

--- a/.github/workflows/_build-liminal-node.yml
+++ b/.github/workflows/_build-liminal-node.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Build liminal node
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_build-liminal-node.yml
+++ b/.github/workflows/_build-liminal-node.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Build liminal node
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_build-production-node-and-e2e-client-image.yml
+++ b/.github/workflows/_build-production-node-and-e2e-client-image.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-production-node-image-and-e2e-client-image:
     name: Build production node docker image and e2e client image
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_build-production-node-and-e2e-client-image.yml
+++ b/.github/workflows/_build-production-node-and-e2e-client-image.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-production-node-image-and-e2e-client-image:
     name: Build production node docker image and e2e client image
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_build-production-node-and-runtime.yml
+++ b/.github/workflows/_build-production-node-and-runtime.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Build production node and runtime
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_build-production-node-and-runtime.yml
+++ b/.github/workflows/_build-production-node-and-runtime.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Build production node and runtime
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_build-test-node-and-e2e-client-image.yml
+++ b/.github/workflows/_build-test-node-and-e2e-client-image.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-test-node-image-and-e2e-client-image:
     name: Build test node docker image and e2e client image
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_build-test-node-and-e2e-client-image.yml
+++ b/.github/workflows/_build-test-node-and-e2e-client-image.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-test-node-image-and-e2e-client-image:
     name: Build test node docker image and e2e client image
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_build-test-node-and-runtime.yml
+++ b/.github/workflows/_build-test-node-and-runtime.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Build test node and runtime
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_build-test-node-and-runtime.yml
+++ b/.github/workflows/_build-test-node-and-runtime.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Build test node and runtime
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_check-excluded-packages.yml
+++ b/.github/workflows/_check-excluded-packages.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   main:
     name: Check excluded packages
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_check-excluded-packages.yml
+++ b/.github/workflows/_check-excluded-packages.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   main:
     name: Check excluded packages
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_check-runtime-determimism.yml
+++ b/.github/workflows/_check-runtime-determimism.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Check runtime build determinism
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_check-runtime-determimism.yml
+++ b/.github/workflows/_check-runtime-determimism.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Check runtime build determinism
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_create-featurenet.yml
+++ b/.github/workflows/_create-featurenet.yml
@@ -38,7 +38,7 @@ jobs:
   create-featurenet:
     needs: [check-vars-and-secrets]
     name: Create featurenet based on the PR
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
@@ -100,7 +100,7 @@ jobs:
   update-featurenet-image:
     needs: [push-pr-image, create-featurenet]
     name: Update featurenet to the latest PR aleph-node image
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/_create-featurenet.yml
+++ b/.github/workflows/_create-featurenet.yml
@@ -38,7 +38,7 @@ jobs:
   create-featurenet:
     needs: [check-vars-and-secrets]
     name: Create featurenet based on the PR
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
@@ -100,7 +100,7 @@ jobs:
   update-featurenet-image:
     needs: [push-pr-image, create-featurenet]
     name: Update featurenet to the latest PR aleph-node image
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/_delete-featurenet.yml
+++ b/.github/workflows/_delete-featurenet.yml
@@ -13,7 +13,7 @@ jobs:
   delete-featurenet:
     needs: [check-vars-and-secrets]
     name: Delete featurenet
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/_delete-featurenet.yml
+++ b/.github/workflows/_delete-featurenet.yml
@@ -13,7 +13,7 @@ jobs:
   delete-featurenet:
     needs: [check-vars-and-secrets]
     name: Delete featurenet
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/_unit-tests-and-static-checks.yml
+++ b/.github/workflows/_unit-tests-and-static-checks.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   main:
     name: Run check, test and lints
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_unit-tests-and-static-checks.yml
+++ b/.github/workflows/_unit-tests-and-static-checks.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   main:
     name: Run check, test and lints
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/build-and-push-cliain.yml
+++ b/.github/workflows/build-and-push-cliain.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-image:
     name: Build binary
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/build-and-push-cliain.yml
+++ b/.github/workflows/build-and-push-cliain.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-image:
     name: Build binary
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   main:
     name: Build docs
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     steps:
       - name: GIT | Checkout source code
         uses: actions/checkout@v3

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   main:
     name: Build docs
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: GIT | Checkout source code
         uses: actions/checkout@v3

--- a/.github/workflows/build-send-postsync-hook-runtime-image.yml
+++ b/.github/workflows/build-send-postsync-hook-runtime-image.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     needs: [check-vars-and-secrets]
     name: Save cliain binary as an artifact
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/build-send-postsync-hook-runtime-image.yml
+++ b/.github/workflows/build-send-postsync-hook-runtime-image.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     needs: [check-vars-and-secrets]
     name: Save cliain binary as an artifact
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -69,7 +69,7 @@ jobs:
       (github.event_name == 'pull_request' &&
        github.event.action == 'labeled' &&
        github.event.label.name == '[AZERO] DEPLOY-CONTRACTS')
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -69,7 +69,7 @@ jobs:
       (github.event_name == 'pull_request' &&
        github.event.action == 'labeled' &&
        github.event.label.name == '[AZERO] DEPLOY-CONTRACTS')
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/on-main-branch-commit-run-button-e2e.yml
+++ b/.github/workflows/on-main-branch-commit-run-button-e2e.yml
@@ -34,7 +34,7 @@ jobs:
   run-e2e-button-contracts-tests:
     needs: [build-test-node-image-and-e2e-client-image]
     name: Run e2e button game contract tests
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/.github/workflows/on-main-branch-commit-run-button-e2e.yml
+++ b/.github/workflows/on-main-branch-commit-run-button-e2e.yml
@@ -34,7 +34,7 @@ jobs:
   run-e2e-button-contracts-tests:
     needs: [build-test-node-image-and-e2e-client-image]
     name: Run e2e button game contract tests
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -34,7 +34,7 @@ jobs:
   create-updatenet:
     needs: [check-vars-and-secrets]
     name: Create updatenet
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -34,7 +34,7 @@ jobs:
   create-updatenet:
     needs: [check-vars-and-secrets]
     name: Create updatenet
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:

--- a/.github/workflows/updatenet-delete.yml
+++ b/.github/workflows/updatenet-delete.yml
@@ -18,7 +18,7 @@ jobs:
   delete-updatenet:
     needs: [check-vars-and-secrets]
     name: Delete updatenet
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     steps:
       - name: Validate inputs
         shell: bash

--- a/.github/workflows/updatenet-delete.yml
+++ b/.github/workflows/updatenet-delete.yml
@@ -18,7 +18,7 @@ jobs:
   delete-updatenet:
     needs: [check-vars-and-secrets]
     name: Delete updatenet
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Validate inputs
         shell: bash

--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -26,7 +26,7 @@ jobs:
   update-updatenet:
     needs: [check-vars-and-secrets]
     name: Update updatenet
-    runs-on: self-hosted
+    runs-on: [self-hosted,Linux,X64,large]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:

--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -26,7 +26,7 @@ jobs:
   update-updatenet:
     needs: [check-vars-and-secrets]
     name: Update updatenet
-    runs-on: [self-hosted,Linux,X64,large]
+    runs-on: [self-hosted, Linux, X64, large]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:


### PR DESCRIPTION
# Description

Change labels for `runs-on` in the workflows from `self-hosted` to `self-hosted, Linux, X64, large` to be more selective.  We are planning to introduce `small` runners as well.
