### PR TITLE
A0-2624: Lower log levels of verification failures

### DIFF
--- a/finality-aleph/src/sync/service.rs
+++ b/finality-aleph/src/sync/service.rs
@@ -188,7 +188,7 @@ where
                 ),
                 e => warn!(
                     target: LOG_TARGET,
-                    "Error handling sync state from {:?}: {}.", peer, e
+                    "Failed to handle sync state from {:?}: {}.", peer, e
                 ),
             },
         }
@@ -223,7 +223,7 @@ where
                     e => {
                         warn!(
                             target: LOG_TARGET,
-                            "Error while handling justification from {:?}: {}.",
+                            "Failed to handle justification from {:?}: {}.",
                             peer.map_or("user".to_string(), |id| format!("{:?}", id)),
                             e
                         );

--- a/finality-aleph/src/sync/service.rs
+++ b/finality-aleph/src/sync/service.rs
@@ -181,10 +181,16 @@ where
         );
         match self.handler.handle_state(state, peer.clone()) {
             Ok(action) => self.perform_sync_action(action, peer),
-            Err(e) => warn!(
-                target: LOG_TARGET,
-                "Error handling sync state from {:?}: {}.", peer, e
-            ),
+            Err(e) => match e {
+                HandlerError::Verifier(e) => debug!(
+                    target: LOG_TARGET,
+                    "Could not verify justification in sync state from {:?}: {}.", peer, e
+                ),
+                e => warn!(
+                    target: LOG_TARGET,
+                    "Error handling sync state from {:?}: {}.", peer, e
+                ),
+            },
         }
     }
 
@@ -204,15 +210,26 @@ where
                 .handle_justification(justification, peer.clone())
             {
                 Ok(maybe_id) => maybe_id,
-                Err(e) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "Error while handling justification from {:?}: {}.",
-                        peer.map_or("user".to_string(), |id| format!("{:?}", id)),
-                        e
-                    );
-                    return;
-                }
+                Err(e) => match e {
+                    HandlerError::Verifier(e) => {
+                        debug!(
+                            target: LOG_TARGET,
+                            "Could not verify justification from {:?}: {}.",
+                            peer.map_or("user".to_string(), |id| format!("{:?}", id)),
+                            e
+                        );
+                        return;
+                    }
+                    e => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Error while handling justification from {:?}: {}.",
+                            peer.map_or("user".to_string(), |id| format!("{:?}", id)),
+                            e
+                        );
+                        return;
+                    }
+                },
             };
             if let Some(block_id) = maybe_block_id {
                 self.request_highest_justified(block_id);
@@ -345,9 +362,9 @@ where
                             }
                         },
                         Err(e) => error!(
-                                        target: LOG_TARGET,
-                                        "Error when retrieving Handler state: {}.", e
-                                    ),
+                            target: LOG_TARGET,
+                            "Error when retrieving Handler state: {}.", e
+                        ),
                     }
                 }
             }


### PR DESCRIPTION
# Description

We expect verification of justifications to sometimes fail, even if everything is going well. In practice this is most pronounced when synchronizing old blocks, but in general it shouldn't be an error. This PR treats verification errors separately for the purposes of logging.

## Type of change

# Checklist: