### PR TITLE
A0-2671: Add try-state hook to the elections pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -2647,7 +2647,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2670,7 +2670,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-support-procedural 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2742,7 +2742,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-system 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -2799,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "futures",
  "log",
@@ -2844,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "bitflags",
  "environmental",
@@ -2892,7 +2892,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2919,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support-procedural-tools-derive 3.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "proc-macro-crate",
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2968,7 +2968,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "log",
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "sp-api 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -2995,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "parity-scale-codec",
@@ -5549,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-system 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5565,7 +5565,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-system 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5579,7 +5579,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-benchmarking",
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5618,7 +5618,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-benchmarking",
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5633,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-system 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5652,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -5722,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "bitflags",
  "environmental",
@@ -5763,7 +5763,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "7.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -5786,7 +5786,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5819,7 +5819,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5835,7 +5835,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-system 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5849,7 +5849,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-benchmarking",
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5866,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-benchmarking",
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5882,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-system 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5899,7 +5899,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-system 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-system 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5947,7 +5947,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5969,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-system 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -5983,7 +5983,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-benchmarking",
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -6001,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "frame-system 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -6017,7 +6017,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6033,7 +6033,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6045,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-benchmarking",
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -6062,7 +6062,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-benchmarking",
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-benchmarking",
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "log",
  "sp-core 7.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -7273,7 +7273,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -7330,7 +7330,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7341,7 +7341,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -7381,7 +7381,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "fnv",
  "futures",
@@ -7407,7 +7407,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "hash-db 0.16.0",
  "kvdb",
@@ -7433,7 +7433,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "futures",
@@ -7458,7 +7458,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "futures",
@@ -7487,7 +7487,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "futures",
@@ -7510,7 +7510,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -7534,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -7547,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "log",
  "sc-allocator",
@@ -7560,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7578,7 +7578,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "ansi_term",
  "futures",
@@ -7594,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -7609,7 +7609,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -7653,7 +7653,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "cid",
  "futures",
@@ -7673,7 +7673,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -7701,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "futures",
@@ -7723,7 +7723,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -7757,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "futures",
@@ -7777,7 +7777,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -7808,7 +7808,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "futures",
  "libp2p 0.50.1",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -7830,7 +7830,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -7860,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7879,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "futures",
@@ -7920,7 +7920,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "directories",
@@ -7986,7 +7986,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "clap",
  "fs4",
@@ -8013,7 +8013,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "futures",
  "libc",
@@ -8032,7 +8032,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "chrono",
  "futures",
@@ -8051,7 +8051,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "ansi_term",
  "atty",
@@ -8082,7 +8082,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8093,7 +8093,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "futures",
@@ -8120,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "futures",
@@ -8134,7 +8134,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-channel",
  "futures",
@@ -8616,7 +8616,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -8646,7 +8646,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "Inflector",
  "blake2",
@@ -8672,7 +8672,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8698,7 +8698,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "sp-api 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -8724,7 +8724,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "futures",
  "log",
@@ -8742,7 +8742,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "futures",
@@ -8757,7 +8757,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8775,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "merlin 2.0.1",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -8817,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8847,7 +8847,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8881,7 +8881,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "base58",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8974,7 +8974,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -8993,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9014,7 +9014,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9036,7 +9036,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9067,7 +9067,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "bytes",
  "ed25519",
@@ -9092,7 +9092,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "lazy_static",
  "sp-core 7.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "futures",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "thiserror",
  "zstd",
@@ -9129,7 +9129,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9161,7 +9161,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "sp-api 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "sp-core 7.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9181,7 +9181,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9211,7 +9211,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9251,7 +9251,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9281,7 +9281,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -9293,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9331,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -9356,7 +9356,7 @@ source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=alep
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 
 [[package]]
 name = "sp-storage"
@@ -9372,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9385,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -9411,7 +9411,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "sp-std 5.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -9423,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "sp-api 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
  "sp-runtime 7.0.0 (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -9432,7 +9432,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "log",
@@ -9448,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "ahash 0.8.3",
  "hash-db 0.16.0",
@@ -9484,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9512,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -9533,7 +9533,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9713,7 +9713,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "platforms 2.0.0",
 ]
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -9740,7 +9740,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "hyper",
  "log",
@@ -9752,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -9765,7 +9765,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -9791,7 +9791,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "cfg-if",
  "frame-support 4.0.0-dev (git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41)",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -9854,7 +9854,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -10421,7 +10421,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#a949d032e6d7436426b73ae8fc5e112cebc6dfa2"
+source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.41#22a2c78786d331d8be3b5b5cf7c9dc3c3c7762d5"
 dependencies = [
  "async-trait",
  "clap",
@@ -10498,7 +10498,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/pallets/elections/src/lib.rs
+++ b/pallets/elections/src/lib.rs
@@ -174,6 +174,27 @@ pub mod pallet {
         }
     }
 
+    #[pallet::hooks]
+    impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
+        #[cfg(feature = "try-runtime")]
+        fn try_state(_n: T::BlockNumber) -> Result<(), &'static str> {
+            let current_validators = CurrentEraValidators::<T>::get();
+            Self::ensure_validators_are_ok(
+                current_validators.reserved,
+                current_validators.non_reserved,
+                CommitteeSize::<T>::get(),
+            )?;
+
+            Self::ensure_validators_are_ok(
+                NextEraReservedValidators::<T>::get(),
+                NextEraNonReservedValidators::<T>::get(),
+                NextEraCommitteeSize::<T>::get(),
+            )?;
+
+            Ok(())
+        }
+    }
+
     #[pallet::genesis_config]
     pub struct GenesisConfig<T: Config> {
         pub non_reserved_validators: Vec<T::AccountId>,


### PR DESCRIPTION
# Description

This is the first PR introducing `try-state` hook to our pallets. Hopefully, more to come.

## Why?

`try-state` is a similar concept to `try-runtime`. Basically, we can put all (storage) invariant checks into a hook and trigger them from anywhere we need. By default, they can be called from most of `try-runtime` commands, like `follow-chain`. More info: https://forum.polkadot.network/t/testing-complex-frame-pallets-discussion-tools/356#try-runtime-follow-chain-trystate-4 

## Local testing

I have broken some of the checks in `ensure_validators_are_ok` function and then:
```shell
$ cargo build --release --features try-runtime
$ ./scripts/run_nodes.sh -b false
$ ./target/release/aleph-node try-runtime --runtime existing --chain /tmp/chainspec.json follow-chain --uri ws://localhost:9944 --keep-connection
```

**Note**: https://github.com/Cardinal-Cryptography/substrate/pull/39 is required for this scenario.

## Type of change

- New feature (non-breaking change which adds functionality)