### PR TITLE
A0-2680: Rename `session_committee` runtime API

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "3.4.0"
+version = "3.4.1"
 edition = "2021"
 authors = ["Cardinal"]
 documentation = "https://docs.rs/aleph_client"

--- a/aleph-client/src/pallets/committee_management.rs
+++ b/aleph-client/src/pallets/committee_management.rs
@@ -181,7 +181,7 @@ impl<C: ConnectionApi + AsConnection> CommitteeManagementApi for C {
         at: Option<BlockHash>,
     ) -> anyhow::Result<Result<SessionCommittee<AccountId>, SessionValidatorError>> {
         let method = "state_call";
-        let api_method = "AlephSessionApi_session_committee";
+        let api_method = "AlephSessionApi_predict_session_committee";
         let params = rpc_params![api_method, Bytes(session.encode()), at];
 
         self.rpc_call(method.to_string(), params).await

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -997,10 +997,10 @@ impl_runtime_apis! {
             Aleph::next_session_finality_version()
         }
 
-        fn session_committee(
+        fn predict_session_committee(
             session: SessionIndex,
         ) -> Result<SessionCommittee<AccountId>, SessionValidatorError> {
-            CommitteeManagement::session_committee_for_session(session)
+            CommitteeManagement::predict_session_committee_for_session(session)
         }
     }
 

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/pallets/committee-management/src/impls.rs
+++ b/pallets/committee-management/src/impls.rs
@@ -66,7 +66,8 @@ fn shuffle_order_for_session<T>(
     validators.shuffle(&mut rng);
 }
 
-/// choose all items from `reserved` if present and extend it by #`non_reserved_seats` from non_reserved if present.
+/// Choose all items from `reserved` if present and extend it by #`non_reserved_seats` from
+/// `non_reserved` if present.
 fn choose_finality_committee<T: Clone>(
     reserved: &Option<Vec<T>>,
     non_reserved: &Option<Vec<T>>,
@@ -432,27 +433,18 @@ impl<T: Config> Pallet<T> {
     }
 
     /// Calculates committee for the given session.
-    /// If the current era `E` starts in the session `a`, and ends in session `b` then from session `a-1`
-    /// to session `b-1` this function can answer question who will be in the committee in the era `E`.
-    /// In the last session of the era `E` this can be used to determine all of the sessions in the
-    /// era `E+1`.
-    pub fn session_committee_for_session(
+    ///
+    /// `session` must be within the current era.
+    pub fn predict_session_committee_for_session(
         session: SessionIndex,
     ) -> Result<SessionCommittee<T::AccountId>, SessionValidatorError> {
-        let ce = match T::EraInfoProvider::current_era() {
-            Some(ce) => ce,
-            _ => return Err(SessionValidatorError::Other("No current era".encode())),
-        };
+        let ce = T::EraInfoProvider::current_era()
+            .ok_or_else(|| SessionValidatorError::Other("No current era".encode()))?;
 
-        let current_starting_index = match T::EraInfoProvider::era_start_session_index(ce) {
-            Some(csi) => csi,
-            // Shouldn't happen
-            None => {
-                return Err(SessionValidatorError::Other(
-                    "No known starting session for current era".encode(),
-                ))
-            }
-        };
+        let current_starting_index =
+            T::EraInfoProvider::era_start_session_index(ce).ok_or_else(|| {
+                SessionValidatorError::Other("No known starting session for current era".encode())
+            })?;
         let planned_era_end = current_starting_index + T::EraInfoProvider::sessions_per_era() - 1;
 
         if session < current_starting_index || session > planned_era_end {

--- a/pallets/committee-management/src/impls.rs
+++ b/pallets/committee-management/src/impls.rs
@@ -432,9 +432,13 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    /// Calculates committee for the given session.
+    /// Predict finality committee and block producers for the given session. `session` must be
+    /// within the current era (current, in the staking context).
     ///
-    /// `session` must be within the current era.
+    /// If the active era `E` starts in the session `a`, and ends in session `b` then from session
+    /// `a` to session `b-1` this function can answer question who will be in the committee in the
+    /// era `E`. In the last session of the era `E` (`b`) this can be used to determine all of the
+    /// sessions in the era `E+1`.
     pub fn predict_session_committee_for_session(
         session: SessionIndex,
     ) -> Result<SessionCommittee<T::AccountId>, SessionValidatorError> {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -274,7 +274,9 @@ sp_api::decl_runtime_apis! {
         fn millisecs_per_block() -> u64;
         fn finality_version() -> Version;
         fn next_session_finality_version() -> Version;
-        fn session_committee(
+        /// Predict finality committee and block producers for the given session. The session must
+        /// be within the current era.
+        fn predict_session_committee(
             session: SessionIndex
         ) -> Result<SessionCommittee<AccountId>, SessionValidatorError>;
     }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -274,8 +274,13 @@ sp_api::decl_runtime_apis! {
         fn millisecs_per_block() -> u64;
         fn finality_version() -> Version;
         fn next_session_finality_version() -> Version;
-        /// Predict finality committee and block producers for the given session. The session must
-        /// be within the current era.
+        /// Predict finality committee and block producers for the given session. `session` must be
+        /// within the current era (current, in the staking context).
+        ///
+        /// If the active era `E` starts in the session `a`, and ends in session `b` then from
+        /// session `a` to session `b-1` this function can answer question who will be in the
+        /// committee in the era `E`. In the last session of the era `E` (`b`) this can be used to
+        /// determine all of the sessions in the era `E+1`.
         fn predict_session_committee(
             session: SessionIndex
         ) -> Result<SessionCommittee<AccountId>, SessionValidatorError>;


### PR DESCRIPTION
# Description

After recent misunderstanding, we decided to rename `session_committee` runtime API to `predict_session_committee`. Also, the documentation of both runtime API endpoint and the pallet implementation were added/updated.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- I have made neccessary updates to the Infrastructure
- I have made corresponding changes to the existing documentation
- I have created new documentation