### PR TITLE
A0-2346: fix for the high-latency e2e-test

### DIFF
--- a/scripts/synthetic-network/build_synthetic-network.sh
+++ b/scripts/synthetic-network/build_synthetic-network.sh
@@ -16,6 +16,7 @@ cd scripts/synthetic-network/vendor/synthetic-network
 
 # this is a dirty-fix for the outdated version of node image used by the
 # synthetic-network's Dockerfile
+# TODO remove it after this push-request is merged into synthetic-network: https://github.com/daily-co/synthetic-network/pull/14
 docker pull node:20.3.0
 docker tag node:20.3.0 node:12.20.2
 

--- a/scripts/synthetic-network/build_synthetic-network.sh
+++ b/scripts/synthetic-network/build_synthetic-network.sh
@@ -6,20 +6,28 @@ source ./scripts/common.sh
 
 UPDATE=${UPDATE:-true}
 
+git submodule update --init
 if [[ "$UPDATE" = true ]]; then
-    git submodule init
-    git submodule update
+    git submodule update --remote
 fi
 
 pushd .
 cd scripts/synthetic-network/vendor/synthetic-network
 
+# this is a dirty-fix for the outdated version of node image used by the
+# synthetic-network's Dockerfile
+docker pull node:20.3.0
+docker tag node:20.3.0 node:12.20.2
+
 log "building base docker image for synthetic-network with support for synthetic-network"
-docker build -t syntheticnet .
+docker build --tag syntheticnet --file Dockerfile .
 
 popd
 
 log "building docker image for aleph-node that supports synthetic-network"
 docker build -t aleph-node:syntheticnet -f docker/Dockerfile.synthetic_network .
+
+# clean previously tagged image
+docker image rm node:12.20.2
 
 exit 0

--- a/scripts/synthetic-network/run_consensus_synthetic-network.sh
+++ b/scripts/synthetic-network/run_consensus_synthetic-network.sh
@@ -15,16 +15,17 @@ Usage:
   IMPORTANT: this script requires aleph-node:latest docker image.
     --no-build-image
         skip docker image build
-    --no-update
-        skip git-submodule update for the synthetic-network repository
+    --update
+        update git-submodule for the synthetic-network repository
 EOF
     exit 0
 }
 
 function build_test_image() {
     local path=$1
+    local update=$2
 
-    ${path}/build_synthetic-network.sh
+    UPDATE=${update} ${path}/build_synthetic-network.sh
 }
 
 while [[ $# -gt 0 ]]; do
@@ -33,8 +34,8 @@ while [[ $# -gt 0 ]]; do
             BUILD_IMAGE=false
             shift
             ;;
-        --no-update)
-            UPDATE=false
+        --update)
+            UPDATE=true
             shift
             ;;
         --help)
@@ -48,17 +49,12 @@ while [[ $# -gt 0 ]]; do
 done
 
 BUILD_IMAGE=${BUILD_IMAGE:-true}
-UPDATE=${UPDATE:-true}
-
-if [[ "$UPDATE" = true ]]; then
-    git submodule init
-    git submodule update
-fi
+UPDATE=${UPDATE:-false}
 
 if [[ "$BUILD_IMAGE" = true ]]; then
     log "building custom docker image for synthetic-network tests"
     path=$(dirname $0)
-    build_test_image $path
+    build_test_image $path $UPDATE
 fi
 
 log "running synthetic-network"


### PR DESCRIPTION
# Description
Fixes a bug within the synthetic-network e2e-test for aleph-node - referenced too old docker image.

Details:
- dirty-hack (docker tag...) for the no longer supported node:12.20.2 docker base image
- fixed `git submodule` update procedure for synthetic-network

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Important
How to test if synthetic-network is ok?
1. Build docker image for `aleph-node:latest`: `docker build -t aleph-node:latest`.
2. Call the synthetic-network build+run script: `./scripts/synthetic-network/run_consensus_synthetic-network.sh`.
3. Open your webrowser (tested on chromium) at [http://localhost:3000/control.html](http://localhost:3000/control.html) and move some of the sliders.
4. Try to observe results of your actions from point 3.: `docker logs Node0` (e.g. set bit-rate to 0).

How to check if e2e-tests for high-latency are ok?
1. Execute points 1. and 2. from previous paragraph.
2. Build docker image for e2e-tests:
```
cargo test --no-run --release --message-format=json --locked
# copy created binary to e2e-tests/target/release/
# build docker image for e2e-tests
cd e2e-tests
docker build --tag aleph-e2e-client:latest -f Dockerfile .
# run the test
cd ..
./.github/scripts/run_e2e_test.sh -t high_out_latency_for_all -m 5
```