### PR TITLE
A0-2692: fix for nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@
 , runTests ? false
 # forces naersk (helper tool for building rust projects under nix) to build in a single derivation, instead default way that uses deps and project derivations
 # it is used for building aleph-runtime (we don't want its dependencies to be build separately for a non-WASM architecture)
-, singleStep ? false
+, singleStep ? true
 # passed to rustc by cargo - it allows us to set the list of supported cpu features
 # we can use for example `-C target-cpu=native` which should produce a binary that is significantly faster than the one produced using `generic`
 # `generic` is the default `target-cpu` provided by cargo

--- a/default.nix
+++ b/default.nix
@@ -140,7 +140,8 @@ with nixpkgs; naersk.buildPackage rec {
   postConfigure = ''
       ${nixpkgs.lib.optionalString providedCargoHome
          ''
-           export CARGO_HOME=${cargoHome}
+           cp -r ${cargoHome} .cargo_home
+           export CARGO_HOME=.cargo_home
          ''
        }
   '';

--- a/default.nix
+++ b/default.nix
@@ -12,6 +12,9 @@
 , runTests ? false
 # forces naersk (helper tool for building rust projects under nix) to build in a single derivation, instead default way that uses deps and project derivations
 # it is used for building aleph-runtime (we don't want its dependencies to be build separately for a non-WASM architecture)
+# FIXME two-step build fails. naersk attempts creating a type of a mock project that mainly consists of no-op main/lib.rs and a list cargo dependencies copied from
+# the processed project. Unfortunately, it somehow fails to process our workspace configuration and crashes while building some of our crates (even we don't use
+# them later in the main build procedure).
 , singleStep ? true
 # passed to rustc by cargo - it allows us to set the list of supported cpu features
 # we can use for example `-C target-cpu=native` which should produce a binary that is significantly faster than the one produced using `generic`
@@ -140,6 +143,10 @@ with nixpkgs; naersk.buildPackage rec {
   postConfigure = ''
       ${nixpkgs.lib.optionalString providedCargoHome
          ''
+           # Somehow cargo attempts to write inside of the CARGO_HOME folder,
+           # which previously was stored inside of the /nix folder and so it was
+           # read-only. This copies it into the build folder to avoid this
+           # issue.
            cp -r ${cargoHome} .cargo_home
            export CARGO_HOME=.cargo_home
          ''

--- a/nix/Dockerfile.build
+++ b/nix/Dockerfile.build
@@ -5,7 +5,7 @@ RUN nix-env -i patchelf && \
 
 COPY nix/ /node/nix-files/nix/
 RUN chmod +x /node/nix-files/nix/nix-build.sh
-COPY default.nix shell.nix rust-toolchain /node/nix-files/
+COPY default.nix shell.nix /node/nix-files/
 
 RUN nix-shell --pure --run 'echo installed all native pre-requisities' /node/nix-files/shell.nix
 

--- a/nix/nix-build.sh
+++ b/nix/nix-build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 NIX_FILE=${NIX_FILE:-"default.nix"}
 DYNAMIC_LINKER_PATH=${DYNAMIC_LINKER_PATH:-"/lib64/ld-linux-x86-64.so.2"}
 CRATES=${CRATES:-'{ "aleph-node" = []; }'}
-SINGLE_STEP=${SINGLE_STEP:-false}
+SINGLE_STEP=${SINGLE_STEP:-true}
 RUSTFLAGS=${RUSTFLAGS:-"-C target-cpu=generic"}
 CARGO_HOME=${CARGO_HOME:-"$(realpath ~/.cargo)"}
 PATH_TO_FIX=${PATH_TO_FIX:-""}
@@ -45,6 +45,6 @@ echo results copied
 if [ ! -z "${PATH_TO_FIX}" ] && [ -f ${PATH_TO_FIX} ]; then
     echo patching...
     chmod +w $PATH_TO_FIX
-    patchelf --set-interpreter $DYNAMIC_LINKER_PATH $PATH_TO_FIX
+    patchelf --set-interpreter $DYNAMIC_LINKER_PATH --set-rpath /lib/x86_64-linux-gnu/ $PATH_TO_FIX
 fi
 echo nix-build.sh finished

--- a/nix/rocksdb.nix
+++ b/nix/rocksdb.nix
@@ -3,7 +3,7 @@ let
   # all of these values can be modified using the override method of this derivation, e.g. `customRocksDb.override { useSnappy = true; }`
   defaultArgs = {
       # defines which version of rocksdb should be downloaded from github
-      version = "6.29.3";
+      version = "7.9.2";
       # allows to disable snappy compression
       useSnappy = false;
       # disables the verify_checksum feature of rocksdb (rocksdb provided by librocksdb-sys calls crc32 each time it reads from database)

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -18,7 +18,6 @@ rec {
       # this overlay allows us to use a version of the rust toolchain specified by the rust-toolchain.toml file
       rustOverlay =
         import (builtins.fetchTarball {
-          # link: https://github.com/mozilla/nixpkgs-mozilla/tree/f233fdc4ff6ba2ffeb1e3e3cd6d63bb1297d6996
           url = "https://github.com/mozilla/nixpkgs-mozilla/archive/f233fdc4ff6ba2ffeb1e3e3cd6d63bb1297d6996.tar.gz";
           sha256 = "1rzz03h0b38l5sg61rmfvzpbmbd5fn2jsi1ccvq22rb76s1nbh8i";
         });
@@ -26,7 +25,6 @@ rec {
       # pinned version of nix packages
       # main reason for not using here the newest available version at the time or writing is that this way we depend on glibc version 2.31 (Ubuntu 20.04 LTS)
       nixpkgs = import (builtins.fetchTarball {
-        # link: https://github.com/NixOS/nixpkgs/tree/20.09
         url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/20.09.tar.gz";
         sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";
       }) { overlays = [
@@ -44,7 +42,6 @@ rec {
   naersk =
     let
       naerskSrc = builtins.fetchTarball {
-        # link: https://github.com/nix-community/naersk/tree/d998160d6a076cfe8f9741e56aeec7e267e3e114
         url = "https://github.com/nix-community/naersk/archive/d998160d6a076cfe8f9741e56aeec7e267e3e114.tar.gz";
         sha256 = "1s10ygdsi17zjfiypwj7bhxys6yxws10hhq3ckfl3996v2q04d3v";
       };

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -44,9 +44,9 @@ rec {
   naersk =
     let
       naerskSrc = builtins.fetchTarball {
-        # link: https://github.com/nix-community/naersk/tree/2fc8ce9d3c025d59fee349c1f80be9785049d653
-        url = "https://github.com/nix-community/naersk/archive/2fc8ce9d3c025d59fee349c1f80be9785049d653.tar.gz";
-        sha256 = "1jhagazh69w7jfbrchhdss54salxc66ap1a1yd7xasc92vr0qsx4";
+        # link: https://github.com/nix-community/naersk/tree/d998160d6a076cfe8f9741e56aeec7e267e3e114
+        url = "https://github.com/nix-community/naersk/archive/d998160d6a076cfe8f9741e56aeec7e267e3e114.tar.gz";
+        sha256 = "1s10ygdsi17zjfiypwj7bhxys6yxws10hhq3ckfl3996v2q04d3v";
       };
     in
       nixpkgs.callPackage naerskSrc { inherit stdenv; cargo = rustToolchain.rust; rustc = rustToolchain.rust; };


### PR DESCRIPTION
# Description

Changes in rust toolchain configuration (renamed rust-toolchain file) and weird behavior of `cargo` while building with `--locked` and `--offline` flags, i.e. writing new files inside of `CARGO_HOME` was causing failures of the nix based build procedure described in our `BUILD.md` document. This PR fixes these issues.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# IMPORTANT:
How to test it?
```
docker build -t aleph-build -f nix/Dockerfile.build . && docker run -ti --volume=$(pwd):/node/build aleph-build
```
After this, results (aleph-node and runtime binaries) should be stored in the `result` folder.
