### PR TITLE
A0-2712: Featurenets works now on short session.

### DIFF
--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -38,7 +38,9 @@ inputs:
     required: false
     default: ''
   aleph-node-image:
-    description: ''
+    description: |
+      Either string testnet or mainnet, in such case feature net is started from current Testnet
+      or Mainnet binary respetively. Othewrise, a 8 byte SHA of exisiting ECR aleph-node image tag.
     required: false
     default: ''
   expiration:
@@ -121,7 +123,8 @@ runs:
         # yamllint disable-line rule:line-length
         APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
       run: |
-        echo "name=${{ env.APP_NAME }}" >> "$GITHUB_OUTPUT"
+        name_local=${{ env.APP_NAME }}
+        echo "name=$name_local" >> $GITHUB_OUTPUT
 
     - name: Start featurenet from PR branch
       shell: bash

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -149,13 +149,14 @@ runs:
           fnet_aleph_node_image="${{ inputs.ecr-public-registry }}feature-env-aleph-node:${pr_image_tag}"
         elif [[ "${{ inputs.featurenet-aleph-node-image }}" == "testnet" || \
             "${{ inputs.featurenet-aleph-node-image }}" == "mainnet" ]]; then
-          ecr_image_tag=$(echo "${{ steps.get-node-commit-sha.outputs.sha }}" | cut -c 7)
+          ecr_image_tag=$(echo "${{ steps.get-node-commit-sha.outputs.sha }}")
           fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${ecr_image_tag}"
         else
           fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${{ inputs.featurenet-aleph-node-image }}"
         fi
         ./Ops.sh create-featurenet \
           "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
+          "${{ steps.get-node-commit-sha.outputs.sha }}" \
           "${fnet_aleph_node_image}" \
           "${{ inputs.rolling-update-partition }}"
       # yamllint enable rule:line-length

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -147,16 +147,19 @@ runs:
         if [[ "${{ inputs.featurenet-aleph-node-image }}" == "" ]]; then
           pr_image_tag="fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
           fnet_aleph_node_image="${{ inputs.ecr-public-registry }}feature-env-aleph-node:${pr_image_tag}"
+          fnet_aleph_node_for_bootstrap_s3_sha="${{ steps.get-ref-properties.outputs.sha }}"
         elif [[ "${{ inputs.featurenet-aleph-node-image }}" == "testnet" || \
             "${{ inputs.featurenet-aleph-node-image }}" == "mainnet" ]]; then
           ecr_image_tag=$(echo "${{ steps.get-node-commit-sha.outputs.sha }}")
           fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${ecr_image_tag}"
+          fnet_aleph_node_for_bootstrap_s3_sha="${ecr_image_tag}"
         else
           fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${{ inputs.featurenet-aleph-node-image }}"
+          fnet_aleph_node_for_bootstrap_s3_sha="${{ inputs.featurenet-aleph-node-image }}"
         fi
         ./Ops.sh create-featurenet \
           "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
-          "${{ steps.get-ref-properties.outputs.sha }}" \
+          "${fnet_aleph_node_for_bootstrap_s3_sha}" \
           "${fnet_aleph_node_image}" \
           "${{ inputs.rolling-update-partition }}"
       # yamllint enable rule:line-length

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -141,6 +141,7 @@ runs:
       shell: bash
       env:
         OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
+      # yamllint disable rule:line-length
       run: |
         cd "${{ inputs.repo-apps-name }}"
         if [[ "${{ inputs.featurenet-aleph-node-image }}" == "" ]]; then
@@ -157,6 +158,7 @@ runs:
           "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
           "${fnet_aleph_node_image}" \
           "${{ inputs.rolling-update-partition }}"
+      # yamllint enable rule:line-length
 
     - name: Set featurenet expiration
       if: inputs.expiration != ''

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -1,7 +1,10 @@
 ---
 name: Create featurenet
-description: Creates featurenet
-
+description: |
+  This action several flows
+  * spawns new feature net bootstraped from PR, node binary is test one (short session)
+  * spawns new update net from a node image that is on ECR, prpduction one (normal session)
+  * upgrades feature net binary to a given version
 inputs:
   gh-ci-token:
     description: 'GH token to be used in the action'
@@ -30,35 +33,24 @@ inputs:
   featurenet-keys-s3bucket-name:
     description: 'S3 bucket name with featurenet keys'
     required: true
-  no-refresh:
-    description: "Set to 'true' if ArgoCD should not be called to refresh"
-    required: false
-    default: 'false'
-  aleph-node-image:
-    description: 'aleph-node image to be started'
-    required: false
-    default: ''
-  create-hook:
-    description: "Set to 'true' to create a hook"
-    required: false
-    default: 'false'
   featurenet-name:
     description: 'Enter name instead of getting it from branch'
     required: false
     default: ''
-  update:
-    description: "Set to 'true' if it is just featurenet update"
-    required: false
-    default: 'false'
-  rolling-update-partition:
-    # yamllint disable-line rule:line-length
-    description: "All aleph-node-validator-N with an ordinal N that is great than or equal to the partition will be updated. Default value: 0"
-    required: false
-    default: '0'
-  expiration:
-    description: "Time after which updatenet will be removed"
+  aleph-node-image:
+    description: ''
     required: false
     default: ''
+  expiration:
+    description: 'Time after which updatenet will be removed'
+    required: false
+    default: ''
+  rolling-update-partition:
+    description: |
+      Number from 0 to N-1, where N is size of am existing feature net.
+      All aleph-node-validator-N with an ordinal N that is great than or equal to the partition
+      will be updated. If not specified, all nodes will be updated.
+    required: false
 
 runs:
   using: "composite"
@@ -75,16 +67,6 @@ runs:
           exit 1
         fi
         if [[
-          "${{ inputs.update }}" != "true" && \
-          "${{ inputs.aleph-node-image }}" != "testnet" && \
-          "${{ inputs.aleph-node-image }}" != "mainnet"
-        ]]
-        then
-          echo "!!! Node image tag must be 'testnet' or 'mainnet'"
-          echo "!!! when featurenet is about to be created"
-          exit 1
-        fi
-        if [[
           "${{ inputs.aleph-node-image }}" != "" && \
           ! "${{ inputs.aleph-node-image }}" =~ ^[a-f0-9]{7}$ && \
           "${{ inputs.aleph-node-image }}" != "testnet" && \
@@ -95,11 +77,11 @@ runs:
           exit 1
         fi
         if [[
-          "${{ inputs.update }}" == "true" && \
+          "${{ inputs.rolling-update-partition }}" != "" && \
           ! "${{ inputs.rolling-update-partition }}" =~ ^[0-9]$
         ]]
         then
-          echo "!!! Partition for Rolling Update is invalid"
+          echo "!!! Expected rolling update partition to be a cardinal value from 0 to 9"
           exit 1
         fi
         if [[
@@ -108,13 +90,12 @@ runs:
           "${{ inputs.expiration }}" != "never"
         ]]
         then
-          echo "!!! Invalid expiration"
+          echo "!!! Expected expiration to have values from set {3h, 12h, 24h, 48h, 96h, never}"
           exit 1
         fi
 
     - name: Get branch name and commit SHA
       id: get-ref-properties
-      # yamllint disable-line rule:line-length
       uses: Cardinal-Cryptography/github-actions/get-ref-properties@v1
 
     - name: Checkout argocd apps repo
@@ -133,95 +114,57 @@ runs:
         path: "${{ inputs.repo-featurenets-name }}"
         ref: main
 
+    - name: Get argocd featurenet app name
+      id: get-argocd-featurnet-app-name
+      shell: bash
+      env:
+        # yamllint disable-line rule:line-length
+        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
+      run: |
+        echo "name=${{ env.APP_NAME }}" >> "$GITHUB_OUTPUT"
+
     - name: Start featurenet from PR branch
-      if: inputs.aleph-node-image == ''
       shell: bash
       env:
-        # yamllint disable-line rule:line-length
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
         OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
       run: |
         cd "${{ inputs.repo-apps-name }}"
-        pr_image_tag="fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
-        pr_image="${{ inputs.ecr-public-registry }}feature-env-aleph-node:${pr_image_tag}"
+        if [[ "${{ inputs.aleph-node-image }}" == "" ]]; then
+          pr_image_tag="fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
+          pr_image="${{ inputs.ecr-public-registry }}feature-env-aleph-node:${pr_image_tag}"
+        else
+          pr_image="${{ inputs.aleph-node-image }}"
+        fi
         ./Ops.sh create-featurenet \
-          "${{ env.APP_NAME }}" \
+          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
           "${pr_image}" \
-          "false" \
-          "false" \
-          "${{ inputs.update == 'true' && inputs.rolling-update-partition || '0' }}"
+          "${{ inputs.rolling-update-partition }}"
 
-    - name: Start featurenet from testnet/mainnet
-      if: inputs.aleph-node-image == 'testnet' || inputs.aleph-node-image == 'mainnet'
+    - name: Set featurenet expiration
+      if: inputs.expiration != ''
       shell: bash
       env:
-        # yamllint disable-line rule:line-length
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
-        OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
-      run: |
-        cd "${{ inputs.repo-apps-name }}"
-        ./Ops.sh create-featurenet \
-          "${{ env.APP_NAME }}" \
-          "${{ inputs.aleph-node-image }}" \
-          "false" \
-          "true"
-
-    - name: Set featurenet expiration (from testnet/mainet)
-      # yamllint disable-line rule:line-length
-      if: (inputs.aleph-node-image == 'testnet' || inputs.aleph-node-image == 'mainnet') && inputs.expiration != ''
-      shell: bash
-      env:
-        # yamllint disable-line rule:line-length
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
         OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
       run: |
         cd "${{ inputs.repo-apps-name }}"
         ./Ops.sh create-featurenet-expiration \
-          "${{ env.APP_NAME }}" \
+          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
           "${{ inputs.expiration }}"
-
-    - name: Start featurenet from image tag
-      if: >
-        inputs.aleph-node-image != '' &&
-        inputs.aleph-node-image != 'testnet' &&
-        inputs.aleph-node-image != 'mainnet'
-      shell: bash
-      env:
-        # yamllint disable-line rule:line-length
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
-        OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
-      run: |
-        cd "${{ inputs.repo-apps-name }}"
-        pr_image="${{ inputs.ecr-public-registry }}aleph-node:${{ inputs.aleph-node-image }}"
-        ./Ops.sh create-featurenet \
-          "${{ env.APP_NAME }}" \
-          "${pr_image}" \
-          "false" \
-          "false" \
-          "${{ inputs.update == 'true' && inputs.rolling-update-partition || '0' }}"
 
     - name: Commit featurenet change
       uses: EndBug/add-and-commit@v9.1.1
-      env:
-        # yamllint disable-line rule:line-length
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
       with:
         author_name: AlephZero Automation
         author_email: alephzero@10clouds.com
         # yamllint disable-line rule:line-length
-        message: "Upsert featurenet ${{ env.APP_NAME }} with image: ${{ inputs.aleph-node-image != '' && inputs.aleph-node-image || steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
+        message: "Upsert featurenet ${{ steps.get-argocd-featurnet-app-name.outputs.name }} with image: ${{ inputs.aleph-node-image != '' && inputs.aleph-node-image || steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
         add: '["*.yaml","*.expiration.txt"]'
         cwd: "${{ inputs.repo-featurenets-name }}"
 
     - name: Refresh Argo and wait for the creation to be finished
-      if: inputs.no-refresh != 'true'
-      env:
-        # yamllint disable-line rule:line-length
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
       shell: bash
       run: |
         cd "${{ inputs.repo-apps-name }}"
         ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
           "${{ inputs.argo-sync-user-token }}" \
-          "${{ env.APP_NAME }}" \
-          "${{ inputs.create-hook }}"
+          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -109,8 +109,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-apps-name }}"
-        # TODO change to main when apps PR is merged
-        ref: A0-2728
+        ref: main
 
     - name: Checkout featurenets repo
       uses: actions/checkout@v3

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -156,7 +156,7 @@ runs:
         fi
         ./Ops.sh create-featurenet \
           "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
-          "${{ steps.get-node-commit-sha.outputs.sha }}" \
+          "${{ steps.get-ref-properties.outputs.sha }}" \
           "${fnet_aleph_node_image}" \
           "${{ inputs.rolling-update-partition }}"
       # yamllint enable rule:line-length

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -37,10 +37,12 @@ inputs:
     description: 'Enter name instead of getting it from branch'
     required: false
     default: ''
-  aleph-node-image:
+  featurenet-aleph-node-image:
     description: |
-      Either string testnet or mainnet, in such case feature net is started from current Testnet
-      or Mainnet binary respetively. Othewrise, a 8 byte SHA of exisiting ECR aleph-node image tag.
+      Set feature net image either to:
+       * 'testnet' or 'mainnet' - to Testnet or Mainnet image respectively,
+       * a 7 byte SHA - to exisiting ECR aleph-node image tag
+       * empty value - to image built from PR
     required: false
     default: ''
   expiration:
@@ -69,10 +71,10 @@ runs:
           exit 1
         fi
         if [[
-          "${{ inputs.aleph-node-image }}" != "" && \
-          ! "${{ inputs.aleph-node-image }}" =~ ^[a-f0-9]{7}$ && \
-          "${{ inputs.aleph-node-image }}" != "testnet" && \
-          "${{ inputs.aleph-node-image }}" != "mainnet"
+          "${{ inputs.featurenet-aleph-node-image }}" != "" && \
+          ! "${{ inputs.featurenet-aleph-node-image }}" =~ ^[a-f0-9]{7}$ && \
+          "${{ inputs.featurenet-aleph-node-image }}" != "testnet" && \
+          "${{ inputs.featurenet-aleph-node-image }}" != "mainnet"
         ]]
         then
           echo "!!! Invalid feature net node image tag"
@@ -126,21 +128,33 @@ runs:
         name_local=${{ env.APP_NAME }}
         echo "name=$name_local" >> $GITHUB_OUTPUT
 
+    - name: Get node commit SHA
+      if: ${{ inputs.featurenet-aleph-node-image == 'testnet' ||
+              inputs.featurenet-aleph-node-image == 'mainnet' }}
+      id: get-node-commit-sha
+      uses: ./.github/actions/get-node-system-version
+      with:
+        env: ${{ inputs.featurenet-aleph-node-image }}
+
     - name: Start featurenet from PR branch
       shell: bash
       env:
         OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
       run: |
         cd "${{ inputs.repo-apps-name }}"
-        if [[ "${{ inputs.aleph-node-image }}" == "" ]]; then
+        if [[ "${{ inputs.featurenet-aleph-node-image }}" == "" ]]; then
           pr_image_tag="fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
-          pr_image="${{ inputs.ecr-public-registry }}feature-env-aleph-node:${pr_image_tag}"
+          fnet_aleph_node_image="${{ inputs.ecr-public-registry }}feature-env-aleph-node:${pr_image_tag}"
+        elif [[ "${{ inputs.featurenet-aleph-node-image }}" == "testnet" || \
+            "${{ inputs.featurenet-aleph-node-image }}" == "mainnet" ]]; then
+          ecr_image_tag=$(echo "${{ steps.get-node-commit-sha.outputs.sha }}" | cut -c 7)
+          fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${ecr_image_tag}"
         else
-          pr_image="${{ inputs.aleph-node-image }}"
+          fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${{ inputs.featurenet-aleph-node-image }}"
         fi
         ./Ops.sh create-featurenet \
           "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
-          "${pr_image}" \
+          "${fnet_aleph_node_image}" \
           "${{ inputs.rolling-update-partition }}"
 
     - name: Set featurenet expiration
@@ -160,7 +174,7 @@ runs:
         author_name: AlephZero Automation
         author_email: alephzero@10clouds.com
         # yamllint disable-line rule:line-length
-        message: "Upsert featurenet ${{ steps.get-argocd-featurnet-app-name.outputs.name }} with image: ${{ inputs.aleph-node-image != '' && inputs.aleph-node-image || steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
+        message: "Upsert featurenet ${{ steps.get-argocd-featurnet-app-name.outputs.name }} with image: ${{ inputs.featurenet-aleph-node-image != '' && inputs.featurenet-aleph-node-image || steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
         add: '["*.yaml","*.expiration.txt"]'
         cwd: "${{ inputs.repo-featurenets-name }}"
 

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -181,11 +181,3 @@ runs:
         message: "Upsert featurenet ${{ steps.get-argocd-featurnet-app-name.outputs.name }} with image: ${{ inputs.featurenet-aleph-node-image != '' && inputs.featurenet-aleph-node-image || steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
         add: '["*.yaml","*.expiration.txt"]'
         cwd: "${{ inputs.repo-featurenets-name }}"
-
-    - name: Refresh Argo and wait for the creation to be finished
-      shell: bash
-      run: |
-        cd "${{ inputs.repo-apps-name }}"
-        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
-          "${{ inputs.argo-sync-user-token }}" \
-          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -130,6 +130,14 @@ runs:
         name_local=${{ env.APP_NAME }}
         echo "name=$name_local" >> $GITHUB_OUTPUT
 
+    - name: Get node commit SHA
+      if: ${{ inputs.featurenet-aleph-node-image == 'testnet' ||
+        inputs.featurenet-aleph-node-image == 'mainnet' }}
+      id: get-node-commit-sha
+      uses: ./.github/actions/get-node-system-version
+      with:
+        env: ${{ inputs.featurenet-aleph-node-image }}
+
     - name: Start featurenet from PR branch
       shell: bash
       env:
@@ -143,7 +151,7 @@ runs:
           fnet_bootstrap_chain_node_image="${{ steps.get-ref-properties.outputs.sha }}"
         elif [[ "${{ inputs.featurenet-aleph-node-image }}" == "testnet" || \
             "${{ inputs.featurenet-aleph-node-image }}" == "mainnet" ]]; then
-          ecr_image_tag=$(echo "${{ steps.get-ref-properties-sha.outputs.sha }}")
+          ecr_image_tag=$(echo "${{ steps.get-node-commit-sha.outputs.sha }}")
           fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${ecr_image_tag}"
           fnet_bootstrap_chain_node_image="${{ inputs.featurenet-aleph-node-image }}"
         else

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -108,7 +108,8 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-apps-name }}"
-        ref: main
+        # TODO change to main when apps PR is merged
+        ref: A0-2728
 
     - name: Checkout featurenets repo
       uses: actions/checkout@v3

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -55,6 +55,7 @@ inputs:
       All aleph-node-validator-N with an ordinal N that is great than or equal to the partition
       will be updated. If not specified, all nodes will be updated.
     required: false
+    default: "0"
 
 runs:
   using: "composite"
@@ -129,14 +130,6 @@ runs:
         name_local=${{ env.APP_NAME }}
         echo "name=$name_local" >> $GITHUB_OUTPUT
 
-    - name: Get node commit SHA
-      if: ${{ inputs.featurenet-aleph-node-image == 'testnet' ||
-              inputs.featurenet-aleph-node-image == 'mainnet' }}
-      id: get-node-commit-sha
-      uses: ./.github/actions/get-node-system-version
-      with:
-        env: ${{ inputs.featurenet-aleph-node-image }}
-
     - name: Start featurenet from PR branch
       shell: bash
       env:
@@ -147,21 +140,22 @@ runs:
         if [[ "${{ inputs.featurenet-aleph-node-image }}" == "" ]]; then
           pr_image_tag="fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
           fnet_aleph_node_image="${{ inputs.ecr-public-registry }}feature-env-aleph-node:${pr_image_tag}"
-          fnet_aleph_node_for_bootstrap_s3_sha="${{ steps.get-ref-properties.outputs.sha }}"
+          fnet_bootstrap_chain_node_image="${{ steps.get-ref-properties.outputs.sha }}"
         elif [[ "${{ inputs.featurenet-aleph-node-image }}" == "testnet" || \
             "${{ inputs.featurenet-aleph-node-image }}" == "mainnet" ]]; then
-          ecr_image_tag=$(echo "${{ steps.get-node-commit-sha.outputs.sha }}")
+          ecr_image_tag=$(echo "${{ steps.get-ref-properties-sha.outputs.sha }}")
           fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${ecr_image_tag}"
-          fnet_aleph_node_for_bootstrap_s3_sha="${ecr_image_tag}"
+          fnet_bootstrap_chain_node_image="${{ inputs.featurenet-aleph-node-image }}"
         else
           fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${{ inputs.featurenet-aleph-node-image }}"
-          fnet_aleph_node_for_bootstrap_s3_sha="${{ inputs.featurenet-aleph-node-image }}"
+          fnet_bootstrap_chain_node_image="none"
         fi
         ./Ops.sh create-featurenet \
           "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
-          "${fnet_aleph_node_for_bootstrap_s3_sha}" \
           "${fnet_aleph_node_image}" \
-          "${{ inputs.rolling-update-partition }}"
+          "${fnet_bootstrap_chain_node_image}" \
+          "${{ inputs.rolling-update-partition }}" \
+          false
       # yamllint enable rule:line-length
 
     - name: Set featurenet expiration

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -181,3 +181,11 @@ runs:
         message: "Upsert featurenet ${{ steps.get-argocd-featurnet-app-name.outputs.name }} with image: ${{ inputs.featurenet-aleph-node-image != '' && inputs.featurenet-aleph-node-image || steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
         add: '["*.yaml","*.expiration.txt"]'
         cwd: "${{ inputs.repo-featurenets-name }}"
+
+    - name: Refresh Argo and wait for the creation to be finished
+      shell: bash
+      run: |
+        cd "${{ inputs.repo-apps-name }}"
+        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
+          "${{ inputs.argo-sync-user-token }}" \
+          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -61,8 +61,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-apps-name }}"
-        # TODO change to main when apps PR is merged
-        ref: A0-2728
+        ref: main
 
     - name: Checkout featurenets repo
       uses: actions/checkout@v3
@@ -118,7 +117,6 @@ runs:
           "${{ inputs.argo-sync-user-token }}"
 
     - name: Clean S3 storage
-      # TODO set to v0.3.0 when docker-featurenet-helper PR is merged
       shell: bash
       run: |
         docker run --rm \
@@ -127,5 +125,5 @@ runs:
           -e AWS_REGION \
           -e FEATURENETS_S3_BUCKET_NAME=${{ inputs.featurenet-keys-s3bucket-name }} \
           -e FEATURENET_NAME=${{ steps.get-argocd-featurnet-app-name.outputs.name }} \
-          ${{ inputs.ecr-public-registry }}featurenet-helper:A0-2728 \
+          ${{ inputs.ecr-public-registry }}featurenet-helper:v0.3.0 \
           delete-featurenet-data-from-s3

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -109,6 +109,7 @@ runs:
         add: '["*.yaml","*.expiration.txt"]'
         cwd: "${{ inputs.repo-featurenets-name }}"
 
+    # we need self-hosted runner only because of this step
     - name: Refresh Argo and wait for the deletion to be finished
       shell: bash
       run: |

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -116,14 +116,14 @@ runs:
           "${{ inputs.argo-sync-user-token }}"
 
     - name: Clean S3 storage
+      # TODO set to v0.3.0 when docker-featurenet-helper PR is merged
       shell: bash
       run: |
         docker run --rm \
-          -e SOURCE_NET=testnet \
           -e AWS_ACCESS_KEY_ID \
           -e AWS_SECRET_ACCESS_KEY \
           -e AWS_REGION \
           -e FEATURENETS_S3_BUCKET_NAME=${{ inputs.featurenet-keys-s3bucket-name }} \
           -e FEATURENET_NAME=${{ steps.get-argocd-featurnet-app-name.outputs.name }} \
-          ${{ inputs.ecr-public-registry }}featurenet-helper:v0.2.0 \
-          delete-data-from-s3
+          ${{ inputs.ecr-public-registry }}featurenet-helper:A0-2728 \
+          delete-featuretnet-data-from-s3

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -128,4 +128,4 @@ runs:
           -e FEATURENETS_S3_BUCKET_NAME=${{ inputs.featurenet-keys-s3bucket-name }} \
           -e FEATURENET_NAME=${{ steps.get-argocd-featurnet-app-name.outputs.name }} \
           ${{ inputs.ecr-public-registry }}featurenet-helper:A0-2728 \
-          delete-featuretnet-data-from-s3
+          delete-featurenet-data-from-s3

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -80,26 +80,30 @@ runs:
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ env.AWS_REGION }}
 
-    - name: Destroy feature branch
+    - name: Get argocd featurenet app name
+      id: get-argocd-featurnet-app-name
       shell: bash
       env:
         # yamllint disable-line rule:line-length
         APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
+      run: |
+        echo "name=${{ env.APP_NAME }}" >> "$GITHUB_OUTPUT"
+
+    - name: Destroy feature branch
+      shell: bash
+      env:
         OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
       run: |
         cd "${{ inputs.repo-apps-name }}"
-        ./Ops.sh delete-featurenet "${{ env.APP_NAME }}"
+        ./Ops.sh delete-featurenet "${{ steps.get-argocd-featurnet-app-name.outputs.name }}"
       # yamllint enable rule:line-length
 
     - name: Commit deletion of the feature environment.
       uses: EndBug/add-and-commit@v9.1.1
-      env:
-        # yamllint disable-line rule:line-length
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
       with:
         author_name: AlephZero Automation
         author_email: alephzero@10clouds.com
-        message: "Delete featurenet ${{ env.APP_NAME }}"
+        message: "Delete featurenet ${{ steps.get-argocd-featurnet-app-name.outputs.name }}"
         add: '["*.yaml","*.expiration.txt"]'
         cwd: "${{ inputs.repo-featurenets-name }}"
 
@@ -112,9 +116,6 @@ runs:
 
     - name: Clean S3 storage
       shell: bash
-      env:
-        # yamllint disable-line rule:line-length
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
       run: |
         docker run --rm \
           -e SOURCE_NET=testnet \
@@ -122,6 +123,6 @@ runs:
           -e AWS_SECRET_ACCESS_KEY \
           -e AWS_REGION \
           -e FEATURENETS_S3_BUCKET_NAME=${{ inputs.featurenet-keys-s3bucket-name }} \
-          -e FEATURENET_NAME=${{ env.APP_NAME }} \
+          -e FEATURENET_NAME=${{ steps.get-argocd-featurnet-app-name.outputs.name }} \
           ${{ inputs.ecr-public-registry }}featurenet-helper:v0.2.0 \
           delete-data-from-s3

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -61,7 +61,8 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-apps-name }}"
-        ref: main
+        # TODO change to main when apps PR is merged
+        ref: A0-2728
 
     - name: Checkout featurenets repo
       uses: actions/checkout@v3

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -87,7 +87,8 @@ runs:
         # yamllint disable-line rule:line-length
         APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
       run: |
-        echo "name=${{ env.APP_NAME }}" >> "$GITHUB_OUTPUT"
+        name_local=${{ env.APP_NAME }}
+        echo "name=$name_local" >> $GITHUB_OUTPUT
 
     - name: Destroy feature branch
       shell: bash

--- a/.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
+++ b/.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
@@ -1,6 +1,7 @@
 ---
 #  This workflow builds aleph-node docker image from pull request commit
-#  and pushes it to featurenet registry.
+#  and pushes it to featurenet registry. Test binary is used, and it is wrapped in registry
+#  separated from production builds
 name: Build and push PR image to featurenets
 on:
   workflow_call:
@@ -15,18 +16,16 @@ jobs:
 
       - name: Call action get-ref-properties
         id: get-ref-properties
-        # yamllint disable-line rule:line-length
         uses: Cardinal-Cryptography/github-actions/get-ref-properties@v1
 
-      - name: Download artifact with built aleph-node binary from PR
+      - name: Download test aleph-node artifact
         uses: actions/download-artifact@v3
         with:
-          name: aleph-release-node
+          name: aleph-test-node
           path: target/release/
 
       - name: Build docker image with PR aleph-node binary
         env:
-          # yamllint disable-line rule:line-length
           IMAGE_TAG: fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}
         run: |
           chmod +x target/release/aleph-node

--- a/.github/workflows/_store-test-node-and-runtime.yml
+++ b/.github/workflows/_store-test-node-and-runtime.yml
@@ -12,8 +12,8 @@ jobs:
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache
-      SECRETS_AWS_MAINNET_ACCESS_KEY_ID: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
-      SECRETS_AWS_MAINNET_SECRET_ACCESS_KEY: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
+      SECRETS_DEVNET_ACCESS_KEY_ID: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
+      SECRETS_DEVNET_SECRET_ACCESS_KEY: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout aleph-node source code
         uses: actions/checkout@v3
@@ -35,10 +35,10 @@ jobs:
           name: aleph-test-runtime
           path: target/release/wbuild/aleph-runtime
 
-      - name: Configure AWS credentials for S3 Mainnet AWS
+      - name: Configure AWS credentials for S3 Devnet AWS
         if: >
-          env.SECRETS_AWS_MAINNET_ACCESS_KEY_ID != '' &&
-          env.SECRETS_AWS_MAINNET_SECRET_ACCESS_KEY != ''
+          env.SECRETS_DEVNET_ACCESS_KEY_ID != '' &&
+          env.SECRETS_DEVNET_SECRET_ACCESS_KEY != ''
         uses: aws-actions/configure-aws-credentials@v2
         env:
           AWS_ACCESS_KEY_ID: ""
@@ -47,14 +47,14 @@ jobs:
           AWS_DEFAULT_REGION: ""
           AWS_REGION: us-east-1
         with:
-          aws-access-key-id: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Copy test binary to S3 Mainnet AWS bucket
+      - name: Copy test binary to S3 Devnet AWS bucket
         if: >
-          env.SECRETS_AWS_MAINNET_ACCESS_KEY_ID != '' &&
-          env.SECRETS_AWS_MAINNET_SECRET_ACCESS_KEY != ''
+          env.SECRETS_DEVNET_ACCESS_KEY_ID != '' &&
+          env.SECRETS_DEVNET_SECRET_ACCESS_KEY != ''
         uses: Cardinal-Cryptography/github-actions/copy-file-to-s3@v1
         with:
           source-path: target/release
@@ -62,12 +62,12 @@ jobs:
           s3-bucket-path:
             builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/aleph-test-node
           s3-bucket-filename: aleph-test-node-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
-          s3-bucket-name: ${{ secrets.CI_MAINNET_S3BUCKET_NAME }}
+          s3-bucket-name: ${{ secrets.CI_DEVNET_S3BUCKET_NAME }}
 
-      - name: Copy test runtime to S3 Mainnet AWS bucket
+      - name: Copy test runtime to S3 Devnet AWS bucket
         if: >
-          env.SECRETS_AWS_MAINNET_ACCESS_KEY_ID != '' &&
-          env.SECRETS_AWS_MAINNET_SECRET_ACCESS_KEY != ''
+          env.SECRETS_DEVNET_ACCESS_KEY_ID != '' &&
+          env.SECRETS_DEVNET_SECRET_ACCESS_KEY != ''
         uses: Cardinal-Cryptography/github-actions/copy-file-to-s3@v1
         with:
           source-path: target/release/wbuild/aleph-runtime
@@ -75,4 +75,4 @@ jobs:
           s3-bucket-path:
             builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/aleph-test-runtime
           s3-bucket-filename: aleph-test-runtime-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
-          s3-bucket-name: ${{ secrets.CI_MAINNET_S3BUCKET_NAME }}
+          s3-bucket-name: ${{ secrets.CI_DEVNET_S3BUCKET_NAME }}

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -41,16 +41,18 @@ jobs:
     uses: ./.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
     secrets: inherit
 
-  delete-featurenet-if-exists:
+  create-featurenet:
     needs: [push-featurnet-node-image-to-ecr]
-    name: Delete featurenet (if exists already)
-    if: contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
+    name: Create featurenet based on the PR
     runs-on: [self-hosted, Linux, X64, large]
+    outputs:
+      deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Delete old featurenet app and data
+        if: contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
         uses: ./.github/actions/delete-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
@@ -62,16 +64,6 @@ jobs:
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
-
-  create-featurenet:
-    needs: [push-featurnet-node-image-to-ecr, delete-featurenet-if-exists]
-    name: Create featurenet based on the PR
-    runs-on: ubuntu-20.04
-    outputs:
-      deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
 
       - name: Call action get-ref-properties
         id: get-ref-properties

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -45,7 +45,7 @@ jobs:
     needs: [push-featurnet-node-image-to-ecr]
     name: Delete featurenet (if exists already)
     if: contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
-    runs-on: [ self-hosted, Linux, X64, large ]
+    runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CI_GH_TOKEN }}
           status: ${{ job.status }}
           env: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
-          deployment_id: ${{ jobs.create-featurenet.outputs.deployment-id }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           # yamllint disable-line rule:line-length
           env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}.dev.azero.dev#/explorer
           ref: ${{ github.head_ref }}

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -116,7 +116,7 @@ jobs:
           token: ${{ secrets.CI_GH_TOKEN }}
           status: ${{ job.status }}
           env: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
-          deployment_id: ${{ needs.create-featurenet.outputs.deployment-id }}
+          deployment_id: ${{ jobs.create-featurenet.outputs.deployment-id }}
           # yamllint disable-line rule:line-length
           env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}.dev.azero.dev#/explorer
           ref: ${{ github.head_ref }}

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -64,7 +64,7 @@ jobs:
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
 
   create-featurenet:
-    needs: [delete-featurenet-if-exists]
+    needs: [push-featurnet-node-image-to-ecr, delete-featurenet-if-exists]
     name: Create featurenet based on the PR
     runs-on: ubuntu-20.04
     outputs:

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -44,7 +44,7 @@ jobs:
   create-featurenet:
     needs: [push-featurnet-node-image-to-ecr]
     name: Create featurenet based on the PR
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, Linux, X64, large]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -41,18 +41,16 @@ jobs:
     uses: ./.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
     secrets: inherit
 
-  create-featurenet:
+  delete-featurenet-if-exists:
     needs: [push-featurnet-node-image-to-ecr]
-    name: Create featurenet based on the PR
-    runs-on: [self-hosted, Linux, X64, large]
-    outputs:
-      deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+    name: Delete featurenet (if exists already)
+    if: contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
+    runs-on: [ self-hosted, Linux, X64, large ]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Delete old featurenet app and data
-        if: contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
         uses: ./.github/actions/delete-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
@@ -64,6 +62,16 @@ jobs:
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
+
+  create-featurenet:
+    needs: [delete-featurenet-if-exists]
+    name: Create featurenet based on the PR
+    runs-on: ubuntu-20.04
+    outputs:
+      deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
       - name: Call action get-ref-properties
         id: get-ref-properties

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -3,12 +3,19 @@ name: Create featurenet
 
 on:
   workflow_call:
+  workflow_dispatch:
     inputs:
-      hotfix:
-        description: Set to 'true' if it is a hotfix environment
+      expiration:
+        description: 'Time after which featurenet will be removed'
         required: false
-        type: boolean
-        default: false
+        type: choice
+        options:
+          - 48h
+          - 24h
+          - 12h
+          - 3h
+          - 96h
+          - never
 
 jobs:
   check-vars-and-secrets:
@@ -16,29 +23,28 @@ jobs:
     uses: ./.github/workflows/_check-vars-and-secrets.yml
     secrets: inherit
 
-  build-aleph-node-binary:
+  build-test-node-and-runtime:
+    name: Build test node and runtime
     needs: [check-vars-and-secrets]
-    name: Build production artifacts
-    uses: ./.github/workflows/_build-production-node-and-runtime.yml
+    uses: ./.github/workflows/_build-test-node-and-runtime.yml
     secrets: inherit
 
-  store-aleph-node-binary:
-    needs: [build-aleph-node-binary]
-    name: Store production artifacts
-    uses: ./.github/workflows/_store-production-node-and-runtime.yml
+  store-test-node-and-runtime:
+    needs: [build-test-node-and-runtime]
+    name: Store test node and runtime
+    uses: ./.github/workflows/_store-test-node-and-runtime.yml
     secrets: inherit
 
-  push-pr-image:
-    needs: [build-aleph-node-binary]
-    name: Build and push PR docker image to featurenet registry
-    # yamllint disable-line rule:line-length
+  push-featurnet-node-image-to-ecr:
+    needs: [store-test-node-and-runtime]
+    name: Build and push PR tesdocker image to ECR
     uses: ./.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
     secrets: inherit
 
   create-featurenet:
-    needs: [check-vars-and-secrets]
+    needs: [push-featurnet-node-image-to-ecr]
     name: Create featurenet based on the PR
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: ubuntu-20.04
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
@@ -61,7 +67,6 @@ jobs:
 
       - name: Call action get-ref-properties
         id: get-ref-properties
-        # yamllint disable-line rule:line-length
         uses: Cardinal-Cryptography/github-actions/get-ref-properties@v1
 
       - name: Start featurenet Deployment
@@ -74,7 +79,7 @@ jobs:
           ref: ${{ github.head_ref }}
           override: true
 
-      - name: Create featurenet data, app and deploy it
+      - name: Create featurenet from scratch
         uses: ./.github/actions/create-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
@@ -82,11 +87,11 @@ jobs:
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
-          # yamllint disable-line rule:line-length
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
+          expiration: ${{ inputs.expiration == '' && '48h' || inputs.expiration }}
 
       - name: Wait for the aleph-node binary to accept some blocks
         uses: ./.github/actions/wait-for-finalized-heads
@@ -95,34 +100,6 @@ jobs:
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           # yamllint disable-line rule:line-length
           json-rpc-endpoint: https://ws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}.dev.azero.dev
-
-  update-featurenet-image:
-    needs: [push-pr-image, create-featurenet]
-    name: Update featurenet to the latest PR aleph-node image
-    runs-on: [self-hosted, Linux, X64, large]
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Call action get-ref-properties
-        id: get-ref-properties
-        # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v1
-
-      - name: Update featurenet app and re-deploy it
-        uses: ./.github/actions/create-featurenet
-        with:
-          gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
-          repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
-          argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
-          create-hook: 'true'
-          ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
-          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
-          featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
-          update: 'true'
 
       - name: Remove deleted label if present
         uses: actions-ecosystem/action-remove-labels@v1.3.0
@@ -144,18 +121,11 @@ jobs:
           env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}.dev.azero.dev#/explorer
           ref: ${{ github.head_ref }}
 
-      - name: Remove testnet deployment request label if exists
+      - name: Remove deployment request label if exists
         if: contains(github.event.pull_request.labels.*.name, 'trigger:create-featurenet')
         uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
           labels: 'trigger:create-featurenet'
-          github_token: ${{ secrets.CI_GH_TOKEN }}
-
-      - name: Remove mainnet deployment request label if exists
-        if: contains(github.event.pull_request.labels.*.name, 'trigger:create-hotfix-featurenet')
-        uses: actions-ecosystem/action-remove-labels@v1.3.0
-        with:
-          labels: 'trigger:create-hotfix-featurenet'
           github_token: ${{ secrets.CI_GH_TOKEN }}
 
       - name: Add label to mark that featurenet has been created

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -13,16 +13,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-vars-and-secrets:
+    name: Check vars and secrets
+    uses: ./.github/workflows/_check-vars-and-secrets.yml
+    secrets: inherit
+
   check-excluded-packages:
     name: Check excluded packages
+    needs: [check-vars-and-secrets]
     uses: ./.github/workflows/_check-excluded-packages.yml
 
   unit-tests-and-static-checks:
     name: Unit tests and clippy
+    needs: [check-vars-and-secrets]
     uses: ./.github/workflows/_unit-tests-and-static-checks.yml
 
   build-production-node-and-runtime:
     name: Build production node and runtime
+    needs: [check-vars-and-secrets]
     uses: ./.github/workflows/_build-production-node-and-runtime.yml
 
   store-production-node-and-runtime:
@@ -37,6 +45,7 @@ jobs:
 
   build-test-node-and-runtime:
     name: Build test node and runtime
+    needs: [check-vars-and-secrets]
     uses: ./.github/workflows/_build-test-node-and-runtime.yml
     secrets: inherit
 
@@ -58,7 +67,7 @@ jobs:
   check-e2e-test-suite-completion:
     needs: [run-e2e-tests]
     name: Check e2e test suite completion
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-20.04
     steps:
       - name: All e2e tests completed

--- a/.github/workflows/on-pull-request-label.yml
+++ b/.github/workflows/on-pull-request-label.yml
@@ -11,14 +11,9 @@ concurrency:
 
 jobs:
   create-featurenet:
-    if: >
-      (github.event.label.name == 'trigger:create-featurenet') ||
-      (github.event.label.name == 'trigger:create-hotfix-featurenet')
+    if: github.event.label.name == 'trigger:create-featurenet'
     name: Create featurenet
-    uses: ./.github/workflows/_create-featurenet.yml
-    with:
-      # yamllint disable-line rule:line-length
-      hotfix: ${{ github.event.label.name == 'trigger:create-hotfix-featurenet' && true || false }}
+    uses: ./.github/workflows/create-featurenet.yml
     secrets: inherit
 
   delete-featurenet:

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -34,7 +34,7 @@ jobs:
   create-updatenet:
     needs: [check-vars-and-secrets]
     name: Create updatenet
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: ubuntu-20.04
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
@@ -65,7 +65,7 @@ jobs:
           env: updatenet-${{ github.run_id }}
           override: true
 
-      - name: Create featurenet data, app and deploy it
+      - name: Create updatenet from scratch, node binary from testnet or mainnet
         uses: ./.github/actions/create-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
@@ -73,14 +73,13 @@ jobs:
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
-          # yamllint disable-line rule:line-length
-          aleph-node-image: ${{ inputs.start == 'mainnet' && 'mainnet' || 'testnet' }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
           featurenet-name: fe-updnet-${{ github.run_id }}
-          expiration: "${{ inputs.expiration }}"
+          aleph-node-image: ${{ inputs.start == 'mainnet' && 'mainnet' || 'testnet' }}
+          expiration: ${{ inputs.expiration }}
 
       - name: Wait for the aleph-node binary to accept some blocks
         uses: ./.github/actions/wait-for-finalized-heads

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -78,7 +78,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
           featurenet-name: fe-updnet-${{ github.run_id }}
-          aleph-node-image: ${{ inputs.start == 'mainnet' && 'mainnet' || 'testnet' }}
+          featurenet-aleph-node-image: ${{ inputs.start == 'mainnet' && 'mainnet' || 'testnet' }}
           expiration: ${{ inputs.expiration }}
 
       - name: Wait for the aleph-node binary to accept some blocks

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -34,7 +34,7 @@ jobs:
   create-updatenet:
     needs: [check-vars-and-secrets]
     name: Create updatenet
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, Linux, X64, large]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -64,6 +64,7 @@ jobs:
           token: ${{ secrets.CI_GH_TOKEN }}
           env: updatenet-${{ github.run_id }}
           override: true
+          debug: true
 
       - name: Create updatenet from scratch, node binary from testnet or mainnet
         uses: ./.github/actions/create-featurenet
@@ -100,3 +101,4 @@ jobs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           # yamllint disable-line rule:line-length
           env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-updnet-${{ github.run_id }}.dev.azero.dev#/explorer
+          debug: true

--- a/.github/workflows/updatenet-delete.yml
+++ b/.github/workflows/updatenet-delete.yml
@@ -18,7 +18,7 @@ jobs:
   delete-updatenet:
     needs: [check-vars-and-secrets]
     name: Delete updatenet
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: ubuntu-20.04
     steps:
       - name: Validate inputs
         shell: bash

--- a/.github/workflows/updatenet-delete.yml
+++ b/.github/workflows/updatenet-delete.yml
@@ -18,7 +18,7 @@ jobs:
   delete-updatenet:
     needs: [check-vars-and-secrets]
     name: Delete updatenet
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, Linux, X64, large]
     steps:
       - name: Validate inputs
         shell: bash

--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -79,7 +79,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
           featurenet-name: fe-updnet-${{ inputs.name }}
-          aleph-node-image: ${{ inputs.destination }}
+          featurenet-aleph-node-image: ${{ inputs.destination }}
           rolling-update-partition: ${{ inputs.rolling-update-partition }}
 
       - name: Wait for the aleph-node binary to accept some blocks

--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -18,6 +18,7 @@ on:
           All aleph-node-validator-N with an ordinal N that is great than or equal to the partition
           will be updated. If not specified, all nodes will be updated.
         required: false
+        default: "0"
 
 jobs:
   check-vars-and-secrets:

--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -9,13 +9,15 @@ on:
         required: true
         type: string
       destination:
-        description: Node image tag
+        description: Node image tag, ie 7-byte SHA of some existing ECR aleph-node image tag
         required: true
         type: string
       rolling-update-partition:
-        description: Rolling Update Partition <0, N-1>
-        required: true
-        type: string
+        description: |
+          Number from 0 to N-1, where N is size of am existing feature net.
+          All aleph-node-validator-N with an ordinal N that is great than or equal to the partition
+          will be updated. If not specified, all nodes will be updated.
+        required: false
 
 jobs:
   check-vars-and-secrets:
@@ -26,7 +28,7 @@ jobs:
   update-updatenet:
     needs: [check-vars-and-secrets]
     name: Update updatenet
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: ubuntu-20.04
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
@@ -40,14 +42,15 @@ jobs:
           if [[
             "${{ inputs.destination }}" != "" && \
             ! "${{ inputs.destination }}" =~ ^[a-f0-9]{7}$
-          ]]
-          then
-            echo "!!! Invalid destination node image tag"
+          ]]; then
+            echo "!!! Expected a 7-byte SHA in destination parameter"
             exit 1
           fi
-          if [[ ! "${{ inputs.rolling-update-partition }}" =~ ^[0-9]$ ]]
-          then
-            echo "!!! Invalid rolling update partition"
+          if [[
+            "${{ inputs.rolling-update-partition }}" != "" && \
+            ! "${{ inputs.rolling-update-partition }}" =~ ^[0-9]$ \
+          ]]; then
+            echo "!!! Expected rolling update partition to be a cardinal value from 0 to 9"
             exit 1
           fi
 
@@ -71,22 +74,19 @@ jobs:
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
-          # yamllint disable-line rule:line-length
-          aleph-node-image: ${{ inputs.destination }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
           featurenet-name: fe-updnet-${{ inputs.name }}
-          update: 'true'
-          rolling-update-partition: '${{ inputs.rolling-update-partition }}'
+          aleph-node-image: ${{ inputs.destination }}
+          rolling-update-partition: ${{ inputs.rolling-update-partition }}
 
       - name: Wait for the aleph-node binary to accept some blocks
         uses: ./.github/actions/wait-for-finalized-heads
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
-          # yamllint disable-line rule:line-length
           json-rpc-endpoint: https://ws-fe-updnet-${{ inputs.name }}.dev.azero.dev
 
       - name: Finish featurenet Deployment

--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -28,7 +28,7 @@ jobs:
   update-updatenet:
     needs: [check-vars-and-secrets]
     name: Update updatenet
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, Linux, X64, large]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -37,7 +37,7 @@ e2e-tests$ RUST_BACKTRACE=1 SUDO_SEED="$THE_SEED" NODE_URL=wss://ws.dev.azero.de
 ## Running on feature net
 
 Run a feature net by adding an appropriate label to a pull request, ie `trigger:create-featurenet`
-or `trigger:create-hotfix-featurenet`, then after its started run
+, then after its started run
 
 ```bash
 e2e-tests$ NODE_URL=wss://ws-fe-a0-1564.dev.azero.dev:443 cargo test finalization


### PR DESCRIPTION
# Description

  * Feature nets should be started from scratch, chainspec generated from node PR version, binary PR test version (short session)
  * Small refactor of create and destroy feature net actions
  * minor bugifx for e2e completion check in PR pipeline so that workflow does not error in case it is cancelled either by dev or by concurrency (ie pushing another commit to PR)
  * remove trigger:create-hotfix-featurenet as it is not needed anymore
  * added manual workflow dispatch possibility to create feature net
  * Added expiration to feature nets
  * Changed placement of test binaries to different bucket

Companion PRs:
* https://github.com/Cardinal-Cryptography/aleph-apps/pull/504/
* https://github.com/Cardinal-Cryptography/docker-featurenet-helper/pull/6


## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have made neccessary updates to the Infrastructure
- I have made corresponding changes to the existing documentation

Testing:
* [Feature net create ](https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/5419647016)
* [Update net create](https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/5419824168/jobs/9853297251)
* [Update net update](https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/5419983697/jobs/9853635869) 
* [Update net delete](https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/5420065741)
