### PR TITLE
A0-2732: Fix handling of incoming responses

### DIFF
--- a/finality-aleph/src/sync/data.rs
+++ b/finality-aleph/src/sync/data.rs
@@ -98,7 +98,7 @@ pub enum NetworkData<B: Block, J: Justification> {
     /// An explicit request for data, potentially a lot of it.
     Request(Request<J>),
     /// Response to the request for data.
-    RequestResponse(Vec<B>, Vec<J::Unverified>),
+    RequestResponse(Vec<J::Unverified>, Vec<J::Header>, Vec<B>),
 }
 
 impl<B: Block, J: Justification> From<NetworkDataV1<J>> for NetworkData<B, J> {
@@ -110,7 +110,7 @@ impl<B: Block, J: Justification> From<NetworkDataV1<J>> for NetworkData<B, J> {
             }
             NetworkDataV1::Request(request) => NetworkData::Request(request),
             NetworkDataV1::RequestResponse(justifications) => {
-                NetworkData::RequestResponse(Vec::new(), justifications)
+                NetworkData::RequestResponse(justifications, Vec::new(), Vec::new())
             }
         }
     }
@@ -124,7 +124,7 @@ impl<B: Block, J: Justification> From<NetworkData<B, J>> for NetworkDataV1<J> {
                 NetworkDataV1::StateBroadcastResponse(justification, maybe_justification)
             }
             NetworkData::Request(request) => NetworkDataV1::Request(request),
-            NetworkData::RequestResponse(_, justifications) => {
+            NetworkData::RequestResponse(justifications, _, _) => {
                 NetworkDataV1::RequestResponse(justifications)
             }
         }

--- a/finality-aleph/src/sync/forest/mod.rs
+++ b/finality-aleph/src/sync/forest/mod.rs
@@ -55,6 +55,7 @@ pub enum Interest<I: PeerId, J: Justification> {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Error {
     HeaderMissingParentId,
+    HeaderNotRequired,
     IncorrectParentState,
     IncorrectVertexState,
     ParentNotImported,
@@ -66,6 +67,7 @@ impl Display for Error {
         use Error::*;
         match self {
             HeaderMissingParentId => write!(f, "header did not contain a parent ID"),
+            HeaderNotRequired => write!(f, "header was not required"),
             IncorrectParentState => write!(
                 f,
                 "parent was in a state incompatible with importing this block"
@@ -332,6 +334,19 @@ where
             true => Ok(self.set_explicitly_required(&id)),
             false => Ok(false),
         }
+    }
+
+    /// Updates the provided header only if the identifier was already required.
+    pub fn update_required_header(
+        &mut self,
+        header: &J::Header,
+        holder: Option<I>,
+    ) -> Result<(), Error> {
+        if matches!(self.request_interest(&header.id()), Interest::Uninterested) {
+            return Err(Error::HeaderNotRequired);
+        }
+        self.update_header(header, holder, true)?;
+        Ok(())
     }
 
     /// Updates the vertex related to the provided header marking it as imported.

--- a/finality-aleph/src/sync/forest/mod.rs
+++ b/finality-aleph/src/sync/forest/mod.rs
@@ -67,7 +67,7 @@ impl Display for Error {
         use Error::*;
         match self {
             HeaderMissingParentId => write!(f, "header did not contain a parent ID"),
-            HeaderNotRequired => write!(f, "header was not required"),
+            HeaderNotRequired => write!(f, "header was not required, but it should have been"),
             IncorrectParentState => write!(
                 f,
                 "parent was in a state incompatible with importing this block"

--- a/finality-aleph/src/sync/handler.rs
+++ b/finality-aleph/src/sync/handler.rs
@@ -769,7 +769,7 @@ mod tests {
     fn handles_request() {
         let (mut handler, backend, _keep) = setup();
         let initial_state = handler.state().expect("state works");
-        let peer: MockPeerId = rand::random();
+        let peer = rand::random();
         let mut justifications: Vec<_> = import_branch(&backend, 500)
             .into_iter()
             .map(MockJustification::for_header)

--- a/finality-aleph/src/sync/handler.rs
+++ b/finality-aleph/src/sync/handler.rs
@@ -550,12 +550,12 @@ mod tests {
             .expect("importing in order");
         let justification = MockJustification::for_header(header);
         let peer = rand::random();
-        assert!(matches!(
+        assert!(
             handler
                 .handle_justification(justification.clone().into_unverified(), Some(peer))
-                .expect("correct justification"),
-            Some(id) if id == justification.id()
-        ));
+                .expect("correct justification")
+                == Some(justification.id())
+        );
         assert_eq!(
             backend.top_finalized().expect("mock backend works"),
             justification
@@ -573,12 +573,12 @@ mod tests {
             .map(MockJustification::for_header)
             .skip(1)
         {
-            assert!(matches!(
+            assert!(
                 handler
                     .handle_justification(justification.clone().into_unverified(), Some(peer))
-                    .expect("correct justification"),
-                Some(id) if id == justification.id()
-            ));
+                    .expect("correct justification")
+                    == Some(justification.id())
+            );
         }
     }
 
@@ -598,12 +598,12 @@ mod tests {
         // skip the first justification, now every next added justification
         // should spawn a new task
         for justification in justifications.into_iter().skip(1) {
-            assert!(matches!(
+            assert!(
                 handler
                     .handle_justification(justification.clone().into_unverified(), Some(peer))
-                    .expect("correct justification"),
-                Some(id) if id == justification.id()
-            ));
+                    .expect("correct justification")
+                    == Some(justification.id())
+            );
         }
     }
 
@@ -622,12 +622,12 @@ mod tests {
         .expect("mock backend works");
         let justification = MockJustification::for_header(header);
         let peer: MockPeerId = rand::random();
-        assert!(matches!(
+        assert!(
             handler
                 .handle_justification(justification.clone().into_unverified(), Some(peer))
-                .expect("correct justification"),
-            Some(id) if id == justification.id()
-        ));
+                .expect("correct justification")
+                == Some(justification.id())
+        );
         // should be auto-finalized, if Forest knows about imported body
         assert_eq!(
             backend.top_finalized().expect("mock backend works"),
@@ -646,7 +646,7 @@ mod tests {
             .expect("correct justification")
         {
             Some(id) => assert_eq!(id, header.id()),
-            _ => panic!("expected an id, got nothing"),
+            None => panic!("expected an id, got nothing"),
         }
         handler.block_imported(header).expect("importing in order");
         assert_eq!(

--- a/finality-aleph/src/sync/mod.rs
+++ b/finality-aleph/src/sync/mod.rs
@@ -36,7 +36,7 @@ pub trait PeerId: Debug + Clone + Hash + Eq {}
 impl<T: Debug + Clone + Hash + Eq> PeerId for T {}
 
 /// The header of a block, containing information about the parent relation.
-pub trait Header: Clone + Codec + Send + Sync + 'static {
+pub trait Header: Clone + Codec + Debug + Send + Sync + 'static {
     type Identifier: BlockIdentifier;
 
     /// The identifier of this block.

--- a/finality-aleph/src/sync/service.rs
+++ b/finality-aleph/src/sync/service.rs
@@ -276,10 +276,16 @@ where
             self.handler
                 .handle_request_response(justifications, headers, blocks, peer.clone());
         if let Some(e) = maybe_error {
-            warn!(
-                target: LOG_TARGET,
-                "Failed to handle sync state response from {:?}: {}.", peer, e
-            );
+            match e {
+                HandlerError::Verifier(e) => debug!(
+                    target: LOG_TARGET,
+                    "Could not verify justification from user: {}", e
+                ),
+                e => warn!(
+                    target: LOG_TARGET,
+                    "Failed to handle sync state response from {:?}: {}.", peer, e
+                ),
+            };
         }
         if let Some(id) = maybe_id {
             self.request_highest_justified(id);
@@ -296,12 +302,16 @@ where
         match self.handler.handle_request(request) {
             Ok(Some(data)) => self.send_to(data, peer),
             Ok(None) => (),
-            Err(e) => {
-                warn!(
+            Err(e) => match e {
+                HandlerError::Verifier(e) => debug!(
+                    target: LOG_TARGET,
+                    "Could not verify justification from user: {}", e
+                ),
+                e => warn!(
                     target: LOG_TARGET,
                     "Error handling request from {:?}: {}.", peer, e
-                );
-            }
+                ),
+            },
         }
     }
 
@@ -348,12 +358,16 @@ where
             Ok(_) => {
                 debug!(target: LOG_TARGET, "Already requested block {:?}.", id);
             }
-            Err(e) => {
-                warn!(
+            Err(e) => match e {
+                HandlerError::Verifier(e) => debug!(
+                    target: LOG_TARGET,
+                    "Could not verify justification from user: {}", e
+                ),
+                e => warn!(
                     target: LOG_TARGET,
                     "Error handling internal request for block {:?}: {}.", id, e
-                );
-            }
+                ),
+            },
         }
     }
 

--- a/finality-aleph/src/sync/service.rs
+++ b/finality-aleph/src/sync/service.rs
@@ -246,7 +246,6 @@ where
     //     }
     // }
 
-
     // fn handle_blocks(&mut self, blocks: Vec<B>, peer: N::PeerId) {
     //     if blocks.len() > MAX_BLOCK_BATCH {
     //         warn!(
@@ -264,8 +263,12 @@ where
     //     }
     // }
 
-
-    fn handle_state_response(&mut self, justification: J::Unverified, maybe_justification: Option<J::Unverified>, peer: N::PeerId) {
+    fn handle_state_response(
+        &mut self,
+        justification: J::Unverified,
+        maybe_justification: Option<J::Unverified>,
+        peer: N::PeerId,
+    ) {
         trace!(
             target: LOG_TARGET,
             "Handling state response {:?} {:?} received from {:?}.",
@@ -273,7 +276,10 @@ where
             maybe_justification,
             peer
         );
-        match self.handler.handle_state_response(justification, maybe_justification, peer.clone()) {
+        match self
+            .handler
+            .handle_state_response(justification, maybe_justification, peer.clone())
+        {
             Ok(Some(block_id)) => self.request_highest_justified(block_id),
             Ok(None) => (),
             Err(e) => match e {
@@ -306,33 +312,38 @@ where
         }
     }
 
-    fn handle_request_response(&mut self, justifications: Vec<J::Unverified>, headers: Vec<J::Header>, blocks: Vec<B>, peer: N::PeerId) {
-        let (maybe_block_id, maybe_error) = self.handler.handle_request_response(justifications, headers, blocks, peer);
+    fn handle_request_response(
+        &mut self,
+        justifications: Vec<J::Unverified>,
+        headers: Vec<J::Header>,
+        blocks: Vec<B>,
+        peer: N::PeerId,
+    ) {
+        let (maybe_block_id, maybe_error) =
+            self.handler
+                .handle_request_response(justifications, headers, blocks, peer);
         if let Some(block_id) = maybe_block_id {
             self.request_highest_justified(block_id);
         }
-        if let Err(e) = maybe_error {
-
-        }
+        if let Err(e) = maybe_error {}
     }
 
+    // if let (Some(peer), true) = (&maybe_peer, justifications.len() > MAX_JUSTIFICATION_BATCH) {
+    //     warn!(
+    //         target: LOG_TARGET,
+    //         "Peer {:?} sent too many justifications: {}, we expected at most {}, aborting.",
+    //         peer,
+    //         justifications.len(),
+    //         MAX_JUSTIFICATION_BATCH,
+    //     );
+    //     return;
+    // }
 
-        // if let (Some(peer), true) = (&maybe_peer, justifications.len() > MAX_JUSTIFICATION_BATCH) {
-        //     warn!(
-        //         target: LOG_TARGET,
-        //         "Peer {:?} sent too many justifications: {}, we expected at most {}, aborting.",
-        //         peer,
-        //         justifications.len(),
-        //         MAX_JUSTIFICATION_BATCH,
-        //     );
-        //     return;
-        // }
-
-        // trace!(
-        //     target: LOG_TARGET,
-        //     "Handling {:?} justifications.",
-        //     justifications.len()
-        // );
+    // trace!(
+    //     target: LOG_TARGET,
+    //     "Handling {:?} justifications.",
+    //     justifications.len()
+    // );
 
     fn handle_request(&mut self, request: Request<J>, peer: N::PeerId) {
         trace!(


### PR DESCRIPTION
# Description

Fixing the flawed handling of incoming responses in the sync.
Further separating `Service` and `Handler` logic.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- I have made corresponding changes to the existing documentation
- I have created new documentation
