### PR TITLE
[Abandoned, see #1273] A0-2776: Bump rust version to 1.68.2

### DIFF
--- a/.github/workflows/_unit-tests-and-static-checks.yml
+++ b/.github/workflows/_unit-tests-and-static-checks.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install Rust Toolchain
         uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v1
         with:
+          channel: nightly-2023-01-22
           targets: wasm32-unknown-unknown
           components: clippy rustfmt
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-10-30"
+channel = "stable-2023-03-28"
 targets = [ "wasm32-unknown-unknown" ]
 components = [ "rustfmt", "clippy", "rust-src" ]
 profile = "minimal"

--- a/scripts/run_checks_on_aleph_node.sh
+++ b/scripts/run_checks_on_aleph_node.sh
@@ -3,5 +3,5 @@
 set -e
 
 CARGO_INCREMENTAL=0 cargo clippy --all-targets --all-features -- --no-deps -D warnings
-CARGO_INCREMENTAL=0 cargo fmt --all
+CARGO_INCREMENTAL=0 cargo +nightly fmt --all
 CARGO_INCREMENTAL=0 cargo test --lib

--- a/scripts/run_checks_on_excluded_packages.sh
+++ b/scripts/run_checks_on_excluded_packages.sh
@@ -51,7 +51,7 @@ for p in ${packages[@]}; do
     cargo +${RUST_TOOLCHAIN} clippy -- --no-deps -D warnings
   fi
 
-  cargo fmt --all --check
+  cargo +nightly fmt --all --check
   popd
 
 done


### PR DESCRIPTION
# Description

Switched to stable rust 1.68.2 and updated scripts and workflows using cargo fmt to still use nightly toolchain (rust 1.68.0 nightly), we have some nightly rules in `rustfmt.toml` file.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- I have made necessary updates to the Infrastructure
