### PR TITLE
A0-2783: Shorten Slack notification

### DIFF
--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -46,3 +46,5 @@ runs:
         SLACK_TITLE: "*Status: ${{ env.STATUS }}* \n || \n Workflow: ${{ env.WORKFLOW_NAME }}"
         SLACK_USERNAME: GithubActions
         SLACK_ICON_EMOJI: ":aleph:"
+        MSG_MINIMAL:  "actions url,commit"
+        SLACK_MESSAGE: ""

--- a/.github/workflows/on-pull-request-label.yml
+++ b/.github/workflows/on-pull-request-label.yml
@@ -27,3 +27,18 @@ jobs:
     name: Delete featurenet
     uses: ./.github/workflows/_delete-featurenet.yml
     secrets: inherit
+
+  slack:
+    name: Slack notification
+    runs-on: ubuntu-20.04
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Send Slack message
+        uses: ./.github/actions/slack-notification
+        with:
+          notify-on: "always"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TEMP_GRAFANA_NOTIFICATIONS }}


### PR DESCRIPTION
# Description
By default Slack notification contains too much information, especially commit message. As know we have a commit message in aleph-node that defaults to PR description that can be lengthy. 

This task is to shorten Slack notification to have just commit sha and information which test failed.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

