### PR TITLE
A0-0000: Bump version of ink-dev image used in clean.sh script

### DIFF
--- a/contracts/scripts/clean.sh
+++ b/contracts/scripts/clean.sh
@@ -12,7 +12,7 @@ function run_ink_builder() {
     --name ink_builder \
     --platform linux/amd64 \
     --detach \
-    --rm public.ecr.aws/p6e8q1z1/ink-dev:1.0.0 sleep 1d
+    --rm public.ecr.aws/p6e8q1z1/ink-dev:1.5.0 sleep 1d
 }
 
 function ink_build() {

--- a/contracts/scripts/clean.sh
+++ b/contracts/scripts/clean.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 
 # --- FUNCTIONS
 
+function stop_ink_builder() {
+  docker stop ink_builder
+}
+
 function run_ink_builder() {
   docker start ink_builder || docker run \
     --network host \
@@ -12,7 +16,7 @@ function run_ink_builder() {
     --name ink_builder \
     --platform linux/amd64 \
     --detach \
-    --rm public.ecr.aws/p6e8q1z1/ink-dev:1.5.0 sleep 1d
+    --rm public.ecr.aws/p6e8q1z1/ink-dev:1.0.0 sleep 1d
 }
 
 function ink_build() {
@@ -111,5 +115,7 @@ echo "succesfully terminated and removed wrapped_azero"
 terminate_contract access_control access_control
 remove_contract_code access_control_code_hash
 echo "succesfully terminated and removed AccessControl"
+
+stop_ink_builder
 
 exit $?


### PR DESCRIPTION
# Description
Version of `ink-dev` image used in `clean.sh` script was not updated and still ran at `1.0.0` which has `cargo-contract` 
 incompatible with updated instructions from `deploy.sh`. Since we run a docker container in a detached, daemon mode in `clean.sh`, a new container with correct version (`1.5.0`) was not ran and old one was reused - which led to failures in the deployment.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have made neccessary updates to the Infrastructure
