### PR TITLE
Local test for block sync in presence of reorgs

### DIFF
--- a/local-tests/test_force_reorg.py
+++ b/local-tests/test_force_reorg.py
@@ -1,0 +1,68 @@
+#!/bin/env python
+import os
+from os.path import abspath, join
+from time import ctime
+from chainrunner import Chain, Seq, generate_keys
+
+
+def printt(s): print(ctime() + ' | ' + s)
+
+
+# Path to working directory, where chainspec, logs and nodes' dbs are written:
+workdir = abspath(os.getenv('WORKDIR', '/tmp/workdir'))
+# Path to the aleph-node binary (important DON'T use short-session feature):
+binary = abspath(os.getenv('ALEPH_NODE_BINARY', join(workdir, 'aleph-node')))
+
+phrases = [f'//{i}' for i in range(8)]
+keys = generate_keys(binary, phrases)
+chain = Chain(workdir)
+printt('Bootstrapping the chain with binary')
+
+chain.bootstrap(binary,
+                keys.values(),
+                sudo_account_id=keys[phrases[0]],
+                chain_type='local')
+chain.set_flags('no-mdns',
+                port=Seq(30334),
+                validator_port=Seq(30343),
+                ws_port=Seq(9944),
+                rpc_port=Seq(9933),
+                unit_creation_delay=200,
+                execution='Native')
+
+addresses = [n.address() for n in chain]
+validator_addresses = [n.validator_address() for n in chain]
+chain.set_flags(bootnodes=addresses[1])
+chain.set_flags_validator(public_addr=addresses, public_validator_addresses=validator_addresses)
+
+BLOCKS_PER_STAGE = 50
+chain.set_flags_validator('validator')
+chain.set_flags('max_nonfinalized_blocks', max_nonfinalized_blocks=BLOCKS_PER_STAGE)
+
+printt('Starting the chain')
+chain.start('aleph')
+part1 = [0, 2, 4, 6]  # Node ids partitioned into two halves
+part2 = [1, 3, 5, 7]
+chain.wait_for_finalization(0)
+chain.wait_for_block_id_imported(BLOCKS_PER_STAGE)
+
+printt('Stopping nodes: ' + ' '.join([str(n) for n in part2]))
+chain.stop(nodes=part2)
+f1 = chain.get_highest_finalized(nodes=part1)
+chain.wait_for_block_id_imported(f1 + BLOCKS_PER_STAGE, nodes=part1)
+
+printt('Stopping nodes: ' + ' '.join([str(n) for n in part1]))
+chain.stop(nodes=part1)
+
+printt('Starting nodes: ' + ' '.join([str(n) for n in part2]))
+chain.start('aleph', nodes=part2)
+chain.wait_for_finalization(0, nodes=part2)
+f2 = chain.get_highest_finalized(nodes=part2)
+chain.wait_for_block_id_imported(f2 + BLOCKS_PER_STAGE, nodes=part2)
+
+printt('Starting nodes: ' + ' '.join([str(n) for n in part1]))
+chain.start('aleph', nodes=part1)
+f = chain.get_highest_finalized()
+chain.wait_for_finalization(0)  # wait for finalization catchup
+
+print('Ok')


### PR DESCRIPTION
# Description
A test which ensures that block sync works in presence of forks.
The test implements the following scenario:
1. split validators into two halves: `X, Y` and let them produce blocks for a while
2. kill `X`, let `Y` produce blocks for a while
3. kill `Y`, recover `X` and let it produce blocks for a while
4. recover `Y`, both `X` and `Y` should discover a fork and one of them should perform a reorg

## Type of change

local test
