### PR TITLE
A0-2942: Remove dead statuses from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 [![LOGO][aleph-logo]][aleph-homepage]
 
-[![Unit tests][unit-tests-badge]][unit-tests]
-[![E2E Tests][e2e-tests-badge]][e2e-tests]
-
 This repository contains the Rust implementation of [Aleph Zero][aleph-homepage] blockchain node based on the [Substrate][substrate-homepage] framework.
 
 Aleph Zero is an open-source layer 1 blockchain focused on privacy, scalability and energy efficiency. It is based on a unique, peer-reviewed consensus algorithm, AlephBFT (as described in our [paper][aleph-bft-paper] and implemented [here][aleph-bft-link]).
@@ -42,8 +39,4 @@ The code in this repository is licensed as follows:
 [aleph-bft-paper]: https://arxiv.org/abs/1908.05156
 [aleph-polkadot-link]: https://github.com/Cardinal-Cryptography/apps
 [substrate-homepage]: https://substrate.io
-[unit-tests]: https://github.com/Cardinal-Cryptography/aleph-node/actions/workflows/unit_tests.yml
-[unit-tests-badge]: https://github.com/Cardinal-Cryptography/aleph-node/actions/workflows/unit_tests.yml/badge.svg
-[e2e-tests]: https://github.com/Cardinal-Cryptography/aleph-node/actions/workflows/e2e-tests-main-devnet.yml
-[e2e-tests-badge]: https://github.com/Cardinal-Cryptography/aleph-node/actions/workflows/e2e-tests-main-devnet.yml/badge.svg
 [build]: ./BUILD.md


### PR DESCRIPTION
# Description

Since we are no longer running unit/e2e tests on merge to the `main` branch (apart from button-related, but this is temporary afaik), we should get rid of invalid links from `README.md` (and thus repo's main page).

## Type of change

- Bug fix (non-breaking change which fixes an issue)