### PR TITLE
A0-1116: Set transaction_version to 16

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -96,7 +96,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 56,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 14,
+    transaction_version: 16,
     state_version: 0,
 };
 


### PR DESCRIPTION
# Description

Mainnet & Testnet should be at least on `transaction_version` 16 , so in order to not do it every time we cut off release branch, we update this value on `main`.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

