### PR TITLE
A0-2968: Remove setup-protoc step

### DIFF
--- a/.github/workflows/build-send-postsync-hook-runtime-image.yml
+++ b/.github/workflows/build-send-postsync-hook-runtime-image.yml
@@ -32,12 +32,6 @@ jobs:
       - name: Install Rust toolchain
         uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v1
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          version: '3.6.1'
-          repo-token: ${{ secrets.CI_GH_TOKEN }}
-
       - name: Build binary
         run: |
           pushd bin/cliain/


### PR DESCRIPTION
# Description

Removes `setup-protoc` action call that install protoc because the workflow runs on our github runner that already has protoc installed (also, in a different version).

## Type of change

The change does not break anything.
