### PR TITLE
A0-2978: Accept more responses in sync Handler

### DIFF
--- a/finality-aleph/src/sync/forest/mod.rs
+++ b/finality-aleph/src/sync/forest/mod.rs
@@ -557,6 +557,18 @@ where
             _ => false,
         }
     }
+
+    /// Whether this block should be skipped during importing.
+    /// It either needs to be already imported, or too old to be checked.
+    pub fn skippable(&self, id: &BlockIdFor<J>) -> bool {
+        use SpecialState::{BelowMinimal, HighestFinalized};
+        use VertexHandle::{Candidate, Special};
+        match self.get(id) {
+            Special(BelowMinimal | HighestFinalized) => true,
+            Candidate(vertex) => vertex.vertex.imported(),
+            _ => false,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/finality-aleph/src/sync/forest/mod.rs
+++ b/finality-aleph/src/sync/forest/mod.rs
@@ -60,7 +60,6 @@ pub enum Interest<I: PeerId, J: Justification> {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Error {
     HeaderMissingParentId,
-    HeaderIsAuxiliary,
     IncorrectParentState,
     IncorrectVertexState,
     ParentNotImported,
@@ -72,7 +71,6 @@ impl Display for Error {
         use Error::*;
         match self {
             HeaderMissingParentId => write!(f, "header did not contain a parent ID"),
-            HeaderIsAuxiliary => write!(f, "header should not be auxiliary"),
             IncorrectParentState => write!(
                 f,
                 "parent was in a state incompatible with importing this block"
@@ -349,20 +347,6 @@ where
             true => Ok(self.set_explicitly_required(&id)),
             false => Ok(false),
         }
-    }
-
-    /// Updates the provided header only if the identifier was not auxiliary.
-    pub fn update_non_auxiliary_header(
-        &mut self,
-        header: &J::Header,
-        holder: Option<I>,
-    ) -> Result<(), Error> {
-        if !matches!(self.get(&header.id()), VertexHandle::Candidate(vertex) if !vertex.vertex.auxiliary())
-        {
-            return Err(Error::HeaderIsAuxiliary);
-        }
-        self.update_header(header, holder, true)?;
-        Ok(())
     }
 
     /// Updates the vertex related to the provided header marking it as imported.

--- a/finality-aleph/src/sync/forest/vertex.rs
+++ b/finality-aleph/src/sync/forest/vertex.rs
@@ -50,22 +50,6 @@ impl<I: PeerId, J: Justification> Vertex<I, J> {
         }
     }
 
-    /// Whether the vertex is auxiliary.
-    pub fn auxiliary(&self) -> bool {
-        use Importance::*;
-        use InnerVertex::*;
-        matches!(
-            self.inner,
-            Empty {
-                required: Auxiliary,
-                ..
-            } | Header {
-                importance: HeaderImportance::Unimported(Auxiliary),
-                ..
-            }
-        )
-    }
-
     /// Whether we want the referenced block in our database.
     pub fn importable(&self) -> bool {
         use Importance::*;

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -416,6 +416,9 @@ where
                     }
                 }
                 ResponseItem::Block(b) => {
+                    if self.forest.skippable(&b.header().id()) {
+                        continue;
+                    }
                     match self.forest.importable(&b.header().id()) {
                         true => self.block_importer.import_block(b),
                         false => return (highest_justified, Some(Error::BlockNotImportable)),

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -792,6 +792,38 @@ mod tests {
         let (mut handler, _backend, mut notifier, genesis) = setup();
         let branch = grow_light_branch(&mut handler, &genesis, 35, 4);
 
+        let short_response = branch_response(
+            branch[..15].to_vec(),
+            BranchResponseContent {
+                headers: false,
+                blocks: true,
+                justifications: false,
+            },
+        );
+        let (maybe_id, maybe_error) = handler.handle_request_response(short_response, 2);
+        assert!(maybe_id.is_none());
+        assert!(maybe_error.is_none());
+        mark_branch_imported(&mut handler, &mut notifier, &branch[..15].to_vec()).await;
+
+        let mid_response = branch_response(
+            branch.to_vec(),
+            BranchResponseContent {
+                headers: false,
+                blocks: true,
+                justifications: false,
+            },
+        );
+        let (maybe_id, maybe_error) = handler.handle_request_response(mid_response, 3);
+        assert!(maybe_id.is_none());
+        assert!(maybe_error.is_none());
+        mark_branch_imported(&mut handler, &mut notifier, &branch[15..].to_vec()).await;
+    }
+
+    #[tokio::test]
+    async fn handles_multiple_overlapping_responses() {
+        let (mut handler, _backend, mut notifier, genesis) = setup();
+        let branch = grow_light_branch(&mut handler, &genesis, 35, 4);
+
         // 15 blocks and justifications -> top is 15, new highest justification
         let short_response = branch_response(
             branch[..15].to_vec(),


### PR DESCRIPTION
# Description

`sync::Handler` should not drop request responses containing already imported blocks. This PR changes the import strategy to simply skip old/imported blocks.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- I have added tests
- I have created new documentation