### PR TITLE
A0-2988: Remove cargo-dylint installation step.

### DIFF
--- a/.github/workflows/_check-excluded-packages.yml
+++ b/.github/workflows/_check-excluded-packages.yml
@@ -48,9 +48,6 @@ jobs:
           export CARGO_TARGET_DIR=/tmp/contracts_toolchain/$RUST_CONTRACTS_TOOLCHAIN/target/
 
           cargo +${RUST_CONTRACTS_TOOLCHAIN} \
-            install cargo-dylint dylint-link
-
-          cargo +${RUST_CONTRACTS_TOOLCHAIN} \
             install --version $CARGO_CONTRACT_VERSION \
             --force --locked cargo-contract
 


### PR DESCRIPTION
# Description

Removes `cargo-dylint` installation from `check-excluded-packages` step. 

## Type of change

# Checklist:
