### PR TITLE
A0-2846: removed purge-alephbft-backup from the purge-backup command

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -1,12 +1,12 @@
 use sc_cli::{
     clap::{self, Parser, Subcommand as ClapSubcommand},
-    ChainSpec, RunCmd, RuntimeVersion, SubstrateCli,
+    ChainSpec, PurgeChainCmd, RunCmd, RuntimeVersion, SubstrateCli,
 };
 
 use crate::{
     aleph_cli::AlephCli,
     chain_spec,
-    commands::{BootstrapChainCmd, BootstrapNodeCmd, ConvertChainspecToRawCmd, PurgeChainCmd},
+    commands::{BootstrapChainCmd, BootstrapNodeCmd, ConvertChainspecToRawCmd, PurgeBackupCmd},
 };
 
 #[derive(Debug, Parser)]
@@ -96,6 +96,9 @@ pub enum Subcommand {
 
     /// Remove the whole chain.
     PurgeChain(PurgeChainCmd),
+
+    /// Remove AlephBFT backup.
+    PurgeBackup(PurgeBackupCmd),
 
     /// Revert the chain to a previous state.
     Revert(sc_cli::RevertCmd),

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -6,7 +6,7 @@ use sc_cli::{
 use crate::{
     aleph_cli::AlephCli,
     chain_spec,
-    commands::{BootstrapChainCmd, BootstrapNodeCmd, ConvertChainspecToRawCmd, PurgeBackupCmd},
+    commands::{BootstrapChainCmd, BootstrapNodeCmd, ConvertChainspecToRawCmd},
 };
 
 #[derive(Debug, Parser)]
@@ -96,9 +96,6 @@ pub enum Subcommand {
 
     /// Remove the whole chain.
     PurgeChain(PurgeChainCmd),
-
-    /// Remove AlephBFT backup.
-    PurgeBackup(PurgeBackupCmd),
 
     /// Revert the chain to a previous state.
     Revert(sc_cli::RevertCmd),

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -97,6 +97,10 @@ fn main() -> sc_cli::Result<()> {
             let runner = cli.create_runner(cmd)?;
             runner.sync_run(|config| cmd.run(config.database))
         }
+        Some(Subcommand::PurgeBackup(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            runner.sync_run(|_| cmd.run())
+        }
         Some(Subcommand::Revert(cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.async_run(|config| {

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -97,10 +97,6 @@ fn main() -> sc_cli::Result<()> {
             let runner = cli.create_runner(cmd)?;
             runner.sync_run(|config| cmd.run(config.database))
         }
-        Some(Subcommand::PurgeBackup(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.sync_run(|_| cmd.run())
-        }
         Some(Subcommand::Revert(cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.async_run(|config| {


### PR DESCRIPTION
# Description

Removed a sub-command of the purge-chain command that was deleting files of the alephbft backup.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
After this change alephbft's backup can be removed only by manually deleting its root folder inside `--base-path`.