### PR TITLE
A0-2902: Fix for nightly pipeline tests

### DIFF
--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -1,7 +1,11 @@
 ---
-name: E2E synthetic network tests (Nightly pipeline)
+name: Nightly pipeline normal session e2e tests
 
 on:
+  # temp, remove before merge
+  push:
+    branches:
+      - A0-2902-fix
   workflow_dispatch:
   schedule:
     - cron: '00 22 * * *'
@@ -45,6 +49,7 @@ jobs:
     with:
       build-production-node: true
       build-synthetic-network-docker: true
+      build-e2e-client-image: true
 
   run-e2e-high-out-latency:
     needs: [build-production-node-and-e2e-client-image]
@@ -78,7 +83,7 @@ jobs:
           path: target/release/
 
       - name: Run test
-        timeout-minutes: 130
+        timeout-minutes: 15
         env:
           ALEPH_NODE_BINARY: ../target/release/aleph-node
         run: ./.github/scripts/test_major_sync.sh

--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -49,7 +49,7 @@ jobs:
     with:
       build-production-node: true
       build-synthetic-network-docker: true
-      build-e2e-client-image: true
+      build-e2e-client: true
 
   run-e2e-high-out-latency:
     needs: [build-production-node-and-e2e-client-image]

--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -2,10 +2,6 @@
 name: Nightly pipeline normal session e2e tests
 
 on:
-  # temp, remove before merge
-  push:
-    branches:
-      - A0-2902-fix
   workflow_dispatch:
   schedule:
     - cron: '00 22 * * *'

--- a/.github/workflows/nightly-short-session-e2e-tests.yml
+++ b/.github/workflows/nightly-short-session-e2e-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: E2E logic tests (Nightly pipeline)
+name: Nightly pipeline short session e2e tests
 on:
   workflow_dispatch:
   schedule:

--- a/local-tests/test_major_sync.py
+++ b/local-tests/test_major_sync.py
@@ -42,8 +42,8 @@ chain.start('aleph', nodes=[0, 1, 2, 3])
 sleep(60)
 chain.start('aleph', nodes=[4])
 
-printt('Waiting around 5 mins')
-sleep(5 * 60)
+printt('Waiting around 10 mins')
+sleep(10 * 60)
 
 finalized = check_finalized(chain)
 


### PR DESCRIPTION
# Description

* bugfix for defect introduced in https://github.com/Cardinal-Cryptography/aleph-node/pull/1356 that e2e client is not build for one nightly pipeline workflow
* increase timeout from 5 to 10 minutes for sync catchup test

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue


