### PR TITLE
A0-3059: Factor out sync metrics

### DIFF
--- a/finality-aleph/src/nodes.rs
+++ b/finality-aleph/src/nodes.rs
@@ -156,7 +156,7 @@ where
         database_io,
         session_info.clone(),
         justification_rx,
-        metrics.clone(),
+        registry.clone(),
     ) {
         Ok(x) => x,
         Err(e) => panic!("Failed to initialize Sync service: {e}"),

--- a/finality-aleph/src/sync/metrics.rs
+++ b/finality-aleph/src/sync/metrics.rs
@@ -76,38 +76,37 @@ pub enum Metrics {
 
 impl Metrics {
     pub fn new(registry: Option<Registry>) -> Result<Self, PrometheusError> {
-        match registry {
-            Some(registry) => {
-                let mut calls = HashMap::new();
-                let mut errors = HashMap::new();
-                for event in ALL_EVENTS {
-                    calls.insert(
-                        event,
-                        register(
-                            Counter::new(
-                                format!("aleph_sync_{}", event.name()),
-                                format!("number of times {} has been called", event.name()),
-                            )?,
-                            &registry,
-                        )?,
-                    );
-                }
-                for event in ERRORING_EVENTS {
-                    errors.insert(
-                        event,
-                        register(
-                            Counter::new(
-                                format!("aleph_sync_{}_error", event.name()),
-                                format!("number of times {} has returned an error", event.name()),
-                            )?,
-                            &registry,
-                        )?,
-                    );
-                }
-                Ok(Metrics::Prometheus { calls, errors })
-            }
-            None => Ok(Metrics::Noop),
+        let registry = match registry {
+            Some(registry) => registry,
+            None => return Ok(Metrics::Noop),
+        };
+        let mut calls = HashMap::new();
+        let mut errors = HashMap::new();
+        for event in ALL_EVENTS {
+            calls.insert(
+                event,
+                register(
+                    Counter::new(
+                        format!("aleph_sync_{}", event.name()),
+                        format!("number of times {} has been called", event.name()),
+                    )?,
+                    &registry,
+                )?,
+            );
         }
+        for event in ERRORING_EVENTS {
+            errors.insert(
+                event,
+                register(
+                    Counter::new(
+                        format!("aleph_sync_{}_error", event.name()),
+                        format!("number of times {} has returned an error", event.name()),
+                    )?,
+                    &registry,
+                )?,
+            );
+        }
+        Ok(Metrics::Prometheus { calls, errors })
     }
 
     pub fn noop() -> Self {

--- a/finality-aleph/src/sync/metrics.rs
+++ b/finality-aleph/src/sync/metrics.rs
@@ -1,0 +1,132 @@
+use std::collections::HashMap;
+
+use substrate_prometheus_endpoint::{register, Counter, PrometheusError, Registry, U64};
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum Event {
+    Broadcast,
+    SendRequest,
+    SendTo,
+    HandleState,
+    HandleRequestResponse,
+    HandleRequest,
+    HandleTask,
+    HandleBlockImported,
+    HandleBlockFinalized,
+    HandleStateResponse,
+    HandleJustificationFromUser,
+    HandleInternalRequest,
+}
+
+use Event::*;
+
+impl Event {
+    fn name(&self) -> &str {
+        match self {
+            Broadcast => "broadcast",
+            SendRequest => "send_request",
+            SendTo => "send_to",
+            HandleState => "handle_state",
+            HandleRequestResponse => "handle_request_response",
+            HandleRequest => "handle_request",
+            HandleTask => "handle_task",
+            HandleBlockImported => "handle_block_imported",
+            HandleBlockFinalized => "handle_block_finalized",
+            HandleStateResponse => "handle_state_response",
+            HandleJustificationFromUser => "handle_justification_from_user",
+            HandleInternalRequest => "handle_internal_request",
+        }
+    }
+}
+
+const ALL_EVENTS: [Event; 12] = [
+    Broadcast,
+    SendRequest,
+    SendTo,
+    HandleState,
+    HandleRequestResponse,
+    HandleRequest,
+    HandleTask,
+    HandleBlockImported,
+    HandleBlockFinalized,
+    HandleStateResponse,
+    HandleJustificationFromUser,
+    HandleInternalRequest,
+];
+
+const ERRORING_EVENTS: [Event; 9] = [
+    Broadcast,
+    SendRequest,
+    SendTo,
+    HandleState,
+    HandleRequest,
+    HandleTask,
+    HandleBlockImported,
+    HandleJustificationFromUser,
+    HandleInternalRequest,
+];
+
+pub enum Metrics {
+    Prometheus {
+        calls: HashMap<Event, Counter<U64>>,
+        errors: HashMap<Event, Counter<U64>>,
+    },
+    Noop,
+}
+
+impl Metrics {
+    pub fn new(registry: Option<Registry>) -> Result<Self, PrometheusError> {
+        match registry {
+            Some(registry) => {
+                let mut calls = HashMap::new();
+                let mut errors = HashMap::new();
+                for event in ALL_EVENTS {
+                    calls.insert(
+                        event,
+                        register(
+                            Counter::new(
+                                format!("aleph_sync_{}", event.name()),
+                                format!("number of times {} has been called", event.name()),
+                            )?,
+                            &registry,
+                        )?,
+                    );
+                }
+                for event in ERRORING_EVENTS {
+                    errors.insert(
+                        event,
+                        register(
+                            Counter::new(
+                                format!("aleph_sync_{}_error", event.name()),
+                                format!("number of times {} has returned an error", event.name()),
+                            )?,
+                            &registry,
+                        )?,
+                    );
+                }
+                Ok(Metrics::Prometheus { calls, errors })
+            }
+            None => Ok(Metrics::Noop),
+        }
+    }
+
+    pub fn noop() -> Self {
+        Metrics::Noop
+    }
+
+    pub fn report_event(&self, event: Event) {
+        if let Metrics::Prometheus { calls, .. } = self {
+            if let Some(counter) = calls.get(&event) {
+                counter.inc();
+            }
+        }
+    }
+
+    pub fn report_event_error(&self, event: Event) {
+        if let Metrics::Prometheus { errors, .. } = self {
+            if let Some(counter) = errors.get(&event) {
+                counter.inc();
+            }
+        }
+    }
+}

--- a/finality-aleph/src/sync/mod.rs
+++ b/finality-aleph/src/sync/mod.rs
@@ -11,6 +11,7 @@ mod data;
 mod forest;
 mod handler;
 mod message_limiter;
+mod metrics;
 #[cfg(test)]
 mod mock;
 mod service;


### PR DESCRIPTION
# Description

Factor out the sync metrics from the centralized metrics, plus some changes to how they are organized. Since the metric names were not uniform anyway I changed them – this means there will need to be a companion PR on the Grafana side.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- I haven't made neccessary updates to the Infrastructure, but I will
