### PR TITLE
A0-3053: Add logging to e2e button tests

### DIFF
--- a/.github/actions/run-e2e-test/action.yml
+++ b/.github/actions/run-e2e-test/action.yml
@@ -128,6 +128,7 @@ runs:
 
         if [[ "${DEPLOY_BUTTON}" = "true" ]]; then
           source contracts/env/dev
+          export LIFETIME=20
           contracts/scripts/deploy.sh
           source contracts/scripts/test_env
         fi

--- a/.github/workflows/_run-button-e2e-tests.yml
+++ b/.github/workflows/_run-button-e2e-tests.yml
@@ -55,6 +55,7 @@ jobs:
           deploy-button: true
           clean-button: true
           test-case: button
+          node-count: 1
         timeout-minutes: 20
 
   deploy-button:

--- a/aleph-client/src/contract/mod.rs
+++ b/aleph-client/src/contract/mod.rs
@@ -256,7 +256,10 @@ impl ContractInstance {
         // and we have to inspect flags manually.
         if let Ok(res) = &contract_read_result.result {
             if res.did_revert() {
-                return Err(anyhow!("Dry-run call reverted"));
+                return Err(anyhow!(
+                    "Dry-run call reverted, decoded result: {:?}",
+                    self.decode(message, res.data.clone())
+                ));
             }
         }
 

--- a/e2e-tests/src/test/button_game/helpers.rs
+++ b/e2e-tests/src/test/button_game/helpers.rs
@@ -226,9 +226,13 @@ pub(super) async fn setup_button_test(
 ) -> Result<ButtonTestContext> {
     let (conn, authority, player) = basic_test_context(config).await?;
 
+    info!("Setting up button contract instance");
     let button = Arc::new(ButtonInstance::new(config, button_contract_address)?);
+    info!("Setting up ticket token contract instance");
     let ticket_token = Arc::new(ticket_token(&conn, &button, config).await?);
+    info!("Setting up reward token contract instance");
     let reward_token = Arc::new(reward_token(&conn, &button, config).await?);
+    info!("Setting up marketplace contract instance");
     let marketplace = Arc::new(marketplace(&conn, &button, config).await?);
 
     let c1 = button.clone();
@@ -247,6 +251,7 @@ pub(super) async fn setup_button_test(
             c4.as_ref().into(),
         ];
 
+        info!("Listening for events from {:?}", contract_metadata);
         listen_contract_events(&listen_conn, &contract_metadata, events_tx)
             .await
             .unwrap();
@@ -268,10 +273,12 @@ pub(super) async fn setup_button_test(
 
 /// Prepares a `(conn, authority, account)` triple with some money in `account` for fees.
 async fn basic_test_context(config: &Config) -> Result<(Connection, KeyPair, KeyPair)> {
+    info!("Connecting to node at {}", config.node);
     let conn = Connection::new(&config.node).await;
     let authority = aleph_client::keypair_from_string(&config.sudo_seed);
     let account = random_account();
 
+    info!("Transferring 100 ALEPH to a random test account");
     transfer(&conn, &authority, &account, alephs(100)).await?;
 
     Ok((conn, authority, account))

--- a/e2e-tests/src/test/button_game/mod.rs
+++ b/e2e-tests/src/test/button_game/mod.rs
@@ -458,6 +458,8 @@ async fn button_game_play<F: Fn(u128, u128, u128, u128)>(
         player,
         ..
     } = setup_button_test(config, button_contract_address).await?;
+    info!("Setup done");
+
     let player = &player;
 
     ticket_token


### PR DESCRIPTION
# Description

I made the tests run on a single node (I think some of the issues, notably the timeouts were related to this) and added some logging around the spots I think can still be flaky to get more info later. This might not solve everything, but I think it's an improvement.

## Type of change

- Bug fix (non-breaking change which fixes an issue)