### PR TITLE
A0-3060: Separate network metrics

### DIFF
--- a/finality-aleph/src/network/gossip/metrics.rs
+++ b/finality-aleph/src/network/gossip/metrics.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+use substrate_prometheus_endpoint::{
+    exponential_buckets, prometheus::HistogramTimer, register, Histogram, HistogramOpts, Opts,
+    PrometheusError, Registry,
+};
+
+use crate::Protocol;
+
+fn protocol_name(protocol: Protocol) -> String {
+    use Protocol::*;
+    match protocol {
+        Authentication => "authentication",
+        BlockSync => "block_sync",
+    }
+    .to_string()
+}
+
+#[derive(Clone)]
+pub enum Metrics {
+    Prometheus {
+        send_times: HashMap<Protocol, Histogram>,
+    },
+    Noop,
+}
+
+impl Metrics {
+    pub fn new(registry: Option<Registry>) -> Result<Self, PrometheusError> {
+        use Protocol::*;
+        let registry = match registry {
+            Some(registry) => registry,
+            None => return Ok(Metrics::Noop),
+        };
+
+        let mut send_times = HashMap::new();
+        for protocol in [Authentication, BlockSync] {
+            send_times.insert(
+                protocol,
+                register(
+                    Histogram::with_opts(HistogramOpts {
+                        common_opts: Opts {
+                            namespace: "gossip_network".to_string(),
+                            subsystem: protocol_name(protocol),
+                            name: "send_duration".to_string(),
+                            help: "How long did it take for substrate to send a message."
+                                .to_string(),
+                            const_labels: Default::default(),
+                            variable_labels: Default::default(),
+                        },
+                        buckets: exponential_buckets(0.001, 1.26, 30)?,
+                    })?,
+                    &registry,
+                )?,
+            );
+        }
+        Ok(Metrics::Prometheus { send_times })
+    }
+
+    pub fn noop() -> Self {
+        Metrics::Noop
+    }
+
+    pub fn start_sending_in(&self, protocol: Protocol) -> Option<HistogramTimer> {
+        match self {
+            Metrics::Prometheus { send_times } => send_times
+                .get(&protocol)
+                .map(|histogram| histogram.start_timer()),
+            Metrics::Noop => None,
+        }
+    }
+}

--- a/finality-aleph/src/network/gossip/mod.rs
+++ b/finality-aleph/src/network/gossip/mod.rs
@@ -9,6 +9,7 @@ use bytes::Bytes;
 
 use crate::network::Data;
 
+mod metrics;
 #[cfg(test)]
 pub mod mock;
 mod service;

--- a/finality-aleph/src/nodes.rs
+++ b/finality-aleph/src/nodes.rs
@@ -111,7 +111,7 @@ where
     let (gossip_network_service, authentication_network, block_sync_network) = GossipService::new(
         SubstrateNetwork::new(network.clone(), sync_network.clone(), protocol_naming),
         spawn_handle.clone(),
-        metrics.clone(),
+        registry.clone(),
     );
     let gossip_network_task = async move { gossip_network_service.run().await };
 

--- a/finality-aleph/src/testing/network.rs
+++ b/finality-aleph/src/testing/network.rs
@@ -27,8 +27,7 @@ use crate::{
         },
         GossipError, GossipNetwork, GossipService, MockEvent, MockRawNetwork, Protocol,
     },
-    testing::mocks::THash,
-    Metrics, MillisecsPerBlock, NodeIndex, Recipient, SessionId, SessionPeriod,
+    MillisecsPerBlock, NodeIndex, Recipient, SessionId, SessionPeriod,
 };
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -101,12 +100,11 @@ async fn prepare_one_session_test_data() -> TestData {
     let network = MockRawNetwork::new(event_stream_tx);
     let validator_network = MockCliqueNetwork::new();
 
-    let (gossip_service, gossip_network, sync_network) =
-        GossipService::<_, _, MockData, THash>::new(
-            network.clone(),
-            task_manager.spawn_handle().into(),
-            Metrics::noop(),
-        );
+    let (gossip_service, gossip_network, sync_network) = GossipService::<_, _, MockData>::new(
+        network.clone(),
+        task_manager.spawn_handle().into(),
+        None,
+    );
 
     let (connection_manager_service, session_manager) = ConnectionManager::new(
         authorities[0].address(),


### PR DESCRIPTION
# Description

Move the network metrics out of the global metrics, the last ones that are there and shouldn't be.

## Type of change

# Checklist:
