### PR TITLE
A0-2935: Investigate flaky e2e tests

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "3.5.1"
+version = "3.6.0"
 edition = "2021"
 authors = ["Cardinal"]
 documentation = "https://docs.rs/aleph_client"

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "3.5.0"
+version = "3.5.1"
 edition = "2021"
 authors = ["Cardinal"]
 documentation = "https://docs.rs/aleph_client"

--- a/aleph-client/src/pallets/mod.rs
+++ b/aleph-client/src/pallets/mod.rs
@@ -23,6 +23,8 @@ pub mod session;
 pub mod staking;
 /// Pallet system API
 pub mod system;
+/// Pallet timestamp API
+pub mod timestamp;
 /// Pallet treasury API
 pub mod treasury;
 /// Pallet utility API

--- a/aleph-client/src/pallets/timestamp.rs
+++ b/aleph-client/src/pallets/timestamp.rs
@@ -1,0 +1,16 @@
+use crate::{api, BlockHash, ConnectionApi};
+
+/// Timestamp payment pallet API.
+#[async_trait::async_trait]
+pub trait TimestampApi {
+    /// API for [`get`](https://paritytech.github.io/substrate/master/pallet_timestamp/pallet/struct.Pallet.html#method.get) call.
+    async fn get_timestamp(&self, at: Option<BlockHash>) -> Option<u64>;
+}
+
+#[async_trait::async_trait]
+impl<C: ConnectionApi> TimestampApi for C {
+    async fn get_timestamp(&self, at: Option<BlockHash>) -> Option<u64> {
+        let addrs = api::storage().timestamp().now();
+        self.get_storage_entry_maybe(&addrs, at).await
+    }
+}

--- a/benches/payout-stakers/Cargo.lock
+++ b/benches/payout-stakers/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/finalizer/Cargo.lock
+++ b/bin/finalizer/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.5.1"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/src/test/era_payout.rs
+++ b/e2e-tests/src/test/era_payout.rs
@@ -1,6 +1,8 @@
 use aleph_client::{
-    pallets::staking::{StakingApi, StakingSudoApi},
-    pallets::timestamp::TimestampApi,
+    pallets::{
+        staking::{StakingApi, StakingSudoApi},
+        timestamp::TimestampApi,
+    },
     utility::BlocksApi,
     waiting::{AlephWaiting, BlockStatus, WaitingExt},
     TxStatus,

--- a/e2e-tests/src/test/era_payout.rs
+++ b/e2e-tests/src/test/era_payout.rs
@@ -1,10 +1,12 @@
 use aleph_client::{
     pallets::staking::{StakingApi, StakingSudoApi},
+    pallets::timestamp::TimestampApi,
+    utility::BlocksApi,
     waiting::{AlephWaiting, BlockStatus, WaitingExt},
     TxStatus,
 };
 use primitives::{
-    staking::era_payout, Balance, EraIndex, DEFAULT_SESSIONS_PER_ERA, DEFAULT_SESSION_PERIOD,
+    staking::era_payout, EraIndex, DEFAULT_SESSIONS_PER_ERA, DEFAULT_SESSION_PERIOD,
     MILLISECS_PER_BLOCK,
 };
 
@@ -19,32 +21,45 @@ pub async fn era_payouts_calculated_correctly() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn payout_within_two_block_delta(expected_payout: Balance, payout: Balance) {
-    let one_block = era_payout(2 * MILLISECS_PER_BLOCK).0;
-
-    let start = expected_payout - one_block;
-    let end = expected_payout + one_block;
-    let within_delta = start <= payout && payout <= end;
-    assert!(
-        within_delta,
-        "payout should fall within range: [{start}, {end}] but was {payout}"
-    );
-}
-
-async fn wait_to_second_era<C: StakingApi + WaitingExt>(connection: &C) -> EraIndex {
+async fn wait_to_kth_era<C: StakingApi + WaitingExt>(
+    connection: &C,
+    kth_era: EraIndex,
+) -> EraIndex {
     let active_era = connection.get_active_era(None).await;
-    if active_era < 2 {
-        connection.wait_for_n_eras(2, BlockStatus::Best).await;
+    if active_era < kth_era {
+        connection
+            .wait_for_n_eras(kth_era - active_era, BlockStatus::Best)
+            .await;
     }
     connection.get_active_era(None).await
 }
 
+async fn get_era_duration<C: TimestampApi + BlocksApi>(era: EraIndex, connection: &C) -> u64 {
+    let current_era_first_block = era * DEFAULT_SESSIONS_PER_ERA * DEFAULT_SESSION_PERIOD;
+    let next_era_first_block = (era + 1) * DEFAULT_SESSIONS_PER_ERA * DEFAULT_SESSION_PERIOD;
+
+    let current_era_first_block_hash = connection
+        .get_block_hash(current_era_first_block)
+        .await
+        .unwrap();
+    let next_era_first_block_hash = connection
+        .get_block_hash(next_era_first_block)
+        .await
+        .unwrap();
+
+    return connection
+        .get_timestamp(next_era_first_block_hash)
+        .await
+        .unwrap()
+        - connection
+            .get_timestamp(current_era_first_block_hash)
+            .await
+            .unwrap();
+}
+
 async fn force_era_payout(config: &Config) -> anyhow::Result<()> {
     let root_connection = config.create_root_connection().await;
-    let active_era = wait_to_second_era(&root_connection).await;
-    root_connection.wait_for_n_eras(1, BlockStatus::Best).await;
-    let active_era = active_era + 1;
-
+    let active_era = wait_to_kth_era(&root_connection, 3).await;
     let starting_session = active_era * DEFAULT_SESSIONS_PER_ERA;
     root_connection
         .wait_for_session(starting_session + 1, BlockStatus::Best)
@@ -56,27 +71,78 @@ async fn force_era_payout(config: &Config) -> anyhow::Result<()> {
         .wait_for_session(starting_session + 3, BlockStatus::Best)
         .await;
 
+    let actual_duration = get_era_duration(active_era - 1, &root_connection).await;
     let payout = root_connection.get_payout_for_era(active_era, None).await;
-    let expected_payout = era_payout((3 * DEFAULT_SESSION_PERIOD) as u64 * MILLISECS_PER_BLOCK).0;
 
-    payout_within_two_block_delta(expected_payout, payout);
+    let expected_era_duration = (3 * DEFAULT_SESSION_PERIOD) as u64 * MILLISECS_PER_BLOCK;
+    let expected_payout = era_payout(expected_era_duration).0;
 
+    assert_within_delta_interval(
+        expected_era_duration,
+        actual_duration,
+        MILLISECS_PER_BLOCK,
+        "era duration",
+        "Probably chain hasn't started correctly, try rerunning the test",
+    );
+    assert_within_delta_interval(
+        expected_payout,
+        payout,
+        era_payout(2 * MILLISECS_PER_BLOCK).0,
+        "payout",
+        "",
+    );
     Ok(())
 }
 
 async fn normal_era_payout(config: &Config) -> anyhow::Result<()> {
     let root_connection = config.create_root_connection().await;
 
-    let active_era = wait_to_second_era(&root_connection).await;
+    let active_era = wait_to_kth_era(&root_connection, 2).await;
     let payout = root_connection
         .get_payout_for_era(active_era - 1, None)
         .await;
-    let expected_payout = era_payout(
-        (DEFAULT_SESSIONS_PER_ERA * DEFAULT_SESSION_PERIOD) as u64 * MILLISECS_PER_BLOCK,
-    )
-    .0;
+    let actual_duration = get_era_duration(active_era - 1, &root_connection).await;
 
-    payout_within_two_block_delta(expected_payout, payout);
+    let expected_era_duration =
+        (DEFAULT_SESSIONS_PER_ERA * DEFAULT_SESSION_PERIOD) as u64 * MILLISECS_PER_BLOCK;
+    let expected_payout = era_payout(expected_era_duration).0;
+
+    assert_within_delta_interval(
+        expected_era_duration,
+        actual_duration,
+        MILLISECS_PER_BLOCK,
+        "era duration",
+        "Probably chain hasn't started correctly, try rerunning the test",
+    );
+    assert_within_delta_interval(
+        expected_payout,
+        payout,
+        era_payout(2 * MILLISECS_PER_BLOCK).0,
+        "payout",
+        "",
+    );
 
     Ok(())
+}
+
+fn assert_within_delta_interval<T>(
+    expected: T,
+    actual: T,
+    delta: T,
+    quantity_name: &str,
+    extra_msg_on_fail: &str,
+) where
+    T: std::fmt::Display
+        + std::ops::Add<Output = T>
+        + std::ops::Sub<Output = T>
+        + PartialOrd
+        + Copy,
+{
+    let start = expected - delta;
+    let end = expected + delta;
+    let within_delta = start <= expected && expected <= end;
+    assert!(
+        within_delta,
+        "{quantity_name} should fall within range: [{start}, {end}] but was {actual}. {extra_msg_on_fail}",
+    );
 }

--- a/e2e-tests/src/test/finalization.rs
+++ b/e2e-tests/src/test/finalization.rs
@@ -1,10 +1,10 @@
+use crate::config::setup_test;
 use aleph_client::{
     utility::BlocksApi,
     waiting::{AlephWaiting, BlockStatus},
 };
 use anyhow::anyhow;
-
-use crate::config::setup_test;
+use log::info;
 
 #[tokio::test]
 pub async fn finalization() -> anyhow::Result<()> {
@@ -12,12 +12,14 @@ pub async fn finalization() -> anyhow::Result<()> {
     let connection = config.create_root_connection().await;
 
     let finalized = connection.get_finalized_block_hash().await?;
+    info!("Highest finalized block hash = {finalized}");
     let finalized_number = connection
         .get_block_number(finalized)
         .await?
         .ok_or(anyhow!(
             "Failed to retrieve block number for hash {finalized:?}"
         ))?;
+    info!("Waiting for block {} to be finalized", finalized_number + 1);
 
     connection
         .wait_for_block(|n| n > finalized_number, BlockStatus::Finalized)

--- a/e2e-tests/src/test/finalization.rs
+++ b/e2e-tests/src/test/finalization.rs
@@ -1,10 +1,11 @@
-use crate::config::setup_test;
 use aleph_client::{
     utility::BlocksApi,
     waiting::{AlephWaiting, BlockStatus},
 };
 use anyhow::anyhow;
 use log::info;
+
+use crate::config::setup_test;
 
 #[tokio::test]
 pub async fn finalization() -> anyhow::Result<()> {

--- a/flooder/Cargo.lock
+++ b/flooder/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
# Description

Changes in e2e-tests and aleph-client only.
* Improved finality version change test [fixes A0-2972] - now it schedules change in (current_session+1) for (current_session+3) instead of in the 1st session for 4th session - it requires one session less and should pass even when ran after 2nd session.
* More checks and better error for era payout test [partially fixes A0-2973] - previously a problem could occur, where one validator was not producing blocks, and because of that session durations were longer than expected. Added block timestamp check to detect such a situation, and report better error message int that case.
* Add logging for finalization test [to make further investigation on A0-2974 easier]

The actual problem in failing e2e-tests is that the chain might sometimes launch incorrectly, with some validators not being able to connect to other peers, causing a finalization stall. One possible solution to this I could imagine is to run the finalization test just after launching the chain and respawn the chain if the test timed out after 60s. Let me know what do you think about it.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have added tests
- I have bumped aleph-client version if relevant
