### PR TITLE
A0-2735: Change featurenets to use kustomize

### DIFF
--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -123,14 +123,14 @@ runs:
     - name: Get argocd featurenet app name
       id: get-argocd-featurnet-app-name
       shell: bash
+      # yamllint disable rule:line-length
       env:
-        # yamllint disable rule:line-length
         APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
         APP_NAME_WITH_RUN_ID: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}-{2}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo, github.run_id) }}
-        # yamllint enable rule:line-length
       run: |
         name_local=${{ inputs.append-run-id-to-name == 'true' && env.APP_NAME_WITH_RUN_ID || env.APP_NAME }}
         echo "name=$name_local" >> $GITHUB_OUTPUT
+      # yamllint enable rule:line-length
 
     - name: Get node commit SHA
       if: ${{ inputs.featurenet-aleph-node-image == 'testnet' ||

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -47,6 +47,11 @@ inputs:
       will be updated. If not specified, all nodes will be updated.
     required: false
     default: "0"
+  replicas:
+    description: |
+      Number of pods to start, from 0 to 50.
+    required: false
+    default: "5"
   append-run-id-to-name:
     description: |
       When 'true' then run ID will be appended to featurenet name
@@ -83,6 +88,14 @@ runs:
         ]]
         then
           echo "!!! Expected rolling update partition to be a cardinal value from 0 to 9"
+          exit 1
+        fi
+        if [[
+          "${{ inputs.replicas }}" != "" && \
+          ! "${{ inputs.replicas }}" =~ ^[0-9]$ || "${{ inputs.replicas }}" -gt 50
+        ]]
+        then
+          echo "!!! Expected replicas to be a cardinal value from 0 to 50"
           exit 1
         fi
         if [[
@@ -159,7 +172,8 @@ runs:
           "${fnet_aleph_node_image}" \
           "${fnet_bootstrap_chain_node_image}" \
           "${{ inputs.rolling-update-partition }}" \
-          "${fnet_create_hook}"
+          "${fnet_create_hook}" \
+          "${{ inputs.replicas }}"
       # yamllint enable rule:line-length
 
     - name: Set featurenet expiration

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -9,9 +9,6 @@ inputs:
   gh-ci-token:
     description: 'GH token to be used in the action'
     required: true
-  repo-apps-name:
-    description: 'Name of the repository containing apps definitions'
-    required: true
   repo-featurenets-name:
     description: 'Name of the repository containing featurenets manifests'
     required: true
@@ -97,14 +94,6 @@ runs:
       id: get-ref-properties
       uses: Cardinal-Cryptography/github-actions/get-ref-properties@v1
 
-    - name: Checkout argocd apps repo
-      uses: actions/checkout@v3
-      with:
-        repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
-        token: ${{ inputs.gh-ci-token }}
-        path: "${{ inputs.repo-apps-name }}"
-        ref: main
-
     - name: Checkout featurenets repo
       uses: actions/checkout@v3
       with:
@@ -137,7 +126,7 @@ runs:
         OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
       # yamllint disable rule:line-length
       run: |
-        cd "${{ inputs.repo-apps-name }}"
+        cd "${{ inputs.repo-featurenets-name }}"
         # featurenet creation from commit from PR
         if [[ "${{ inputs.featurenet-aleph-node-image }}" == "" ]]; then
           pr_image_tag="fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
@@ -158,7 +147,7 @@ runs:
           # Disabling hook here as work in progress
           fnet_create_hook="false"
         fi
-        ./Ops.sh create-featurenet \
+        ./Ops.sh create-featurenet-using-kustomize \
           "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
           "${fnet_aleph_node_image}" \
           "${fnet_bootstrap_chain_node_image}" \
@@ -172,7 +161,7 @@ runs:
       env:
         OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
       run: |
-        cd "${{ inputs.repo-apps-name }}"
+        cd "${{ inputs.repo-featurenets-name }}"
         ./Ops.sh create-featurenet-expiration \
           "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
           "${{ inputs.expiration }}"
@@ -190,7 +179,7 @@ runs:
     - name: Refresh Argo and wait for the creation to be finished
       shell: bash
       run: |
-        cd "${{ inputs.repo-apps-name }}"
+        cd "${{ inputs.repo-featurenets-name }}"
         ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
           "${{ inputs.argo-sync-user-token }}" \
           "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \

--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -47,6 +47,11 @@ inputs:
       will be updated. If not specified, all nodes will be updated.
     required: false
     default: "0"
+  append-run-id-to-name:
+    description: |
+      When 'true' then run ID will be appended to featurenet name
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -106,10 +111,12 @@ runs:
       id: get-argocd-featurnet-app-name
       shell: bash
       env:
-        # yamllint disable-line rule:line-length
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}-{2}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo, github.run_id) }}
+        # yamllint disable rule:line-length
+        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
+        APP_NAME_WITH_RUN_ID: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}-{2}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo, github.run_id) }}
+        # yamllint enable rule:line-length
       run: |
-        name_local=${{ env.APP_NAME }}
+        name_local=${{ inputs.append-run-id-to-name == 'true' && env.APP_NAME_WITH_RUN_ID || env.APP_NAME }}
         echo "name=$name_local" >> $GITHUB_OUTPUT
 
     - name: Get node commit SHA

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -6,9 +6,6 @@ inputs:
   gh-ci-token:
     description: 'GH token to be used in the action'
     required: true
-  repo-apps-name:
-    description: 'Name of the repository containing apps definitions'
-    required: true
   repo-featurenets-name:
     description: 'Name of the repository containing featurenets manifests'
     required: true
@@ -55,14 +52,6 @@ runs:
       # yamllint disable-line rule:line-length
       uses: Cardinal-Cryptography/github-actions/get-ref-properties@v1
 
-    - name: Checkout argocd apps repo
-      uses: actions/checkout@v3
-      with:
-        repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
-        token: ${{ inputs.gh-ci-token }}
-        path: "${{ inputs.repo-apps-name }}"
-        ref: main
-
     - name: Checkout featurenets repo
       uses: actions/checkout@v3
       with:
@@ -95,7 +84,7 @@ runs:
       env:
         OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
       run: |
-        cd "${{ inputs.repo-apps-name }}"
+        cd "${{ inputs.repo-featurenets-name }}"
         ./Ops.sh delete-featurenet "${{ steps.get-argocd-featurnet-app-name.outputs.name }}"
       # yamllint enable rule:line-length
 
@@ -112,7 +101,7 @@ runs:
     - name: Refresh Argo and wait for the deletion to be finished
       shell: bash
       run: |
-        cd "${{ inputs.repo-apps-name }}"
+        cd "${{ inputs.repo-featurenets-name }}"
         ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
           "${{ inputs.argo-sync-user-token }}"
 

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -77,14 +77,14 @@ runs:
     - name: Get argocd featurenet app name
       id: get-argocd-featurnet-app-name
       shell: bash
+      # yamllint disable rule:line-length
       env:
-        # yamllint disable rule:line-length
         APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
         APP_NAME_WITH_RUN_ID: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}-{2}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo, github.run_id) }}
-        # yamllint enable rule:line-length
       run: |
         name_local=${{ inputs.append-run-id-to-name == 'true' && env.APP_NAME_WITH_RUN_ID || env.APP_NAME }}
         echo "name=$name_local" >> $GITHUB_OUTPUT
+      # yamllint enable rule:line-length
 
     - name: Destroy feature branch
       shell: bash

--- a/.github/actions/delete-featurenet/action.yml
+++ b/.github/actions/delete-featurenet/action.yml
@@ -31,6 +31,11 @@ inputs:
     description: 'Enter name instead of getting it from branch'
     required: false
     default: ''
+  append-run-id-to-name:
+    description: |
+      When 'true' then run ID will be appended to featurenet name
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -73,10 +78,12 @@ runs:
       id: get-argocd-featurnet-app-name
       shell: bash
       env:
-        # yamllint disable-line rule:line-length
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}-{2}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo, github.run_id) }}
+        # yamllint disable rule:line-length
+        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
+        APP_NAME_WITH_RUN_ID: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}-{2}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo, github.run_id) }}
+        # yamllint enable rule:line-length
       run: |
-        name_local=${{ env.APP_NAME }}
+        name_local=${{ inputs.append-run-id-to-name == 'true' && env.APP_NAME_WITH_RUN_ID || env.APP_NAME }}
         echo "name=$name_local" >> $GITHUB_OUTPUT
 
     - name: Destroy feature branch

--- a/.github/actions/wait-for-finalized-heads/action.yml
+++ b/.github/actions/wait-for-finalized-heads/action.yml
@@ -6,31 +6,31 @@ inputs:
   gh-ci-token:
     description: 'GH token to be used in the action'
     required: true
-  repo-apps-name:
-    description: 'Name of the repository containing apps definitions'
+  repo-featurenets-name:
+    description: 'Name of the repository containing featurenets definitions'
     required: true
   json-rpc-endpoint:
     description: 'JSON RPC endpoint, eg. https://dev.azero.dev'
     required: true
-  repo-apps-checkout:
-    description: "Checkout apps repository"
+  repo-featurenets-checkout:
+    description: "Checkout featurenets repository"
     required: false
     default: 'false'
 
 runs:
   using: "composite"
   steps:
-    - name: Checkout argocd apps repo
-      if: inputs.repo-apps-checkout == 'true'
+    - name: Checkout argocd featurenets repo
+      if: inputs.repo-featurenets-checkout == 'true'
       uses: actions/checkout@v3
       with:
-        repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
+        repository: Cardinal-Cryptography/${{ inputs.repo-featurenets-name }}
         token: ${{ inputs.gh-ci-token }}
-        path: "${{ inputs.repo-apps-name }}"
+        path: "${{ inputs.repo-featurenets-name }}"
         ref: main
 
     - name: Wait for the unique consecutive finalized heads
       shell: bash
       run: |
-        cd "${{ inputs.repo-apps-name }}"
+        cd "${{ inputs.repo-featurenets-name }}"
         ./Ops.sh wait-for-finalized-heads "${{ inputs.json-rpc-endpoint }}"

--- a/.github/workflows/_delete-featurenet.yml
+++ b/.github/workflows/_delete-featurenet.yml
@@ -13,7 +13,7 @@ jobs:
   delete-featurenet:
     needs: [check-vars-and-secrets]
     name: Delete featurenet
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: [self-hosted, Linux, X64, small]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/_delete-featurenet.yml
+++ b/.github/workflows/_delete-featurenet.yml
@@ -3,6 +3,12 @@ name: Delete featurenet
 
 on:
   workflow_call:
+    inputs:
+      append-run-id-to-name:
+        description: When set to 'true' then run ID will be appended to featurenet name
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   check-vars-and-secrets:
@@ -34,6 +40,7 @@ jobs:
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
+          append-run-id-to-name: "${{ inputs.append-run-id-to-name }}"
 
       - name: Remove created label if present
         uses: actions-ecosystem/action-remove-labels@v1.3.0

--- a/.github/workflows/_delete-featurenet.yml
+++ b/.github/workflows/_delete-featurenet.yml
@@ -31,7 +31,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -70,7 +70,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
@@ -94,7 +93,6 @@ jobs:
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
@@ -105,7 +103,7 @@ jobs:
         uses: ./.github/actions/wait-for-finalized-heads
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
+          repo-featurenets-name: ${{ secrets.REPO_ARGOCD_FEATURENETS_NAME }}
           # yamllint disable-line rule:line-length
           json-rpc-endpoint: https://ws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}-${{ github.run_id }}.dev.azero.dev
 

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -54,7 +54,7 @@ jobs:
   create-featurenet:
     needs: [push-featurnet-node-image-to-ecr]
     name: Create featurenet based on the PR
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: [self-hosted, Linux, X64, small]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -3,6 +3,12 @@ name: Create featurenet
 
 on:
   workflow_call:
+    inputs:
+      append-run-id-to-name:
+        description: When set to 'true' then run ID will be appended to featurenet name
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       expiration:
@@ -98,6 +104,7 @@ jobs:
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
           expiration: ${{ inputs.expiration == '' && '48h' || inputs.expiration }}
+          append-run-id-to-name: "${{ inputs.append-run-id-to-name }}"
 
       - name: Wait for the aleph-node binary to accept some blocks
         uses: ./.github/actions/wait-for-finalized-heads
@@ -105,7 +112,7 @@ jobs:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           # yamllint disable-line rule:line-length
-          json-rpc-endpoint: https://ws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}-${{ github.run_id }}.dev.azero.dev
+          json-rpc-endpoint: https://ws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}${{ inputs.append-run-id-to-name == 'true' && format("-{0}", github.run_id) || '' }}.dev.azero.dev
 
       - name: Remove deleted label if present
         uses: actions-ecosystem/action-remove-labels@v1.3.0
@@ -124,7 +131,7 @@ jobs:
           env: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           # yamllint disable-line rule:line-length
-          env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}-${{ github.run_id }}.dev.azero.dev#/explorer
+          env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}${{ inputs.append-run-id-to-name == 'true' && format("-{0}", github.run_id) || '' }}.dev.azero.dev#/explorer
           ref: ${{ github.head_ref }}
 
       - name: Remove deployment request label if exists

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -112,7 +112,7 @@ jobs:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           # yamllint disable-line rule:line-length
-          json-rpc-endpoint: https://ws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}${{ inputs.append-run-id-to-name == 'true' && format("-{0}", github.run_id) || '' }}.dev.azero.dev
+          json-rpc-endpoint: https://ws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}${{ inputs.append-run-id-to-name == 'true' && format('-{0}', github.run_id) || '' }}.dev.azero.dev
 
       - name: Remove deleted label if present
         uses: actions-ecosystem/action-remove-labels@v1.3.0
@@ -131,7 +131,7 @@ jobs:
           env: ${{ steps.get-ref-properties.outputs.branch-name-flattened }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           # yamllint disable-line rule:line-length
-          env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}${{ inputs.append-run-id-to-name == 'true' && format("-{0}", github.run_id) || '' }}.dev.azero.dev#/explorer
+          env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}${{ inputs.append-run-id-to-name == 'true' && format('-{0}', github.run_id) || '' }}.dev.azero.dev#/explorer
           ref: ${{ github.head_ref }}
 
       - name: Remove deployment request label if exists

--- a/.github/workflows/create-featurenet.yml
+++ b/.github/workflows/create-featurenet.yml
@@ -103,7 +103,7 @@ jobs:
         uses: ./.github/actions/wait-for-finalized-heads
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          repo-featurenets-name: ${{ secrets.REPO_ARGOCD_FEATURENETS_NAME }}
+          repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           # yamllint disable-line rule:line-length
           json-rpc-endpoint: https://ws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}-${{ github.run_id }}.dev.azero.dev
 

--- a/.github/workflows/nightly-short-session-e2e-tests.yml
+++ b/.github/workflows/nightly-short-session-e2e-tests.yml
@@ -67,7 +67,6 @@ jobs:
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
@@ -78,7 +77,7 @@ jobs:
         uses: ./.github/actions/wait-for-finalized-heads
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
+          repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           # yamllint disable-line rule:line-length
           json-rpc-endpoint: https://ws-fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo }}-${{ github.run_id }}.dev.azero.dev
 
@@ -110,7 +109,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}

--- a/.github/workflows/nightly-short-session-e2e-tests.yml
+++ b/.github/workflows/nightly-short-session-e2e-tests.yml
@@ -72,6 +72,7 @@ jobs:
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
           expiration: '3h'
+          append-run-id-to-name: "true"
 
       - name: Wait for the aleph-node binary to accept some blocks
         uses: ./.github/actions/wait-for-finalized-heads
@@ -112,6 +113,7 @@ jobs:
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
+          append-run-id-to-name: "true"
 
 
   slack-notification:

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -50,7 +50,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
@@ -71,7 +70,6 @@ jobs:
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
@@ -84,7 +82,7 @@ jobs:
         uses: ./.github/actions/wait-for-finalized-heads
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
+          repo-featurenets-name: ${{ secrets.REPO_ARGOCD_FEATURENETS_NAME }}
           # yamllint disable-line rule:line-length
           json-rpc-endpoint: https://ws-fe-updnet-${{ github.run_id }}.dev.azero.dev
 

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -82,7 +82,7 @@ jobs:
         uses: ./.github/actions/wait-for-finalized-heads
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          repo-featurenets-name: ${{ secrets.REPO_ARGOCD_FEATURENETS_NAME }}
+          repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           # yamllint disable-line rule:line-length
           json-rpc-endpoint: https://ws-fe-updnet-${{ github.run_id }}.dev.azero.dev
 

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -34,7 +34,7 @@ jobs:
   create-updatenet:
     needs: [check-vars-and-secrets]
     name: Create updatenet
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: [self-hosted, Linux, X64, small]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -24,6 +24,10 @@ on:
           - 96h
           - never
         default: 48h
+      replicas:
+        description: 'Number of replicas to start, from 0 to 50'
+        required: true
+        default: '5'
 
 jobs:
   check-vars-and-secrets:
@@ -77,6 +81,7 @@ jobs:
           featurenet-name: fe-updnet-${{ github.run_id }}
           featurenet-aleph-node-image: ${{ inputs.start == 'mainnet' && 'mainnet' || 'testnet' }}
           expiration: ${{ inputs.expiration }}
+          replicas: ${{ inputs.replicas }}
 
       - name: Wait for the aleph-node binary to accept some blocks
         uses: ./.github/actions/wait-for-finalized-heads

--- a/.github/workflows/updatenet-delete.yml
+++ b/.github/workflows/updatenet-delete.yml
@@ -39,7 +39,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}

--- a/.github/workflows/updatenet-delete.yml
+++ b/.github/workflows/updatenet-delete.yml
@@ -18,7 +18,7 @@ jobs:
   delete-updatenet:
     needs: [check-vars-and-secrets]
     name: Delete updatenet
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: [self-hosted, Linux, X64, small]
     steps:
       - name: Validate inputs
         shell: bash

--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -19,6 +19,10 @@ on:
           will be updated. If not specified, all nodes will be updated.
         required: false
         default: "0"
+      replicas:
+        description: 'Number of replicas to start, from 0 to 50'
+        required: true
+        default: '5'
 
 jobs:
   check-vars-and-secrets:
@@ -79,6 +83,7 @@ jobs:
           featurenet-name: fe-updnet-${{ inputs.name }}
           featurenet-aleph-node-image: ${{ inputs.destination }}
           rolling-update-partition: ${{ inputs.rolling-update-partition }}
+          replicas: ${{ inputs.replicas }}
 
       - name: Wait for the aleph-node binary to accept some blocks
         uses: ./.github/actions/wait-for-finalized-heads

--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -72,7 +72,6 @@ jobs:
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
@@ -85,7 +84,7 @@ jobs:
         uses: ./.github/actions/wait-for-finalized-heads
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          repo-apps-name: ${{ secrets.REPO_ARGOCD_APPS_NAME }}
+          repo-featurenets-name: ${{ secrets.REPO_ARGOCD_FEATURENETS_NAME }}
           json-rpc-endpoint: https://ws-fe-updnet-${{ inputs.name }}.dev.azero.dev
 
       - name: Finish featurenet Deployment

--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -29,7 +29,7 @@ jobs:
   update-updatenet:
     needs: [check-vars-and-secrets]
     name: Update updatenet
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: [self-hosted, Linux, X64, small]
     outputs:
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
     steps:

--- a/.github/workflows/updatenet-update.yml
+++ b/.github/workflows/updatenet-update.yml
@@ -84,7 +84,7 @@ jobs:
         uses: ./.github/actions/wait-for-finalized-heads
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          repo-featurenets-name: ${{ secrets.REPO_ARGOCD_FEATURENETS_NAME }}
+          repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           json-rpc-endpoint: https://ws-fe-updnet-${{ inputs.name }}.dev.azero.dev
 
       - name: Finish featurenet Deployment


### PR DESCRIPTION
# Description

#### Changes featurenets to be created using kustomize instead of helm charts
This is done to unify things a little bit and not copy aleph-node-validator manifests but use the already-existing kustomize base (with an overlay on top of it)

#### Fixes broken featurenets
Among few things the biggest bug that was introduced was appending Run ID to the name of featurenet which caused plenty of infrastructure problems (no sense to list them all here).

Appending Run ID is now optional for featurenet actions

#### Introduces `replicas` input for updatenets
Allows specific number of statefulset's replicas (meaning how many aleph nodes are meant to be started).  It's added both to `create` and `update`, hence it is possible to scale up and down existing featurenets.

## Type of change
It is an important fix.  Featurenets are broken anyway.
