### PR TITLE
A0-3198: Add name input to updatenets

### DIFF
--- a/.github/actions/create-featurenet/action.yml
+++ b/.github/actions/create-featurenet/action.yml
@@ -92,7 +92,7 @@ runs:
         fi
         if [[
           "${{ inputs.replicas }}" != "" && \
-          ! "${{ inputs.replicas }}" =~ ^[0-9]$ || "${{ inputs.replicas }}" -gt 50
+          ! "${{ inputs.replicas }}" =~ ^[0-9]{1,2}$ || "${{ inputs.replicas }}" -gt 50
         ]]
         then
           echo "!!! Expected replicas to be a cardinal value from 0 to 50"

--- a/.github/workflows/updatenet-create.yml
+++ b/.github/workflows/updatenet-create.yml
@@ -28,6 +28,10 @@ on:
         description: 'Number of replicas to start, from 0 to 50'
         required: true
         default: '5'
+      name:
+        description: 'Name of the updatenet, used instead of run ID'
+        required: false
+        default: ''
 
 jobs:
   check-vars-and-secrets:
@@ -45,6 +49,23 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Get updatenet name
+        id: get-updatenet-name
+        shell: bash
+        # yamllint disable rule:line-length
+        run: |
+          if [[
+            "${{ inputs.name }}" != "" && \
+            ! "${{ inputs.name }}" =~ ^[a-z0-9][a-z0-9\-]{4,30}$
+          ]]
+          then
+            echo "!!! Invalid name"
+            exit 1
+          fi
+          name_local=${{ inputs.name != '' && inputs.name || github.run_id }}
+          echo "updatenet_name=$name_local" >> $GITHUB_OUTPUT
+        # yamllint enable rule:line-length
+
       - name: Delete old featurenet app and data
         if: contains(github.event.pull_request.labels.*.name, 'state:created-featurenet')
         uses: ./.github/actions/delete-featurenet
@@ -57,7 +78,7 @@ jobs:
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
-          featurenet-name: fe-updnet-${{ github.run_id }}
+          featurenet-name: fe-updnet-${{ steps.get-updatenet-name.outputs.updatenet_name }}
 
       - name: Start updatenet Deployment
         uses: bobheadxi/deployments@v1.1.0
@@ -78,7 +99,7 @@ jobs:
           argo-host: ${{ secrets.ARGOCD_DEVNET_HOST }}
           ecr-public-registry: ${{ vars.ECR_PUBLIC_REGISTRY }}
           featurenet-keys-s3bucket-name: ${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}
-          featurenet-name: fe-updnet-${{ github.run_id }}
+          featurenet-name: fe-updnet-${{ steps.get-updatenet-name.outputs.updatenet_name }}
           featurenet-aleph-node-image: ${{ inputs.start == 'mainnet' && 'mainnet' || 'testnet' }}
           expiration: ${{ inputs.expiration }}
           replicas: ${{ inputs.replicas }}
@@ -89,7 +110,7 @@ jobs:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           repo-featurenets-name: ${{ secrets.REPO_OPS_FEATURENETS_NAME }}
           # yamllint disable-line rule:line-length
-          json-rpc-endpoint: https://ws-fe-updnet-${{ github.run_id }}.dev.azero.dev
+          json-rpc-endpoint: https://ws-fe-updnet-${{ steps.get-updatenet-name.outputs.updatenet_name }}.dev.azero.dev
 
       - name: Finish featurenet Deployment
         uses: bobheadxi/deployments@v1
@@ -101,5 +122,5 @@ jobs:
           env: updatenet-${{ github.run_id }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           # yamllint disable-line rule:line-length
-          env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-updnet-${{ github.run_id }}.dev.azero.dev#/explorer
+          env_url: https://dev.azero.dev/?rpc=wss%3A%2F%2Fws-fe-updnet-${{ steps.get-updatenet-name.outputs.updatenet_name }}.dev.azero.dev#/explorer
           debug: true


### PR DESCRIPTION
# Description

Introduces `name` input to UpdateNet Create workflow so that an updatenet can be named, eg. `fe-updnet-mynet`.  It is optional.  Hence, when no name is provided, run ID will be used, eg. `fe-updnet-1234567` (and this is how it works right now).

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:
