### PR TITLE
A0-3210: disable contract crates check in check excluded packages 

### DIFF
--- a/scripts/run_checks_on_excluded_packages.sh
+++ b/scripts/run_checks_on_excluded_packages.sh
@@ -24,7 +24,9 @@ for p in ${packages[@]}; do
   pushd "$p"
 
   if [[ "$p" =~ .*contracts.* ]] && [[ "$p" != "contracts/poseidon_host_bench" ]]; then
-    cargo contract check
+    echo "Disabling contract check as per https://github.com/727-Ventures/openbrush-contracts"
+    echo "is not available."
+    # cargo contract check
   elif [ "$p" = "baby-liminal-extension" ] || [ "$p" = "contracts/poseidon_host_bench" ]; then
     # cargo clippy --release --no-default-features --features substrate \
       #  --target wasm32-unknown-unknown -- --no-deps -D warnings


### PR DESCRIPTION
# Description

https://github.com/727-Ventures/openbrush-contracts is not available atm, and this is breaking contract crates checks. Hance this is breaking our CI we need to disable them for now. 

See https://medium.com/brushfam/brushfam-is-leaving-polkadot-story-unfold-4fa5c38716dc for background

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

