### PR TITLE
A0-2021: Use compact compressed runtime in workflows

### DIFF
--- a/.github/actions/store-node-and-runtime/action.yml
+++ b/.github/actions/store-node-and-runtime/action.yml
@@ -84,7 +84,7 @@ runs:
       uses: Cardinal-Cryptography/github-actions/copy-file-to-s3@v1
       with:
         source-path: target/${{ steps.get-local-envs.outputs.cargo_profile }}/wbuild/aleph-runtime
-        source-filename: aleph_runtime.compact.wasm
+        source-filename: aleph_runtime.compact.compressed.wasm
         s3-bucket-path:
           # yamllint disable-line rule:line-length
           builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/aleph-${{ inputs.profile }}-runtime

--- a/.github/workflows/_build-production-node-and-runtime.yml
+++ b/.github/workflows/_build-production-node-and-runtime.yml
@@ -41,6 +41,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: aleph-production-runtime
-          path: target/production/wbuild/aleph-runtime/aleph_runtime.compact.wasm
+          path: target/production/wbuild/aleph-runtime/aleph_runtime.compact.compressed.wasm
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/_build-test-node-and-runtime.yml
+++ b/.github/workflows/_build-test-node-and-runtime.yml
@@ -43,6 +43,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: aleph-test-runtime
-          path: target/release/wbuild/aleph-runtime/aleph_runtime.compact.wasm
+          path: target/release/wbuild/aleph-runtime/aleph_runtime.compact.compressed.wasm
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/_check-runtime-determimism.yml
+++ b/.github/workflows/_check-runtime-determimism.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build runtime 2nd time and compare checksum with previous build
         env:
-          ARTIFACT: aleph_runtime.compact.wasm
+          ARTIFACT: aleph_runtime.compact.compressed.wasm
           TARGET_DIR: target/production/wbuild/aleph-runtime
         run: |
           mkdir -p "$TARGET_DIR"

--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -63,7 +63,7 @@ jobs:
           path: target/release/
 
       - name: Run test
-        timeout-minutes: 20
+        timeout-minutes: 15
         env:
           ALEPH_NODE_BINARY: ../target/release/aleph-node
         run: ./.github/scripts/test_major_sync.sh

--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -21,22 +21,6 @@ jobs:
     name: Build production node and runtime artifacts (PR version)
     uses: ./.github/workflows/_build-production-node-and-runtime.yml
 
-  store-production-node-and-runtime:
-    name: Store production node and runtime in Mainnet bucket
-    runs-on: ubuntu-20.04
-    needs: [build-production-node-and-runtime]
-    steps:
-      - name: Checkout aleph-node source code
-        uses: actions/checkout@v4
-
-      - name: Store production node and runtime
-        uses: ./.github/actions/store-node-and-runtime
-        with:
-          profile: production
-          aws-access-key-id: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
-          aws-bucket: ${{ secrets.CI_MAINNET_S3BUCKET_NAME }}
-
   build-production-node-and-e2e-client-image:
     needs: [build-production-node-and-runtime]
     name: Build production node and e2e client docker image
@@ -79,7 +63,7 @@ jobs:
           path: target/release/
 
       - name: Run test
-        timeout-minutes: 15
+        timeout-minutes: 20
         env:
           ALEPH_NODE_BINARY: ../target/release/aleph-node
         run: ./.github/scripts/test_major_sync.sh

--- a/.github/workflows/nightly-short-session-e2e-tests.yml
+++ b/.github/workflows/nightly-short-session-e2e-tests.yml
@@ -67,6 +67,7 @@ jobs:
     uses: ./.github/workflows/_build-test-node-and-runtime.yml
     secrets: inherit
 
+  # this job is required for bootstrapping featurenet
   store-test-node-and-runtime:
     name: Store test node and runtime in Devnet bucket
     runs-on: ubuntu-20.04

--- a/default.nix
+++ b/default.nix
@@ -59,7 +59,7 @@ let
 
   modePath = if release then "release" else "debug";
   pathToWasm = "target/" + modePath + "/wbuild/aleph-runtime/target/wasm32-unknown-unknown/" + modePath + "/aleph_runtime.wasm";
-  pathToCompactWasm = "target/" + modePath + "/wbuild/aleph-runtime/aleph_runtime.compact.wasm";
+  pathToCompactWasm = "target/" + modePath + "/wbuild/aleph-runtime/aleph_runtime.compact.compressed.wasm";
 
   featureIntoPrefixedFeature = packageName: feature: packageName + "/" + feature;
   featuresIntoPrefixedFeatures = package: features: builtins.map (featureIntoPrefixedFeature package) features;

--- a/local-tests/test_major_sync.py
+++ b/local-tests/test_major_sync.py
@@ -42,8 +42,8 @@ chain.start('aleph', nodes=[0, 1, 2, 3])
 sleep(60)
 chain.start('aleph', nodes=[4])
 
-printt('Waiting around 10 mins')
-sleep(10 * 60)
+printt('Waiting around 15 mins')
+sleep(15 * 60)
 
 finalized = check_finalized(chain)
 

--- a/local-tests/test_major_sync.py
+++ b/local-tests/test_major_sync.py
@@ -42,8 +42,8 @@ chain.start('aleph', nodes=[0, 1, 2, 3])
 sleep(60)
 chain.start('aleph', nodes=[4])
 
-printt('Waiting around 15 mins')
-sleep(15 * 60)
+printt('Waiting around 10 mins')
+sleep(10 * 60)
 
 finalized = check_finalized(chain)
 


### PR DESCRIPTION
# Description

Currently, we produce compact wasm in the workflows, but we should use compact.compressed to follow Polkadot approach, as well as to decrease amount of bytes sent in the network during runtime upgrade.

This PR also removes not not-needed job which uploaded procution runtime to S3. While this file was not overwritten, it is not good practice to deploy runtime from non-push-to-main job.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have made neccessary updates to the Infrastructure
