### PR TITLE
A0-3112: Update python framework with RPC port changes

### DIFF
--- a/local-tests/chainrunner/node.py
+++ b/local-tests/chainrunner/node.py
@@ -68,14 +68,6 @@ class Node:
             raise KeyError("RPC port unknown, please set rpc_port flag")
         return port
 
-    def ws_port(self):
-        """Return WS port for this node. The value is taken from `flags` dictionary.
-        Raises KeyError if not present."""
-        port = self.flags.get('ws_port', self.flags.get('ws-port'))
-        if port is None:
-            raise KeyError("WS port unknown, please set ws_port flag")
-        return port
-
     def greplog(self, regexp):
         """Find in the logs all occurrences of the given regexp. Returns a list of matches."""
         if not self.logfile:
@@ -178,7 +170,7 @@ class Node:
         Returns an instance of ExtrinsicReceipt."""
         with open(check_file(runtime_path), 'rb') as file:
             runtime = file.read()
-        port = self.ws_port()
+        port = self.rpc_port()
         subint = SubstrateInterface(url=f'ws://localhost:{port}', ss58_format=42)
         set_code_call = subint.compose_call(call_module='System', call_function='set_code', call_params={'code': runtime})
         zero_weight = {"proof_size":0, "ref_time":0}

--- a/local-tests/rolling_update.ipynb
+++ b/local-tests/rolling_update.ipynb
@@ -90,7 +90,6 @@
     "                'unsafe-rpc-external',\n",
     "                'no-mdns',\n",
     "                port=Seq(PORT),\n",
-    "                ws_port=Seq(WS_PORT),\n",
     "                rpc_port=Seq(RPC_PORT),\n",
     "                validator_port=Seq(VAL_PORT),\n",
     "                public_validator_addresses=val_addrs,\n",

--- a/local-tests/run_nodes.py
+++ b/local-tests/run_nodes.py
@@ -11,8 +11,7 @@ nodes = 4
 workdir = '.'
 binary = '../target/release/aleph-node'
 port = 30334
-ws_port = 9944
-rpc_port = 9933
+rpc_port = 9944
 
 phrases = ['//Alice', '//Bob', '//Charlie', '//Dave', '//Ezekiel', '//Fanny', '//George', '//Hugo']
 keys_dict = generate_keys(binary, phrases)
@@ -30,7 +29,6 @@ chain.set_flags('validator',
                 'unsafe-rpc-external',
                 'no-mdns',
                 port=Seq(port),
-                ws_port=Seq(ws_port),
                 rpc_port=Seq(rpc_port),
                 unit_creation_delay=500,
                 execution='Native',

--- a/local-tests/test_catch_up.py
+++ b/local-tests/test_catch_up.py
@@ -34,8 +34,7 @@ chain.bootstrap(binary,
 chain.set_flags('no-mdns',
                 port=Seq(30334),
                 validator_port=Seq(30343),
-                ws_port=Seq(9944),
-                rpc_port=Seq(9933),
+                rpc_port=Seq(9944),
                 unit_creation_delay=200,
                 execution='Native')
 addresses = [n.address() for n in chain]

--- a/local-tests/test_force_reorg.py
+++ b/local-tests/test_force_reorg.py
@@ -25,8 +25,7 @@ chain.bootstrap(binary,
 chain.set_flags('no-mdns',
                 port=Seq(30334),
                 validator_port=Seq(30343),
-                ws_port=Seq(9944),
-                rpc_port=Seq(9933),
+                rpc_port=Seq(9944),
                 unit_creation_delay=200,
                 execution='Native')
 

--- a/local-tests/test_major_sync.py
+++ b/local-tests/test_major_sync.py
@@ -23,8 +23,7 @@ chain.new(binary, all_accounts)
 chain.set_flags('no-mdns',
                 port=Seq(30334),
                 validator_port=Seq(30343),
-                ws_port=Seq(9944),
-                rpc_port=Seq(9933),
+                rpc_port=Seq(9944),
                 unit_creation_delay=200,
                 execution='Native')
 addresses = [n.address() for n in chain]

--- a/local-tests/test_multiple_restarts.py
+++ b/local-tests/test_multiple_restarts.py
@@ -32,8 +32,7 @@ chain.bootstrap(binary,
 chain.set_flags('no-mdns',
                 port=Seq(30334),
                 validator_port=Seq(30343),
-                ws_port=Seq(9944),
-                rpc_port=Seq(9933),
+                rpc_port=Seq(9944),
                 unit_creation_delay=200,
                 execution='Native')
 addresses = [n.address() for n in chain]


### PR DESCRIPTION
# Description

We forgot to update python framework with recent changes that removed WS_PORT. Hence, the long session nightly test failed.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
