### PR TITLE
A0-3236: Fix dry-running when value is nonzero

### DIFF
--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "3.7.0"
+version = "3.7.1"
 edition = "2021"
 authors = ["Cardinal"]
 documentation = "https://docs.rs/aleph_client"

--- a/aleph-client/src/contract/mod.rs
+++ b/aleph-client/src/contract/mod.rs
@@ -143,7 +143,7 @@ impl ContractInstance {
         sender: AccountId,
     ) -> Result<T> {
         let result = self
-            .dry_run(conn, message, args, sender)
+            .dry_run(conn, message, args, sender, 0)
             .await?
             .result
             .map_err(|e| anyhow!("Contract exec failed {:?}", e))?;
@@ -192,7 +192,7 @@ impl ContractInstance {
         value: Balance,
     ) -> Result<TxInfo> {
         let dry_run_result = self
-            .dry_run(conn, message, args, conn.account_id().clone())
+            .dry_run(conn, message, args, conn.account_id().clone(), value)
             .await?;
 
         let data = self.encode(message, args)?;
@@ -224,12 +224,13 @@ impl ContractInstance {
         message: &str,
         args: &[S],
         sender: AccountId,
+        value: Balance,
     ) -> Result<ContractExecResult<Balance, EventRecord>> {
         let payload = self.encode(message, args)?;
         let args = ContractCallArgs {
             origin: sender,
             dest: self.address.clone(),
-            value: 0,
+            value,
             gas_limit: None,
             input_data: payload,
             storage_deposit_limit: None,

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",


### PR DESCRIPTION
# Description

Passes the trasmitted value to dry-run in aleph-client/contracts, which fixes gas estimation in cases where gas usage is dependent on the value.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- I have bumped aleph-client version if relevant
