### PR TITLE
A0-3037: Sync information for Aura

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,7 +1451,7 @@ checksum = "b9b68e3193982cd54187d71afdb2a271ad4cf8af157858e9cb911b91321de143"
 dependencies = [
  "core2",
  "multibase",
- "multihash 0.17.0",
+ "multihash",
  "serde",
  "unsigned-varint",
 ]
@@ -2706,7 +2706,7 @@ dependencies = [
  "hash-db 0.16.0",
  "ip_network",
  "log",
- "lru 0.10.1",
+ "lru",
  "network-clique",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -4437,7 +4437,7 @@ dependencies = [
  "libp2p-identity",
  "log",
  "multiaddr",
- "multihash 0.17.0",
+ "multihash",
  "multistream-select",
  "once_cell",
  "parking_lot 0.12.1",
@@ -4479,7 +4479,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "lru 0.10.1",
+ "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
@@ -4497,7 +4497,7 @@ dependencies = [
  "ed25519-dalek 2.0.0",
  "log",
  "multiaddr",
- "multihash 0.17.0",
+ "multihash",
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.7",
@@ -4744,7 +4744,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-noise",
  "log",
- "multihash 0.17.0",
+ "multihash",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
@@ -4930,15 +4930,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "lru"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
-dependencies = [
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "lru"
@@ -5229,7 +5220,7 @@ dependencies = [
  "data-encoding",
  "log",
  "multibase",
- "multihash 0.17.0",
+ "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -5246,19 +5237,6 @@ dependencies = [
  "base-x",
  "data-encoding",
  "data-encoding-macro",
-]
-
-[[package]]
-name = "multihash"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
-dependencies = [
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "sha2 0.10.7",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -5429,7 +5407,7 @@ dependencies = [
  "hash-db 0.16.0",
  "ip_network",
  "log",
- "lru 0.10.1",
+ "lru",
  "parity-scale-codec",
  "rand 0.8.5",
  "rate-limiter",

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -9,7 +9,7 @@ use aleph_runtime::{self, opaque::Block, RuntimeApi};
 use finality_aleph::{
     run_validator_node, AlephBlockImport, AlephConfig, BlockImporter, BlockMetrics, Justification,
     JustificationTranslator, MillisecsPerBlock, Protocol, ProtocolNaming, RateLimiterConfig,
-    SessionPeriod, SubstrateChainStatus, TracingBlockImport,
+    SessionPeriod, SubstrateChainStatus, SyncOracle, TracingBlockImport,
 };
 use futures::channel::mpsc;
 use log::warn;
@@ -354,6 +354,8 @@ pub fn new_authority(
 
     let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
 
+    let sync_oracle = SyncOracle::new();
+
     let aura = sc_consensus_aura::start_aura::<AuraPair, _, _, _, _, _, _, _, _, _, _>(
         StartAuraParams {
             slot_duration,
@@ -375,7 +377,7 @@ pub fn new_authority(
             force_authoring,
             backoff_authoring_blocks,
             keystore: keystore_container.keystore(),
-            sync_oracle: sync_network.clone(),
+            sync_oracle: sync_oracle.clone(),
             justification_sync_link: sync_network.clone(),
             block_proposal_slot_portion: SlotProportion::new(2f32 / 3f32),
             max_block_proposal_slot_portion: None,
@@ -419,6 +421,7 @@ pub fn new_authority(
         validator_port: aleph_config.validator_port(),
         protocol_naming,
         rate_limiter_config,
+        sync_oracle,
     };
 
     task_manager.spawn_essential_handle().spawn_blocking(

--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -53,6 +53,7 @@ mod party;
 mod session;
 mod session_map;
 mod sync;
+mod sync_oracle;
 #[cfg(test)]
 pub mod testing;
 
@@ -67,6 +68,7 @@ pub use crate::{
         substrate::{BlockImporter, Justification},
         JustificationTranslator, SubstrateChainStatus,
     },
+    sync_oracle::SyncOracle,
 };
 
 /// Constant defining how often components of finality-aleph should report their state
@@ -291,4 +293,5 @@ pub struct AlephConfig<C, SC> {
     pub validator_port: u16,
     pub protocol_naming: ProtocolNaming,
     pub rate_limiter_config: RateLimiterConfig,
+    pub sync_oracle: SyncOracle,
 }

--- a/finality-aleph/src/nodes.rs
+++ b/finality-aleph/src/nodes.rs
@@ -25,9 +25,9 @@ use crate::{
     session::SessionBoundaryInfo,
     session_map::{AuthorityProviderImpl, FinalityNotifierImpl, SessionMapUpdater},
     sync::{
-        ChainStatus, DatabaseIO as SyncDatabaseIO, FinalizationStatus, Justification,
-        JustificationTranslator, OldSyncCompatibleRequestBlocks, Service as SyncService,
-        SubstrateChainStatusNotifier, SubstrateFinalizationInfo, VerifierCache,
+        ChainStatus, FinalizationStatus, Justification, JustificationTranslator,
+        OldSyncCompatibleRequestBlocks, Service as SyncService, SubstrateChainStatusNotifier,
+        SubstrateFinalizationInfo, VerifierCache, IO as SyncIO,
     },
     AlephConfig,
 };
@@ -70,6 +70,7 @@ where
         validator_port,
         protocol_naming,
         rate_limiter_config,
+        sync_oracle,
     } = aleph_config;
 
     // We generate the phrase manually to only save the key in RAM, we don't want to have these
@@ -148,19 +149,20 @@ where
         genesis_header,
     );
     let finalizer = AlephFinalizer::new(client.clone(), metrics.clone());
-    let database_io = SyncDatabaseIO::new(chain_status.clone(), finalizer, import_queue_handle);
-    let (sync_service, justifications_for_sync, request_block) = match SyncService::new(
+    let sync_io = SyncIO::new(
+        chain_status.clone(),
+        finalizer,
+        import_queue_handle,
         block_sync_network,
         chain_events,
-        verifier,
-        database_io,
-        session_info.clone(),
+        sync_oracle,
         justification_rx,
-        registry.clone(),
-    ) {
-        Ok(x) => x,
-        Err(e) => panic!("Failed to initialize Sync service: {e}"),
-    };
+    );
+    let (sync_service, justifications_for_sync, request_block) =
+        match SyncService::new(verifier, session_info.clone(), sync_io, registry.clone()) {
+            Ok(x) => x,
+            Err(e) => panic!("Failed to initialize Sync service: {e}"),
+        };
     let sync_task = async move { sync_service.run().await };
 
     let (connection_manager_service, connection_manager) = ConnectionManager::new(

--- a/finality-aleph/src/sync/forest/mod.rs
+++ b/finality-aleph/src/sync/forest/mod.rs
@@ -596,6 +596,13 @@ where
         }
     }
 
+    /// How far behind in finalization are we.
+    pub fn behind_finalization(&self) -> u32 {
+        self.highest_justified
+            .number()
+            .saturating_sub(self.root_id.number())
+    }
+
     /// Returns an extension request with the appropriate data if either:
     /// 1. We know of a justified header for which we do not have a block, or
     /// 2. We know of nodes which have children of our favourite block.
@@ -603,7 +610,7 @@ where
     #[allow(dead_code)]
     pub fn extension_request(&self) -> ExtensionRequest<I, J> {
         use ExtensionRequest::*;
-        if self.highest_justified.number() > self.root_id.number() {
+        if self.behind_finalization() > 0 {
             // This should always happen, but if it doesn't falling back to other forms of extension requests is acceptable.
             if let Some((know_most, branch_knowledge)) =
                 self.prepare_request_info(&self.highest_justified)

--- a/finality-aleph/src/sync/mod.rs
+++ b/finality-aleph/src/sync/mod.rs
@@ -21,7 +21,7 @@ mod tasks;
 mod ticker;
 
 pub use compatibility::OldSyncCompatibleRequestBlocks;
-pub use service::{DatabaseIO, Service};
+pub use service::{Service, IO};
 pub use substrate::{
     Justification as SubstrateJustification, JustificationTranslator, SessionVerifier,
     SubstrateChainStatus, SubstrateChainStatusNotifier, SubstrateFinalizationInfo, VerifierCache,

--- a/finality-aleph/src/sync/service.rs
+++ b/finality-aleph/src/sync/service.rs
@@ -5,13 +5,12 @@ use futures::{channel::mpsc, StreamExt};
 use log::{debug, error, trace, warn};
 use substrate_prometheus_endpoint::Registry;
 
-pub use crate::sync::handler::DatabaseIO;
 use crate::{
     network::GossipNetwork,
     session::SessionBoundaryInfo,
     sync::{
         data::{NetworkData, Request, ResponseItems, State, VersionWrapper, VersionedNetworkData},
-        handler::{Action, Error as HandlerError, HandleStateAction, Handler},
+        handler::{Action, DatabaseIO, Error as HandlerError, HandleStateAction, Handler},
         message_limiter::MsgLimiter,
         metrics::{Event, Metrics},
         task_queue::TaskQueue,
@@ -21,10 +20,58 @@ use crate::{
         ChainStatusNotifier, Finalizer, Header, Justification, JustificationSubmissions,
         RequestBlocks, Verifier, LOG_TARGET,
     },
+    SyncOracle,
 };
 
 const BROADCAST_COOLDOWN: Duration = Duration::from_millis(600);
 const BROADCAST_PERIOD: Duration = Duration::from_secs(5);
+
+pub struct IO<B, J, N, CE, CS, F, BI>
+where
+    B: Block,
+    J: Justification<Header = B::Header>,
+    N: GossipNetwork<VersionedNetworkData<B, J>>,
+    CE: ChainStatusNotifier<B::Header>,
+    CS: ChainStatus<B, J>,
+    F: Finalizer<J>,
+    BI: BlockImport<B>,
+{
+    network: N,
+    chain_events: CE,
+    sync_oracle: SyncOracle,
+    additional_justifications_from_user: mpsc::UnboundedReceiver<J::Unverified>,
+    database_io: DatabaseIO<B, J, CS, F, BI>,
+}
+
+impl<B, J, N, CE, CS, F, BI> IO<B, J, N, CE, CS, F, BI>
+where
+    B: Block,
+    J: Justification<Header = B::Header>,
+    N: GossipNetwork<VersionedNetworkData<B, J>>,
+    CE: ChainStatusNotifier<B::Header>,
+    CS: ChainStatus<B, J>,
+    F: Finalizer<J>,
+    BI: BlockImport<B>,
+{
+    pub fn new(
+        chain_status: CS,
+        finalizer: F,
+        block_importer: BI,
+        network: N,
+        chain_events: CE,
+        sync_oracle: SyncOracle,
+        additional_justifications_from_user: mpsc::UnboundedReceiver<J::Unverified>,
+    ) -> Self {
+        let database_io = DatabaseIO::new(chain_status, finalizer, block_importer);
+        IO {
+            network,
+            chain_events,
+            sync_oracle,
+            additional_justifications_from_user,
+            database_io,
+        }
+    }
+}
 
 /// A service synchronizing the knowledge about the chain between the nodes.
 pub struct Service<B, J, N, CE, CS, V, F, BI>
@@ -81,12 +128,9 @@ where
     /// Also returns an interface for submitting additional justifications,
     /// and an interface for requesting blocks.
     pub fn new(
-        network: N,
-        chain_events: CE,
         verifier: V,
-        database_io: DatabaseIO<B, J, CS, F, BI>,
         session_info: SessionBoundaryInfo,
-        additional_justifications_from_user: mpsc::UnboundedReceiver<J::Unverified>,
+        io: IO<B, J, N, CE, CS, F, BI>,
         metrics_registry: Option<Registry>,
     ) -> Result<
         (
@@ -96,8 +140,15 @@ where
         ),
         HandlerError<B, J, CS, V, F>,
     > {
+        let IO {
+            network,
+            chain_events,
+            sync_oracle,
+            additional_justifications_from_user,
+            database_io,
+        } = io;
         let network = VersionWrapper::new(network);
-        let handler = Handler::new(database_io, verifier, session_info)?;
+        let handler = Handler::new(database_io, verifier, sync_oracle, session_info)?;
         let tasks = TaskQueue::new();
         let broadcast_ticker = Ticker::new(BROADCAST_PERIOD, BROADCAST_COOLDOWN);
         let (justifications_for_sync, justifications_from_user) = mpsc::unbounded();

--- a/finality-aleph/src/sync_oracle.rs
+++ b/finality-aleph/src/sync_oracle.rs
@@ -32,6 +32,7 @@ impl SyncOracle {
 
     pub fn update_behind(&self, behind: u32) {
         self.behind.store(behind, Ordering::Relaxed);
+        *self.last_update.lock() = Instant::now();
     }
 }
 

--- a/finality-aleph/src/sync_oracle.rs
+++ b/finality-aleph/src/sync_oracle.rs
@@ -1,0 +1,50 @@
+use std::{
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use parking_lot::Mutex;
+use sp_consensus::SyncOracle as SyncOracleT;
+
+/// A sync oracle implementation tracking how far behind the highest known justification the node is.
+/// It defines being in major sync as knowing of any justification of an unknown block.
+/// It defines being offline as not getting any update for at least 6 seconds (or never at all).
+#[derive(Clone)]
+pub struct SyncOracle {
+    behind: Arc<AtomicU32>,
+    last_update: Arc<Mutex<Instant>>,
+}
+
+impl SyncOracle {
+    pub fn new() -> Self {
+        SyncOracle {
+            // This should never exceed 1800 due to the structure of the forest, thus 9000 is a decent marker of being uninitialized.
+            behind: Arc::new(AtomicU32::new(9001)),
+            last_update: Arc::new(Mutex::new(Instant::now())),
+        }
+    }
+
+    pub fn update_behind(&self, behind: u32) {
+        self.behind.store(behind, Ordering::Relaxed);
+    }
+}
+
+impl Default for SyncOracle {
+    fn default() -> Self {
+        SyncOracle::new()
+    }
+}
+
+impl SyncOracleT for SyncOracle {
+    fn is_major_syncing(&self) -> bool {
+        self.behind.load(Ordering::Relaxed) > 0
+    }
+
+    fn is_offline(&self) -> bool {
+        self.last_update.lock().elapsed() > Duration::from_secs(6)
+            || self.behind.load(Ordering::Relaxed) > 9000
+    }
+}

--- a/finality-aleph/src/sync_oracle.rs
+++ b/finality-aleph/src/sync_oracle.rs
@@ -9,6 +9,10 @@ use std::{
 use parking_lot::Mutex;
 use sp_consensus::SyncOracle as SyncOracleT;
 
+// This should never exceed 1800 due to the structure of the forest, thus 9000 is a decent marker of being uninitialized.
+const UNINITIALIZED_THRESHOLD: u32 = 9000;
+const OFFLINE_THRESHOLD: Duration = Duration::from_secs(6);
+
 /// A sync oracle implementation tracking how far behind the highest known justification the node is.
 /// It defines being in major sync as knowing of any justification of an unknown block.
 /// It defines being offline as not getting any update for at least 6 seconds (or never at all).
@@ -21,8 +25,7 @@ pub struct SyncOracle {
 impl SyncOracle {
     pub fn new() -> Self {
         SyncOracle {
-            // This should never exceed 1800 due to the structure of the forest, thus 9000 is a decent marker of being uninitialized.
-            behind: Arc::new(AtomicU32::new(9001)),
+            behind: Arc::new(AtomicU32::new(UNINITIALIZED_THRESHOLD + 1)),
             last_update: Arc::new(Mutex::new(Instant::now())),
         }
     }
@@ -44,7 +47,7 @@ impl SyncOracleT for SyncOracle {
     }
 
     fn is_offline(&self) -> bool {
-        self.last_update.lock().elapsed() > Duration::from_secs(6)
-            || self.behind.load(Ordering::Relaxed) > 9000
+        self.last_update.lock().elapsed() > OFFLINE_THRESHOLD
+            || self.behind.load(Ordering::Relaxed) > UNINITIALIZED_THRESHOLD
     }
 }


### PR DESCRIPTION
# Description

Make Aura use the information from our sync to decide on block production (whether we are in "major sync").

Some of the choices here might be controversial, so I would welcome opinions about them. <_<

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have created new documentation