### PR TITLE
A0-3249: Prepare release-12 RC commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-node"
-version = "0.9.0"
+version = "0.12.0"
 dependencies = [
  "aleph-runtime",
  "finality-aleph",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-runtime"
-version = "0.10.0"
+version = "0.12.0"
 dependencies = [
  "baby-liminal-extension",
  "frame-benchmarking",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-node"
-version = "0.9.0"
+version = "0.12.0"
 description = "Aleph node binary"
 build = "build.rs"
 license = "GPL-3.0-or-later"

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-runtime"
-version = "0.10.0"
+version = "0.12.0"
 license = "GPL-3.0-or-later"
 authors.workspace = true
 edition.workspace = true

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -29,6 +29,7 @@ use frame_support::{
     weights::constants::WEIGHT_REF_TIME_PER_MILLIS,
     PalletId,
 };
+use frame_support::pallet_prelude::Get;
 use frame_system::{EnsureRoot, EnsureSignedBy};
 #[cfg(feature = "try-runtime")]
 use frame_try_runtime::UpgradeCheckSelect;
@@ -832,6 +833,24 @@ pub type SignedExtra = (
     frame_system::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
+
+pub struct NominationPoolsMigrationV5OldPallet;
+impl Get<Perbill> for NominationPoolsMigrationV5OldPallet {
+    fn get() -> Perbill {
+        Perbill::from_percent(0)
+    }
+}
+
+/// All migrations that will run on the next runtime upgrade.
+///
+/// Should be cleared after every release.
+pub type Migrations = (
+    pallet_nomination_pools::migration::v4::MigrateV3ToV5<
+        Runtime,
+        NominationPoolsMigrationV5OldPallet,
+    >,
+);
+
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =
     generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
@@ -844,6 +863,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    Migrations
 >;
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+use frame_support::pallet_prelude::Get;
 pub use frame_support::{
     construct_runtime, log, parameter_types,
     traits::{
@@ -29,7 +30,6 @@ use frame_support::{
     weights::constants::WEIGHT_REF_TIME_PER_MILLIS,
     PalletId,
 };
-use frame_support::pallet_prelude::Get;
 use frame_system::{EnsureRoot, EnsureSignedBy};
 #[cfg(feature = "try-runtime")]
 use frame_try_runtime::UpgradeCheckSelect;
@@ -863,7 +863,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    Migrations
+    Migrations,
 >;
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -844,12 +844,8 @@ impl Get<Perbill> for ZeroMaxGlobalCommission {
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// Should be cleared after every release.
-pub type Migrations = (
-    pallet_nomination_pools::migration::v4::MigrateV3ToV5<
-        Runtime,
-        ZeroMaxGlobalCommission,
-    >,
-);
+pub type Migrations =
+    (pallet_nomination_pools::migration::v4::MigrateV3ToV5<Runtime, ZeroMaxGlobalCommission>,);
 
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -6,7 +6,6 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use frame_support::pallet_prelude::Get;
 pub use frame_support::{
     construct_runtime, log, parameter_types,
     traits::{
@@ -22,6 +21,7 @@ pub use frame_support::{
     StorageValue,
 };
 use frame_support::{
+    pallet_prelude::Get,
     sp_runtime::Perquintill,
     traits::{
         ConstBool, ConstU32, EqualPrivilegeOnly, EstimateNextSessionRotation, SortedMembers,
@@ -834,8 +834,8 @@ pub type SignedExtra = (
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 
-pub struct NominationPoolsMigrationV5OldPallet;
-impl Get<Perbill> for NominationPoolsMigrationV5OldPallet {
+pub struct ZeroMaxGlobalCommission;
+impl Get<Perbill> for ZeroMaxGlobalCommission {
     fn get() -> Perbill {
         Perbill::from_percent(0)
     }
@@ -847,7 +847,7 @@ impl Get<Perbill> for NominationPoolsMigrationV5OldPallet {
 pub type Migrations = (
     pallet_nomination_pools::migration::v4::MigrateV3ToV5<
         Runtime,
-        NominationPoolsMigrationV5OldPallet,
+        ZeroMaxGlobalCommission,
     >,
 );
 

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -94,10 +94,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 56,
+    spec_version: 66,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 16,
+    transaction_version: 17,
     state_version: 0,
 };
 
@@ -720,7 +720,11 @@ impl pallet_contracts::Config for Runtime {
     type MaxStorageKeyLen = ConstU32<128>;
     type UnsafeUnstableInterface = ConstBool<false>;
     type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
-    type Migrations = ();
+    type Migrations = (
+        pallet_contracts::migration::v10::Migration<Runtime>,
+        pallet_contracts::migration::v11::Migration<Runtime>,
+        pallet_contracts::migration::v12::Migration<Runtime>,
+    );
 }
 
 parameter_types! {


### PR DESCRIPTION
# Description

This change
* bumps `spec_version` and `tx_version` - latter since quite a lot pallet API changed 
* bumps node and runtime version to `0.12.0`
* enable contract migrations

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have bumped `spec_version` and `transaction_version`
