### PR TITLE
A0-3149: Enable, in a correct way, multi block contract migrations

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 66,
+    spec_version: 67,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 17,
@@ -844,8 +844,10 @@ impl Get<Perbill> for ZeroMaxGlobalCommission {
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// Should be cleared after every release.
-pub type Migrations =
-    (pallet_nomination_pools::migration::v4::MigrateV3ToV5<Runtime, ZeroMaxGlobalCommission>,);
+pub type Migrations = (
+    pallet_nomination_pools::migration::v4::MigrateV3ToV5<Runtime, ZeroMaxGlobalCommission>,
+    pallet_contracts::migration::Migration<Runtime>,
+);
 
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =


### PR DESCRIPTION
# Description

In order to enable pallet contracts multi block migrations, one need to do two changes in the runtime:
1. Specify all migrations structs in `impl Runtime for pallet_contracts`, `Migrations` trait, and
2. Specify `pallet_contracts::migration::Migration<Runtime>` struct in `Executive`, aleong withh all current migrations

We missed point 2 which this PR fixes. This design is as follow:

```
//! When a migration starts and [OnRuntimeUpgrade::on_runtime_upgrade] is called, instead of
//! performing the actual migration, we set a custom storage item [MigrationInProgress].
//! This storage item defines a [Cursor] for the current migration.
```

see https://github.com/Cardinal-Cryptography/substrate/blob/aleph-v1.0.0/frame/contracts/src/migration.rs#L292

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


