### PR TITLE
A0-2714: Nightly pipeline notifications and A0-3212: Move rest of e2e tests to nightly pipeline

### DIFF
--- a/.github/actions/run-e2e-test/action.yml
+++ b/.github/actions/run-e2e-test/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: Download artifact with the test suite image
       if: inputs.test-case != ''
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: aleph-e2e-client
 

--- a/.github/workflows/_check-vars-and-secrets.yml
+++ b/.github/workflows/_check-vars-and-secrets.yml
@@ -47,7 +47,6 @@ jobs:
             -z "${{ secrets.SYNCAZF }}" || \
             -z "${{ secrets.DOCKERHUB_PASSWORD }}" || \
             -z "${{ secrets.DOCKERHUB_USERNAME }}" || \
-            -z "${{ secrets.SLACK_WEBHOOK_NIGHTLY_PIPELINE }}" || \
             -z "${{ secrets.SLACK_WEBHOOK_TRACK_APPLICATIONS }}" || \
             -z "${{ secrets.SLACK_WEBHOOK_DEV_ONDUTY }}"
           ]]; then

--- a/.github/workflows/_run-e2e-tests.yml
+++ b/.github/workflows/_run-e2e-tests.yml
@@ -1,5 +1,5 @@
 ---
-#  This workflow run e2e tests as jobs (ie, in paraller)
+#  This workflow run e2e tests as jobs (ie, in parallel)
 name: Run e2e tests
 on:
   workflow_call:
@@ -16,11 +16,11 @@ jobs:
         uses: ./.github/actions/run-e2e-test
         with:
           test-case: finalization::finalization
-        timeout-minutes: 2
-
+        timeout-minutes: 3
 
   run-e2e-rewards-disable-node-test:
     name: Run e2e reward points - disable node test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -31,11 +31,12 @@ jobs:
         with:
           test-case: rewards::disable_node
           follow-up-finalization-check: true
-        timeout-minutes: 15
+        timeout-minutes: 20
 
 
   run-e2e-token-transfer-test:
     name: Run e2e token transfer test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -45,10 +46,11 @@ jobs:
         uses: ./.github/actions/run-e2e-test
         with:
           test-case: token_transfer
-        timeout-minutes: 3
+        timeout-minutes: 20
 
   run-e2e-fee-calculation-test:
     name: Run e2e fee calculation test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -58,10 +60,11 @@ jobs:
         uses: ./.github/actions/run-e2e-test
         with:
           test-case: fee_calculation
-        timeout-minutes: 5
+        timeout-minutes: 20
 
   run-e2e-channeling-fee-test:
     name: Run e2e channeling fee test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -71,10 +74,11 @@ jobs:
         uses: ./.github/actions/run-e2e-test
         with:
           test-case: channeling_fee_and_tip
-        timeout-minutes: 4
+        timeout-minutes: 20
 
   run-e2e-treasury-access-test:
     name: Run e2e treasury access test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -84,10 +88,11 @@ jobs:
         uses: ./.github/actions/run-e2e-test
         with:
           test-case: treasury_access
-        timeout-minutes: 4
+        timeout-minutes: 20
 
   run-e2e-batch-transactions-test:
     name: Run e2e batch transactions test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -97,10 +102,11 @@ jobs:
         uses: ./.github/actions/run-e2e-test
         with:
           test-case: batch_transactions
-        timeout-minutes: 4
+        timeout-minutes: 20
 
   run-e2e-staking-era-payouts-test:
     name: Run e2e staking era payouts test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -111,11 +117,12 @@ jobs:
         with:
           test-case: staking_era_payouts
           follow-up-finalization-check: true
-        timeout-minutes: 15
+        timeout-minutes: 20
 
 
   run-e2e-staking-new-validator-test:
     name: Run e2e staking new validator test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -126,11 +133,12 @@ jobs:
         with:
           test-case: staking_new_validator
           follow-up-finalization-check: true
-        timeout-minutes: 10
+        timeout-minutes: 20
 
 
   run-e2e-change-validators-test:
     name: Run e2e change validators test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -141,10 +149,11 @@ jobs:
         with:
           test-case: change_validators
           follow-up-finalization-check: true
-        timeout-minutes: 3
+        timeout-minutes: 20
 
   run-e2e-fail-change-validators-test:
     name: Run e2e fail change validators test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -155,10 +164,11 @@ jobs:
         with:
           test-case: fail_changing_validators
           follow-up-finalization-check: true
-        timeout-minutes: 3
+        timeout-minutes: 20
 
   run-e2e-validators-rotate:
     name: Run validators rotation test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -169,10 +179,11 @@ jobs:
         with:
           test-case: validators_rotate
           follow-up-finalization-check: true
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-era-payout:
     name: Run era payout test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -183,10 +194,11 @@ jobs:
         with:
           test-case: era_payout::era_payout
           follow-up-finalization-check: true
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-era-validators:
     name: Run era validators test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -197,10 +209,11 @@ jobs:
         with:
           test-case: era_validators
           follow-up-finalization-check: true
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-rewards-force-new-era:
     name: Run force new era test to check rewards
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -211,10 +224,11 @@ jobs:
         with:
           test-case: rewards::force_new_era
           follow-up-finalization-check: true
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-rewards-stake-change:
     name: Run reward points with stake changed test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -225,10 +239,11 @@ jobs:
         with:
           test-case: rewards::points_stake_change
           follow-up-finalization-check: true
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-rewards-change-stake-force-new-era:
     name: Run reward points with stake changed and new era forced test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -239,10 +254,11 @@ jobs:
         with:
           test-case: rewards::change_stake_and_force_new_era
           follow-up-finalization-check: true
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-rewards-points-basic:
     name: Run basic reward points calculation test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -253,10 +269,11 @@ jobs:
         with:
           test-case: points_basic
           follow-up-finalization-check: true
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-authorities-are-staking:
     name: Run authorities are staking test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -270,10 +287,11 @@ jobs:
           reserved-seats: 3
           non-reserved-seats: 3
           follow-up-finalization-check: true
-        timeout-minutes: 15
+        timeout-minutes: 20
 
   run-e2e-ban-automatic:
     name: Run ban automatic test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -284,10 +302,11 @@ jobs:
         with:
           test-case: ban_automatic
           follow-up-finalization-check: true
-        timeout-minutes: 15
+        timeout-minutes: 20
 
   run-e2e-ban-manual:
     name: Run ban manual test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -298,10 +317,11 @@ jobs:
         with:
           test-case: ban_manual
           follow-up-finalization-check: true
-        timeout-minutes: 15
+        timeout-minutes: 20
 
   run-e2e-ban-counter-clearing:
     name: Run ban counter clearing test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -312,10 +332,11 @@ jobs:
         with:
           test-case: clearing_session_count
           follow-up-finalization-check: true
-        timeout-minutes: 15
+        timeout-minutes: 20
 
   run-e2e-ban-threshold:
     name: Run ban threshold test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -326,10 +347,11 @@ jobs:
         with:
           test-case: ban_threshold
           follow-up-finalization-check: true
-        timeout-minutes: 15
+        timeout-minutes: 20
 
   run-e2e-permissionless-ban:
     name: Run permissionless ban test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -340,10 +362,11 @@ jobs:
         with:
           test-case: permissionless_ban
           follow-up-finalization-check: true
-        timeout-minutes: 15
+        timeout-minutes: 20
 
   run-e2e-version-upgrade:
     name: Run basic (positive) version-upgrade test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -357,10 +380,11 @@ jobs:
           UPGRADE_VERSION: 1
           UPGRADE_SESSION: 3
           UPGRADE_FINALIZATION_WAIT_SESSIONS: 2
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-adder-contract-test:
     name: Run e2e adder contract test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -377,10 +401,11 @@ jobs:
         with:
           deploy-adder: true
           test-case: adder
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-finality-version-change:
     name: Run finality version change test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -391,10 +416,11 @@ jobs:
         with:
           test-case: finality_version::finality_version_change
           follow-up-finalization-check: true
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-committee-split-reserved-01:
     name: Run committee split test with node-0 and node-1 dead
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -407,10 +433,11 @@ jobs:
         with:
           test-case: committee_split::split_test_reserved_01
           node-count: 7
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-committee-split-reserved-12:
     name: Run committee split test with node-1 and node-2 dead
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -423,10 +450,11 @@ jobs:
         with:
           test-case: committee_split::split_test_reserved_12
           node-count: 7
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-committee-split-reserved-02:
     name: Run committee split test with node-0 and node-2 dead
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -439,10 +467,11 @@ jobs:
         with:
           test-case: committee_split::split_test_reserved_02
           node-count: 7
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-committee-split-test-success-without-any-deads:
     name: Run committee split test without any deads
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -456,10 +485,11 @@ jobs:
           test-case: committee_split::split_test_success_without_any_deads
           follow-up-finalization-check: true
           node-count: 7
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-committee-split-test-success-with-one-dead:
     name: Run committee split test with one node dead
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -473,10 +503,11 @@ jobs:
           test-case: committee_split::split_test_success_with_one_dead
           follow-up-finalization-check: true
           node-count: 7
-        timeout-minutes: 10
+        timeout-minutes: 20
 
   run-e2e-set-emergency-finalizer:
     name: Run set emergency finalizer test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -487,10 +518,11 @@ jobs:
         with:
           test-case: set_emergency_finalizer_test
           follow-up-finalization-check: true
-        timeout-minutes: 4
+        timeout-minutes: 20
 
   run-e2e-set-lenient-threshold:
     name: Run set lenient threshold test
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -501,9 +533,10 @@ jobs:
         with:
           test-case: set_lenient_threshold_test
           follow-up-finalization-check: true
-        timeout-minutes: 3
+        timeout-minutes: 20
 
   run-e2e-emergency-finalizer-usage:
+    needs: [run-e2e-finalization-test]
     name: Run chain dead scenario
     runs-on: ubuntu-20.04
     steps:
@@ -518,10 +551,11 @@ jobs:
           test-case: chain_dead_scenario
           follow-up-finalization-check: true
           node-count: 6
-        timeout-minutes: 8
+        timeout-minutes: 20
 
   run-e2e-committee-split-test-success-with-all-non-reserved-dead:
     name: Run committee split test with all non-reserved nodes dead
+    needs: [run-e2e-finalization-test]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -535,4 +569,4 @@ jobs:
           test-case: committee_split::split_test_success_with_all_non_reserved_dead
           follow-up-finalization-check: true
           node-count: 7
-        timeout-minutes: 10
+        timeout-minutes: 20

--- a/.github/workflows/nightly-e2e-logic-tests.yml
+++ b/.github/workflows/nightly-e2e-logic-tests.yml
@@ -44,7 +44,7 @@ jobs:
     name: Slack notification
     runs-on: ubuntu-20.04
     needs: [check-e2e-test-suite-completion]
-    if: ${{ !cancelled() && "${{ github.event_name }}" != "workflow_dispatch" }}
+    if: ${{ !cancelled() && github.event_name != "workflow_dispatch" }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-e2e-logic-tests.yml
+++ b/.github/workflows/nightly-e2e-logic-tests.yml
@@ -5,10 +5,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '00 21 * * *'
-  # testing, remove before merge
-  push:
-    branches:
-      - A0-3212
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/nightly-e2e-logic-tests.yml
+++ b/.github/workflows/nightly-e2e-logic-tests.yml
@@ -52,4 +52,4 @@ jobs:
         with:
           notify-on: "always"
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_PIPELINE }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ONDUTY }}

--- a/.github/workflows/nightly-e2e-logic-tests.yml
+++ b/.github/workflows/nightly-e2e-logic-tests.yml
@@ -1,0 +1,53 @@
+---
+name: Nightly pipeline logic e2e tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 21 * * *'
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build-test-node-and-runtime:
+    name: Build test node and runtime
+    uses: ./.github/workflows/_build-test-node-and-runtime.yml
+
+  build-test-node-image-and-e2e-client-image:
+    needs: [build-test-node-and-runtime]
+    uses: ./.github/workflows/_build-test-node-and-e2e-client-image.yml
+
+  run-e2e-tests:
+    name: Run e2e tests
+    needs: [build-test-node-image-and-e2e-client-image]
+    uses: ./.github/workflows/_run-e2e-tests.yml
+
+  check-e2e-test-suite-completion:
+    needs: [run-e2e-tests]
+    name: Check e2e test suite completion
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: All e2e tests completed
+        run: |
+          # due to the fact GitHub treats skipped jobs as success, and when any of dependant
+          # jobs fail, this check will be skipped, we need to check status manually
+          jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
+
+  slack-notification:
+    name: Slack notification
+    runs-on: ubuntu-20.04
+    needs: [check-e2e-test-suite-completion]
+    if: ${{ !cancelled() && "${{ github.event_name }}" != "workflow_dispatch" }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Send Slack message
+        uses: ./.github/actions/slack-notification
+        with:
+          notify-on: "always"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_PIPELINE }}

--- a/.github/workflows/nightly-e2e-logic-tests.yml
+++ b/.github/workflows/nightly-e2e-logic-tests.yml
@@ -44,7 +44,9 @@ jobs:
     name: Slack notification
     runs-on: ubuntu-20.04
     needs: [check-e2e-test-suite-completion]
-    if: ${{ !cancelled() && github.event_name != "workflow_dispatch" }}
+    if: >
+      !cancelled() &&
+      github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-e2e-logic-tests.yml
+++ b/.github/workflows/nightly-e2e-logic-tests.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '00 21 * * *'
+  # testing, remove before merge
+  push:
+    branches:
+      - A0-3212
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/nightly-fe-e2e-tests.yml
+++ b/.github/workflows/nightly-fe-e2e-tests.yml
@@ -1,12 +1,12 @@
 ---
-name: Nightly pipeline short session e2e tests
+name: Nightly pipeline e2e tests on featurenet
 on:
   workflow_dispatch:
   schedule:
     - cron: '00 23 * * *'
 
 concurrency:
-  group: "${{ github.ref }}-${{ github.workflow }}"
+  group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
@@ -180,7 +180,7 @@ jobs:
     name: Slack notification
     runs-on: ubuntu-20.04
     needs: [runs-e2e-test-on-fe]
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && "${{ github.event_name }}" != "workflow_dispatch" }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-fe-e2e-tests.yml
+++ b/.github/workflows/nightly-fe-e2e-tests.yml
@@ -180,7 +180,9 @@ jobs:
     name: Slack notification
     runs-on: ubuntu-20.04
     needs: [runs-e2e-test-on-fe]
-    if: ${{ !cancelled() && "${{ github.event_name }}" != "workflow_dispatch" }}
+    if: >
+      !cancelled() &&
+      github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-fe-e2e-tests.yml
+++ b/.github/workflows/nightly-fe-e2e-tests.yml
@@ -192,4 +192,4 @@ jobs:
         with:
           notify-on: "always"
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_PIPELINE }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ONDUTY }}

--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -260,4 +260,4 @@ jobs:
         with:
           notify-on: "always"
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_PIPELINE }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ONDUTY }}

--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -248,7 +248,9 @@ jobs:
     name: Slack notification
     runs-on: ubuntu-20.04
     needs: [check-nightly-pipeline-completion]
-    if: ${{ !cancelled() && "${{ github.event_name }}" != "workflow_dispatch" }}
+    if: >
+      !cancelled() &&
+      github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -248,7 +248,7 @@ jobs:
     name: Slack notification
     runs-on: ubuntu-20.04
     needs: [check-nightly-pipeline-completion]
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && "${{ github.event_name }}" != "workflow_dispatch" }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -41,10 +41,19 @@ jobs:
     needs: [build-test-node-and-runtime]
     uses: ./.github/workflows/_build-test-node-and-e2e-client-image.yml
 
-  run-e2e-tests:
-    name: Run e2e tests
-    needs: [build-test-node-image-and-e2e-client-image]
-    uses: ./.github/workflows/_run-e2e-tests.yml
+  run-e2e-finalization-test:
+    name: Run e2e finalization test
+    needs: [ build-test-node-image-and-e2e-client-image ]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Run e2e test
+        uses: ./.github/actions/run-e2e-test
+        with:
+          test-case: finalization::finalization
+        timeout-minutes: 3
 
   check-e2e-test-suite-completion:
     needs: [run-e2e-tests]

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -43,7 +43,7 @@ jobs:
 
   run-e2e-finalization-test:
     name: Run e2e finalization test
-    needs: [ build-test-node-image-and-e2e-client-image ]
+    needs: [build-test-node-image-and-e2e-client-image]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -54,15 +54,3 @@ jobs:
         with:
           test-case: finalization::finalization
         timeout-minutes: 3
-
-  check-e2e-test-suite-completion:
-    needs: [run-e2e-tests]
-    name: Check e2e test suite completion
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-20.04
-    steps:
-      - name: All e2e tests completed
-        run: |
-          # due to the fact GitHub treats skipped jobs as success, and when any of dependant
-          # jobs fail, this check will be skipped, we need to check status manually
-          jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'


### PR DESCRIPTION
# Descriprion

* Move all e2e tests except finalization to the nightly pipeline. This shortens the PR pipeline by about 6 minutes. Now most culprit is runtime determinism check. 
* The finalization e2e test must stay in PR pipeline as it is an important smoke test. 
* all nightly pipelines can be triggered on demand, in which case there won't be a slack notification sent
* redirect slack notifications to different channel

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change to repo check settings. Before merge I'll remove  e2e test suite completion check and add e2e finalization check.

## Testing

See sample new wokrflow run https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/6478879803
