### PR TITLE
A0-3298: Move clique network tests to nightly

### DIFF
--- a/.github/workflows/_check-code-formatting.yml
+++ b/.github/workflows/_check-code-formatting.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   main:
     name: Run check, test and lints
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: [self-hosted, Linux, X64, small]
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/_check-production-node-and-runtime.yml
+++ b/.github/workflows/_check-production-node-and-runtime.yml
@@ -1,0 +1,30 @@
+---
+# This workflow checks production version of aleph-node and aleph-runtime, ie
+# only compilation and not linking, which takes most of the time
+name: Check production node and runtime
+on:
+  workflow_call:
+
+jobs:
+  main:
+    name: Build production node and runtime
+    runs-on: [self-hosted, Linux, X64, large]
+    env:
+      RUST_BACKTRACE: full
+      RUSTC_WRAPPER: sccache
+    steps:
+      - name: Checkout aleph-node source code
+        uses: actions/checkout@v4
+
+      - name: Call action get-ref-properties
+        id: get-ref-properties
+        # yamllint disable-line rule:line-length
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v2
+
+      - name: Install Rust toolchain
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v2
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Build production binary and runtime
+        run: cargo check --profile production -p aleph-node

--- a/.github/workflows/_check-production-node-and-runtime.yml
+++ b/.github/workflows/_check-production-node-and-runtime.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   main:
-    name: Build production node and runtime
+    name: Check production node and runtime
     runs-on: [self-hosted, Linux, X64, large]
     env:
       RUST_BACKTRACE: full
@@ -26,5 +26,5 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Build production binary and runtime
+      - name: Check production binary and runtime
         run: cargo check --profile production -p aleph-node

--- a/.github/workflows/_unit-tests-and-static-checks.yml
+++ b/.github/workflows/_unit-tests-and-static-checks.yml
@@ -45,4 +45,5 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features "liminal-try-runtime liminal-runtime-benchmarks"
+          # yamllint disable-line rule:line-length
+          args: --features "liminal-try-runtime liminal-runtime-benchmarks" -- --skip clique_network

--- a/.github/workflows/_unit-tests-and-static-checks.yml
+++ b/.github/workflows/_unit-tests-and-static-checks.yml
@@ -46,4 +46,4 @@ jobs:
         with:
           command: test
           # yamllint disable-line rule:line-length
-          args: --features "liminal-try-runtime liminal-runtime-benchmarks" -- --skip clique_network
+          args: -- --skip clique_network

--- a/.github/workflows/_unit-tests-and-static-checks.yml
+++ b/.github/workflows/_unit-tests-and-static-checks.yml
@@ -5,8 +5,8 @@ on:
   workflow_call:
 
 jobs:
-  main:
-    name: Run check, test and lints
+  clippy:
+    name: Run static checks (clippy)
     runs-on: [self-hosted, Linux, X64, large]
     env:
       CARGO_INCREMENTAL: 0
@@ -18,7 +18,7 @@ jobs:
       - name: Install Rust Toolchain
         uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v2
 
-      - name: Run Linter
+      - name: Run clippy
         uses: actions-rs/cargo@v1
         env:
           # https://github.com/mozilla/sccache/issues/966
@@ -27,6 +27,19 @@ jobs:
         with:
           command: clippy
           args: --all-targets -- --no-deps -D warnings
+
+  unit-tests:
+    name: Run unit tests
+    runs-on: [self-hosted, Linux, X64, large]
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+    steps:
+      - name: Checkout Source code
+        uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v2
 
       - name: Run Unit Test Suite
         uses: actions-rs/cargo@v1

--- a/.github/workflows/_unit-tests-and-static-checks.yml
+++ b/.github/workflows/_unit-tests-and-static-checks.yml
@@ -45,5 +45,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          # yamllint disable-line rule:line-length
           args: -- --skip clique_network

--- a/.github/workflows/nightly-check-runtime-determinism.yml
+++ b/.github/workflows/nightly-check-runtime-determinism.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '00 00 * * *'
+  # testing, remove before merge
+  push:
+    branches:
+      - A0-3298
 
 concurrency:
   group: "${{ github.ref }}-${{ github.workflow }}"
@@ -27,7 +31,7 @@ jobs:
   slack-notification:
     name: Slack notification
     runs-on: ubuntu-20.04
-    needs: [runs-e2e-test-on-fe]
+    needs: [check-runtime-determinism]
     if: ${{ !cancelled() }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly-check-runtime-determinism.yml
+++ b/.github/workflows/nightly-check-runtime-determinism.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '00 00 * * *'
-  # testing, remove before merge
-  push:
-    branches:
-      - A0-3298
 
 concurrency:
   group: "${{ github.ref }}-${{ github.workflow }}"

--- a/.github/workflows/nightly-checkruntime-determinism.yml
+++ b/.github/workflows/nightly-checkruntime-determinism.yml
@@ -1,0 +1,41 @@
+---
+name: Nightly pipeline check runtime determinism
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 00 * * *'
+
+concurrency:
+  group: "${{ github.ref }}-${{ github.workflow }}"
+  cancel-in-progress: true
+
+jobs:
+  check-vars-and-secrets:
+    name: Check vars and secrets
+    uses: ./.github/workflows/_check-vars-and-secrets.yml
+    secrets: inherit
+
+  build-production-node-and-runtime:
+    needs: [check-vars-and-secrets]
+    name: Build production node and runtime artifacts (PR version)
+    uses: ./.github/workflows/_build-production-node-and-runtime.yml
+
+  check-runtime-determinism:
+    needs: [build-production-node-and-runtime]
+    uses: ./.github/workflows/_check-runtime-determimism.yml
+
+  slack-notification:
+    name: Slack notification
+    runs-on: ubuntu-20.04
+    needs: [runs-e2e-test-on-fe]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Send Slack message
+        uses: ./.github/actions/slack-notification
+        with:
+          notify-on: "failure"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ONDUTY }}

--- a/.github/workflows/nightly-e2e-logic-tests.yml
+++ b/.github/workflows/nightly-e2e-logic-tests.yml
@@ -50,6 +50,6 @@ jobs:
       - name: Send Slack message
         uses: ./.github/actions/slack-notification
         with:
-          notify-on: "always"
+          notify-on: "failure"
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ONDUTY }}

--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '01 00 * * *'
+  # testing, remove before merge
+  push:
+    branches:
+      - A0-3298
 
 concurrency:
   group: "${{ github.ref }}-${{ github.workflow }}"
@@ -15,8 +19,8 @@ jobs:
     uses: ./.github/workflows/_check-vars-and-secrets.yml
     secrets: inherit
 
-  build-tests:
-    name: Run unit tests
+  run-tests:
+    name: Run all unit and integration workspace tests
     runs-on: [self-hosted, Linux, X64, large]
     env:
       CARGO_INCREMENTAL: 0
@@ -28,7 +32,25 @@ jobs:
       - name: Install Rust Toolchain
         uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v2
 
-      - name: Run Unit Test Suite
+      - name: Run Test Suite
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  run-tests-liminal:
+    name: Run all unit and integration workspace tests (including liminal features)
+    runs-on: [self-hosted, Linux, X64, large]
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+    steps:
+      - name: Checkout Source code
+        uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v2
+
+      - name: Run Test Suite
         uses: actions-rs/cargo@v1
         with:
           command: test
@@ -37,7 +59,7 @@ jobs:
   slack-notification:
     name: Slack notification
     runs-on: ubuntu-20.04
-    needs: [runs-e2e-test-on-fe]
+    needs: [run-tests, run-tests-liminal]
     if: ${{ !cancelled() }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -1,0 +1,51 @@
+---
+name: Nightly pipeline integration tests
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '01 00 * * *'
+
+concurrency:
+  group: "${{ github.ref }}-${{ github.workflow }}"
+  cancel-in-progress: true
+
+jobs:
+  check-vars-and-secrets:
+    name: Check vars and secrets
+    uses: ./.github/workflows/_check-vars-and-secrets.yml
+    secrets: inherit
+
+  build-tests:
+    name: Run unit tests
+    runs-on: [self-hosted, Linux, X64, large]
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+    steps:
+      - name: Checkout Source code
+        uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v2
+
+      - name: Run Unit Test Suite
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features "liminal-try-runtime liminal-runtime-benchmarks"
+
+  slack-notification:
+    name: Slack notification
+    runs-on: ubuntu-20.04
+    needs: [runs-e2e-test-on-fe]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Send Slack message
+        uses: ./.github/actions/slack-notification
+        with:
+          notify-on: "failure"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ONDUTY }}

--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '01 00 * * *'
-  # testing, remove before merge
-  push:
-    branches:
-      - A0-3298
 
 concurrency:
   group: "${{ github.ref }}-${{ github.workflow }}"

--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -256,6 +256,6 @@ jobs:
       - name: Send Slack message
         uses: ./.github/actions/slack-notification
         with:
-          notify-on: "always"
+          notify-on: "failure"
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_PIPELINE }}

--- a/.github/workflows/nightly-short-session-e2e-tests.yml
+++ b/.github/workflows/nightly-short-session-e2e-tests.yml
@@ -188,6 +188,6 @@ jobs:
       - name: Send Slack message
         uses: ./.github/actions/slack-notification
         with:
-          notify-on: "always"
+          notify-on: "failure"
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_PIPELINE }}

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -25,13 +25,9 @@ jobs:
     name: Unit tests and clippy
     uses: ./.github/workflows/_unit-tests-and-static-checks.yml
 
-  build-production-node-and-runtime:
-    name: Build production node and runtime
-    uses: ./.github/workflows/_build-production-node-and-runtime.yml
-
-  check-runtime-determinism:
-    needs: [build-production-node-and-runtime]
-    uses: ./.github/workflows/_check-runtime-determimism.yml
+  check-production-node-and-runtime:
+    name: Check production node and runtime
+    uses: ./.github/workflows/_check-production-node-and-runtime.yml
 
   build-test-node-and-runtime:
     name: Build test node and runtime


### PR DESCRIPTION
# Description

* Moved check runtime determinism to nightly. Motivation is that we don't need to check it that often, and it burns computation power. It is enough to check it every 24 hours in nightly.
* In PR pipeline, just check the production binary instead of compiling it. This is because we do not use production binary in this pipeline, just we want to know whether it compiles. Especially it's hard for linking time as it's 70% of compilation time (due to LTO). Hence I moved actual build to nightly as well.
* Move clique network tests to nightly. This is because they are long-running integration tests 
* Now the outlier is check excluded packages, but we'll deal with it in the next PRs.
* Split `clippy` and `cargo test` into two paraller jobs
* There's one required check pending in this PR but this is because of naming in repo settings. I'll deal with it just before this PR is merged.

New workflow runs: 
https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/6481519250
https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/6481519240

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:
