### PR TITLE
A0-3363: Runtime api for aleph key owner

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -1022,7 +1022,7 @@ impl_runtime_apis! {
             queued_keys.into_iter().filter_map(|(_, keys)| keys.get(AURA)).collect()
         }
 
-         fn aleph_key_owner(key: AlephId) -> Option<AccountId> {
+         fn key_owner(key: AlephId) -> Option<AccountId> {
             Session::key_owner(primitives::KEY_TYPE, key.as_ref())
         }
     }

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -1021,6 +1021,10 @@ impl_runtime_apis! {
 
             queued_keys.into_iter().filter_map(|(_, keys)| keys.get(AURA)).collect()
         }
+
+         fn aleph_key_owner(key: AlephId) -> Option<AccountId> {
+            Session::key_owner(primitives::KEY_TYPE, key.as_ref())
+        }
     }
 
     impl pallet_nomination_pools_runtime_api::NominationPoolsApi<Block, AccountId, Balance> for Runtime {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -283,6 +283,8 @@ sp_api::decl_runtime_apis! {
             session: SessionIndex
         ) -> Result<SessionCommittee<AccountId>, SessionValidatorError>;
         fn next_session_aura_authorities() -> Vec<AuraAuthorityId>;
+        /// Allows to get owner's AccountId for an Aleph key used in the current session.
+        fn aleph_key_owner(key: AuthorityId) -> Option<AccountId>;
     }
 }
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -283,8 +283,10 @@ sp_api::decl_runtime_apis! {
             session: SessionIndex
         ) -> Result<SessionCommittee<AccountId>, SessionValidatorError>;
         fn next_session_aura_authorities() -> Vec<AuraAuthorityId>;
-        /// Allows to get owner's AccountId for an Aleph key used in the current session.
-        fn aleph_key_owner(key: AuthorityId) -> Option<AccountId>;
+        /// Returns owner (`AccountId`) corresponding to an AuthorityId (in some contexts referenced
+        /// also as `aleph_key` - consensus engine's part of session keys) in the current session
+        /// of AlephBFT (finalisation committee).
+        fn key_owner(key: AuthorityId) -> Option<AccountId>;
     }
 }
 


### PR DESCRIPTION
# Description

Add runtime api for getting owner of aleph key.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:
