### PR TITLE
A0-3380: Fixed schedule so all nightly workflows are run within one hour distance.

### DIFF
--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -3,7 +3,7 @@ name: Nightly pipeline integration tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '01 00 * * *'
+    - cron: '00 01 * * *'
 
 concurrency:
   group: "${{ github.ref }}-${{ github.workflow }}"


### PR DESCRIPTION
# Description

Pipelines

* Nightly pipeline check runtime determinism
* Nightly pipeline integration tests

are spawned in one minute from each other, so in practice, it means in parallel, which is a bug.

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)