### PR TITLE
A0-3398: Change docker tag to use inputs.target-image as source

### DIFF
--- a/.github/actions/build-and-push-dockerhub-image/action.yml
+++ b/.github/actions/build-and-push-dockerhub-image/action.yml
@@ -42,6 +42,6 @@ runs:
       run: |
         docker push '${{ inputs.target-image }}'
         if [[ -n '${{ inputs.additional-image }}' ]]; then
-          docker tag '${{ inputs.source-image }}' '${{ inputs.additional-image }}'
+          docker tag '${{ inputs.target-image }}' '${{ inputs.additional-image }}'
           docker push '${{ inputs.additional-image }}'
         fi


### PR DESCRIPTION
# Description

Fixes action for pushing image to dockerhub.  It doesn't properly push the "latest" tag.  The `docker tag` command used in the step has invalid source image.
