### PR TITLE
A0-3398: Change docker tag to use inputs.target-image as source (#1458)

### DIFF
--- a/.github/actions/build-and-push-dockerhub-image/action.yml
+++ b/.github/actions/build-and-push-dockerhub-image/action.yml
@@ -27,9 +27,9 @@ runs:
     - name: Build Docker Hub image
       shell: bash
       run: |
-        echo "FROM ${{ inputs.source-image }}" > Dockerfile.dockerhub
+        echo 'FROM ${{ inputs.source-image }}' > Dockerfile.dockerhub
         echo 'ENTRYPOINT ["/usr/local/bin/aleph-node"]' >> Dockerfile.dockerhub
-        docker build -t "${{ inputs.target-image }}" -f Dockerfile.dockerhub .
+        docker build -t '${{ inputs.target-image }}' -f Dockerfile.dockerhub .
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2
@@ -40,8 +40,8 @@ runs:
     - name: Push image to Docker Hub
       shell: bash
       run: |
-        docker push ${{ inputs.target-image }}
-        if [[ -n "${{ inputs.additional-image }}" ]]; then
-          docker tag ${{ inputs.source-image }} ${{ inputs.additional-image }}
-          docker push ${{ inputs.additional-image }}
+        docker push '${{ inputs.target-image }}'
+        if [[ -n '${{ inputs.additional-image }}' ]]; then
+          docker tag '${{ inputs.target-image }}' '${{ inputs.additional-image }}'
+          docker push '${{ inputs.additional-image }}'
         fi


### PR DESCRIPTION
# Description

Backport of fix https://github.com/Cardinal-Cryptography/aleph-node/commit/36bdfbde92f0a4b6a65372d223581273b8c2fe73 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

