### PR TITLE
A0-3422: Fix major sync finalization problems

### DIFF
--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -435,7 +435,7 @@ where
         header: J::Header,
     ) -> Result<(), <Self as HandlerTypes>::Error> {
         if let Err(e) = self.forest.update_body(&header) {
-            if matches!(e, ForestError::TooNew) {
+            if matches!(e, ForestError::TooNew | ForestError::ParentNotImported) {
                 self.missed_import_data
                     .update(header.id().number(), &self.chain_status)
                     .map_err(Error::ChainStatus)?;

--- a/finality-aleph/src/sync/service.rs
+++ b/finality-aleph/src/sync/service.rs
@@ -133,8 +133,10 @@ where
             target: LOG_TARGET,
             "Initiating a request for highest justified block {:?}.", block_id
         );
-        self.tasks
-            .schedule_in(RequestTask::new_highest_justified(block_id), Duration::ZERO);
+        self.tasks.schedule_in(
+            RequestTask::new_highest_justified(block_id),
+            Duration::from_millis(200),
+        );
     }
 
     fn request_block(&mut self, block_id: BlockIdFor<J>) {


### PR DESCRIPTION
# Description

There was a race making finalization sometimes stop if it fell too far behind the head of the imported chain, this works around that problem. It also slows down some requests, to lower the amount of log spamming during major sync (still spammy tho).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

