### PR TITLE
A0-3422: Deal with too many nonfinalized blocks on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-node"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aleph-runtime",
  "finality-aleph",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-runtime"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "baby-liminal-extension",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-runtime"
-version = "0.12.1"
+version = "0.12.0"
 dependencies = [
  "baby-liminal-extension",
  "frame-benchmarking",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-node"
-version = "0.12.0"
+version = "0.12.1"
 description = "Aleph node binary"
 build = "build.rs"
 license = "GPL-3.0-or-later"

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-runtime"
-version = "0.12.0"
+version = "0.12.1"
 license = "GPL-3.0-or-later"
 authors.workspace = true
 edition.workspace = true

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-runtime"
-version = "0.12.1"
+version = "0.12.0"
 license = "GPL-3.0-or-later"
 authors.workspace = true
 edition.workspace = true

--- a/finality-aleph/src/sync/forest/mod.rs
+++ b/finality-aleph/src/sync/forest/mod.rs
@@ -158,7 +158,9 @@ where
     I: PeerId,
     J: Justification,
 {
-    pub fn new<B, CS>(chain_status: &CS) -> Result<Self, InitializationError<B, J, CS>>
+    /// Creates a new forest and returns whether we have too many nonfinalized blocks in the DB.
+    //TODO(A0-2984): the latter part of the result should be removed after legacy sync is excised
+    pub fn new<B, CS>(chain_status: &CS) -> Result<(Self, bool), InitializationError<B, J, CS>>
     where
         B: Block<Header = J::Header>,
         CS: ChainStatus<B, J>,
@@ -184,14 +186,17 @@ where
                 .children(hash)
                 .map_err(InitializationError::ChainStatus)?;
             for header in children.iter() {
-                forest
-                    .update_body(header)
-                    .map_err(InitializationError::Error)?;
+                if let Err(e) = forest.update_body(header) {
+                    match e {
+                        Error::TooNew => return Ok((forest, true)),
+                        e => return Err(InitializationError::Error(e)),
+                    }
+                }
             }
             deque.extend(children.into_iter().map(|header| header.id()));
         }
 
-        Ok(forest)
+        Ok((forest, false))
     }
 
     fn special_state(&self, id: &BlockIdFor<J>) -> Option<SpecialState> {
@@ -579,7 +584,8 @@ mod tests {
             .expect("should return genesis")
             .header()
             .clone();
-        let forest = Forest::new(&backend).expect("should initialize");
+        let (forest, too_many_nonfinalized) = Forest::new(&backend).expect("should initialize");
+        assert!(!too_many_nonfinalized);
         (header, forest)
     }
 


### PR DESCRIPTION
# Description

Make sync handler understand having too many nonfinalized blocks on startup instead of panicking.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have made corresponding changes to the existing documentation
- I have created new documentation
