### PR TITLE
A0-3466: FIX calling scripts/build_synthetic_network.sh failed due to missing TERM

### DIFF
--- a/.github/workflows/_build-production-node-and-e2e-client-image.yml
+++ b/.github/workflows/_build-production-node-and-e2e-client-image.yml
@@ -101,7 +101,9 @@ jobs:
 
       - name: Build release docker image
         id: build-image
+        shell: bash
         run: |
+          export TERM=xterm-256color
           scripts/synthetic-network/build_synthetic-network.sh
           docker save -o aleph-node.tar aleph-node:syntheticnet
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 function log() {
     echo $1 1>&2

--- a/scripts/synthetic-network/build_synthetic-network.sh
+++ b/scripts/synthetic-network/build_synthetic-network.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
# Description

Calling scripts/build_synthetic_network.sh from within nightly-pipeline was failling due to missing TERM env variable.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)