### PR TITLE
Bump Cardinal-Cryptography/github-actions from v3 to v4

### DIFF
--- a/.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
+++ b/.github/workflows/_build-and-push-pull-request-image-to-featurenets.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Call action get-ref-properties
         id: get-ref-properties
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Download test aleph-node artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/_build-liminal-node.yml
+++ b/.github/workflows/_build-liminal-node.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
         with:
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/_build-production-node-and-e2e-client-image.yml
+++ b/.github/workflows/_build-production-node-and-e2e-client-image.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
 
       - name: Build binary and docker image
         run: |

--- a/.github/workflows/_build-production-node-and-runtime.yml
+++ b/.github/workflows/_build-production-node-and-runtime.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
         with:
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/_build-test-node-and-e2e-client-image.yml
+++ b/.github/workflows/_build-test-node-and-e2e-client-image.yml
@@ -43,7 +43,7 @@ jobs:
           retention-days: 7
 
       - name: Install Rust Toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
 
       - name: Build binary and docker image
         run: |

--- a/.github/workflows/_build-test-node-and-runtime.yml
+++ b/.github/workflows/_build-test-node-and-runtime.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
         with:
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/_check-code-formatting.yml
+++ b/.github/workflows/_check-code-formatting.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nightly Rust Toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
         with:
           channel: nightly-2023-01-10
           targets: wasm32-unknown-unknown

--- a/.github/workflows/_check-excluded-packages.yml
+++ b/.github/workflows/_check-excluded-packages.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rustup and rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
 
       - name: Read contracts toolchain
         id: contracts-toolchain-channel

--- a/.github/workflows/_check-production-node-and-runtime.yml
+++ b/.github/workflows/_check-production-node-and-runtime.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
         with:
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/_check-runtime-determimism.yml
+++ b/.github/workflows/_check-runtime-determimism.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
         with:
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/_run-e2e-tests.yml
+++ b/.github/workflows/_run-e2e-tests.yml
@@ -391,7 +391,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
         with:
           targets: wasm32-unknown-unknown
           components: rust-src

--- a/.github/workflows/_unit-tests-and-static-checks.yml
+++ b/.github/workflows/_unit-tests-and-static-checks.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
 
       - name: Run clippy
         uses: actions-rs/cargo@v1
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
 
       - name: Run Unit Test Suite
         uses: actions-rs/cargo@v1

--- a/.github/workflows/_update-node-image-infra.yml
+++ b/.github/workflows/_update-node-image-infra.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Call action Get ECR image names
         id: get-docker-image-names
@@ -42,7 +42,7 @@ jobs:
       # otherwise ECR image would not exist
       - name: Check deploy image existence
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/check-image-existence-ecr@v3
+        uses: Cardinal-Cryptography/github-actions/check-image-existence-ecr@v4
         with:
           ecr-image: ${{ steps.get-docker-image-names.outputs.ecr-deploy-image }}
 

--- a/.github/workflows/build-and-push-cliain.yml
+++ b/.github/workflows/build-and-push-cliain.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
 
       - name: Cargo | Build release binary
         run: |
@@ -47,7 +47,7 @@ jobs:
 
       - name: Call action get-ref-properties
         id: get-ref-properties
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Login to ECR
         if: >
@@ -108,7 +108,7 @@ jobs:
           env.AWS_MAINNET_ACCESS_KEY_ID != '' &&
           env.AWS_MAINNET_SECRET_ACCESS_KEY != '' &&
           env.CI_DEVNET_S3BUCKET_NAME != ''
-        uses: Cardinal-Cryptography/github-actions/copy-file-to-s3@v3
+        uses: Cardinal-Cryptography/github-actions/copy-file-to-s3@v4
         with:
           source-path: bin/cliain/target/release
           source-filename: cliain

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
 
       - name: rustdoc | Build aleph-client docs
         run: |

--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Install jq
         shell: bash

--- a/.github/workflows/deploy-to-mainnet.yml
+++ b/.github/workflows/deploy-to-mainnet.yml
@@ -30,14 +30,14 @@ jobs:
 
       - name: Get Testnet node commit SHA
         id: get-testnet-node-commit-sha
-        uses: Cardinal-Cryptography/github-actions/get-node-system-version@v3
+        uses: Cardinal-Cryptography/github-actions/get-node-system-version@v4
         with:
           env: testnet
 
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Compare Testnet node SHA version with currently deployed SHA
         if: inputs.force != true

--- a/.github/workflows/featurenet-create-from-branch.yml
+++ b/.github/workflows/featurenet-create-from-branch.yml
@@ -108,7 +108,7 @@ jobs:
     needs: [push-featurnet-node-image-to-ecr]
     name: Create featurenet based on the PR
     # yamllint disable-line rule:line-length
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create-from-branch.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create-from-branch.yml@v4
     secrets: inherit
     with:
       expiration: ${{ inputs.expiration }}

--- a/.github/workflows/featurenet-create-from-net.yml
+++ b/.github/workflows/featurenet-create-from-net.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [check-vars-and-secrets]
     name: Create featurenet
     # yamllint disable-line rule:line-length
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create-from-net.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create-from-net.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ inputs.featurenet-name }}

--- a/.github/workflows/featurenet-delete.yml
+++ b/.github/workflows/featurenet-delete.yml
@@ -25,7 +25,7 @@ jobs:
     needs: [check-vars-and-secrets]
     name: Delete featurenet
     # yamllint disable-line rule:line-length
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-delete.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-delete.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ inputs.featurenet-name }}

--- a/.github/workflows/featurenet-update.yml
+++ b/.github/workflows/featurenet-update.yml
@@ -69,7 +69,7 @@ jobs:
     needs: [check-vars-and-secrets]
     name: Update featurenet
     # yamllint disable-line rule:line-length
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-update.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-update.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ inputs.featurenet-name }}

--- a/.github/workflows/nightly-fe-e2e-tests.yml
+++ b/.github/workflows/nightly-fe-e2e-tests.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Call action get-ref-properties
         id: get-ref-properties
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Get fe name
         id: get-final-featurenet-name
@@ -123,7 +123,7 @@ jobs:
         # yamllint enable rule:line-length
 
       - name: Create featurenet from scratch
-        uses: Cardinal-Cryptography/github-actions/create-featurenet@v3
+        uses: Cardinal-Cryptography/github-actions/create-featurenet@v4
         id: create-featurenet
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
@@ -161,7 +161,7 @@ jobs:
         # yamllint enable rule:line-length
 
       - name: Delete old featurenet app and data
-        uses: Cardinal-Cryptography/github-actions/delete-featurenet@v3
+        uses: Cardinal-Cryptography/github-actions/delete-featurenet@v4
         with:
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}

--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
 
       - name: Run Test Suite
         uses: actions-rs/cargo@v1
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v3
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v4
 
       - name: Run Test Suite
         uses: actions-rs/cargo@v1

--- a/.github/workflows/nightly-update-net-tests.yml
+++ b/.github/workflows/nightly-update-net-tests.yml
@@ -52,7 +52,7 @@ jobs:
   delete-ops-testnet-featurenet:
     needs: [get-aleph-node-main-sha, check-vars-and-secrets]
     name: Delete existing ops-updatenet-testnet featurenet
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-delete.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-delete.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ needs.get-aleph-node-main-sha.outputs.updatenet-testnet-name }}
@@ -60,7 +60,7 @@ jobs:
   delete-ops-mainnet-featurenet:
     needs: [get-aleph-node-main-sha, check-vars-and-secrets]
     name: Delete existing ops-updatenet-mainnet featurenet
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-delete.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-delete.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ needs.get-aleph-node-main-sha.outputs.updatenet-mainnet-name }}
@@ -68,7 +68,7 @@ jobs:
   create-featurenet-from-testnet:
     needs: [get-aleph-node-main-sha, delete-ops-testnet-featurenet]
     name: Create featurenet from testnet
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create-from-net.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create-from-net.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ needs.get-aleph-node-main-sha.outputs.updatenet-testnet-name }}
@@ -80,7 +80,7 @@ jobs:
   create-featurenet-from-mainnet:
     needs: [get-aleph-node-main-sha, delete-ops-mainnet-featurenet]
     name: Create featurenet from mainnet
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create-from-net.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create-from-net.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ needs.get-aleph-node-main-sha.outputs.updatenet-mainnet-name }}
@@ -93,7 +93,7 @@ jobs:
     needs: [get-aleph-node-main-sha, create-featurenet-from-testnet]
     # yamllint disable-line rule:line-length
     name: Update featurenet from testnet to ${{ needs.get-aleph-node-main-sha.outputs.aleph-node-main-hash }}
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-update.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-update.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ needs.get-aleph-node-main-sha.outputs.updatenet-testnet-name }}
@@ -106,7 +106,7 @@ jobs:
     needs: [get-aleph-node-main-sha, create-featurenet-from-mainnet]
     # yamllint disable-line rule:line-length
     name: Update featurenet from mainnet to ${{ needs.get-aleph-node-main-sha.outputs.aleph-node-main-hash }}
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-update.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-update.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ needs.get-aleph-node-main-sha.outputs.updatenet-mainnet-name }}
@@ -118,7 +118,7 @@ jobs:
   delete-featurenet-from-testnet:
     needs: [get-aleph-node-main-sha, update-featurenet-from-testnet]
     name: Delete featurenet from testnet
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-delete.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-delete.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ needs.get-aleph-node-main-sha.outputs.updatenet-testnet-name }}
@@ -126,7 +126,7 @@ jobs:
   delete-featurenet-from-mainnet:
     needs: [get-aleph-node-main-sha, update-featurenet-from-mainnet]
     name: Delete featurenet from mainnet
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-delete.yml@v3
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-delete.yml@v4
     secrets: inherit
     with:
       featurenet-name: ${{ needs.get-aleph-node-main-sha.outputs.updatenet-mainnet-name }}

--- a/.github/workflows/on-main-branch-commit-push-liminal-node-to-ecr.yml
+++ b/.github/workflows/on-main-branch-commit-push-liminal-node-to-ecr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Download node production binary from artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/on-main-or-release-branch-commit.yml
+++ b/.github/workflows/on-main-or-release-branch-commit.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Download node production binary from artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/on-pull-request-change.yml
+++ b/.github/workflows/on-pull-request-change.yml
@@ -23,6 +23,6 @@ jobs:
 
       - name: VALIDATE | Check PR title
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/check-pr-title@v3
+        uses: Cardinal-Cryptography/github-actions/check-pr-title@v4
         with:
           pr-title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/on-pull-request-close.yml
+++ b/.github/workflows/on-pull-request-close.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get branch name and commit SHA
         id: get-ref-properties
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Get argocd featurenet app name
         id: get-argocd-featurenet-app-name

--- a/.github/workflows/on-pull-request-label.yml
+++ b/.github/workflows/on-pull-request-label.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get branch name and commit SHA
         id: get-ref-properties
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Get argocd featurenet app name
         id: get-argocd-featurenet-app-name

--- a/.github/workflows/on-push-release-tag.yml
+++ b/.github/workflows/on-push-release-tag.yml
@@ -39,7 +39,7 @@ jobs:
       # or release branch, see on-main-or-release-branch-commit.yml
       - name: Check release candidate docker image existence
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/check-image-existence-ecr@v3
+        uses: Cardinal-Cryptography/github-actions/check-image-existence-ecr@v4
         with:
           ecr-image: ${{ steps.get-docker-image-names.outputs.ecr-rc-image }}
 

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Push to Aleph-Zero-Foundation
         # yamllint disable rule:line-length
@@ -72,7 +72,7 @@ jobs:
       - name: Call action get-ref-properties
         id: get-ref-properties
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v3
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v4
 
       - name: Checkout Aleph-Zero-Foundation repository
         uses: actions/checkout@v4

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - name: LINT | Execute YAML linter
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/yaml-lint@v3
+        uses: Cardinal-Cryptography/github-actions/yaml-lint@v4

--- a/.github/workflows/yaml-validate.yml
+++ b/.github/workflows/yaml-validate.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - name: VALIDATE | Execute github-actions-validator
         # yamllint disable-line rule:line-length
-        uses: Cardinal-Cryptography/github-actions/yaml-validate@v3
+        uses: Cardinal-Cryptography/github-actions/yaml-validate@v4


### PR DESCRIPTION
# Description

Bumps our github actions from v3 to v4 to make use of new version of featurenet actions, which now spin archivist as a bootnode.

## Type of change

Change only to actions related to featurenets.

# Checklist:

- I have added tests
