### PR TITLE
A0-3307: Introduce verifiable requests

### DIFF
--- a/finality-aleph/src/data_io/data_store.rs
+++ b/finality-aleph/src/data_io/data_store.rs
@@ -151,7 +151,7 @@ where
     B: BlockT<Hash = BlockHash>,
     B::Header: HeaderT<Number = BlockNumber> + UnverifiedHeader + Header<Unverified = B::Header>,
     C: HeaderBackend<B> + BlockchainEvents<B> + Send + Sync + 'static,
-    RB: RequestBlocks + 'static,
+    RB: RequestBlocks<B::Header>,
     Message: AlephNetworkMessage<B::Header>
         + std::fmt::Debug
         + Send
@@ -186,7 +186,7 @@ where
     B: BlockT<Hash = BlockHash>,
     B::Header: HeaderT<Number = BlockNumber> + UnverifiedHeader + Header<Unverified = B::Header>,
     C: HeaderBackend<B> + BlockchainEvents<B> + Send + Sync + 'static,
-    RB: RequestBlocks + 'static,
+    RB: RequestBlocks<B::Header>,
     Message: AlephNetworkMessage<B::Header>
         + std::fmt::Debug
         + Send
@@ -307,11 +307,12 @@ where
                 _ => continue,
             };
 
-            let block = proposal.top_block();
-            if !self.chain_info_provider.is_block_imported(&block) {
-                debug!(target: "aleph-data-store", "Requesting a block {:?} after it has been missing for {:?} secs.", block, time_waiting.as_secs());
-                if let Err(e) = self.block_requester.request_block(block.clone()) {
-                    warn!(target: "aleph-data-store", "Error requesting block {:?}, {}.", block, e);
+            let header = proposal.top_block_header();
+            let block_id = proposal.top_block();
+            if !self.chain_info_provider.is_block_imported(&block_id) {
+                debug!(target: "aleph-data-store", "Requesting a block {:?} after it has been missing for {:?} secs.", block_id, time_waiting.as_secs());
+                if let Err(e) = self.block_requester.request_block(header) {
+                    warn!(target: "aleph-data-store", "Error requesting block {:?}, {}.", block_id, e);
                 }
                 continue;
             }
@@ -667,7 +668,7 @@ where
     B: BlockT<Hash = BlockHash>,
     B::Header: HeaderT<Number = BlockNumber> + UnverifiedHeader + Header<Unverified = B::Header>,
     C: HeaderBackend<B> + BlockchainEvents<B> + Send + Sync + 'static,
-    RB: RequestBlocks + 'static,
+    RB: RequestBlocks<B::Header>,
     Message: AlephNetworkMessage<B::Header>
         + std::fmt::Debug
         + Send

--- a/finality-aleph/src/data_io/legacy/data_store.rs
+++ b/finality-aleph/src/data_io/legacy/data_store.rs
@@ -35,7 +35,7 @@ use crate::{
         Network as DataNetwork,
     },
     party::manager::Runnable,
-    sync::RequestBlocks,
+    sync::LegacyRequestBlocks,
     BlockId, SessionBoundaries,
 };
 
@@ -152,7 +152,7 @@ where
     B: BlockT<Hash = BlockHash>,
     B::Header: HeaderT<Number = BlockNumber>,
     C: HeaderBackend<B> + BlockchainEvents<B> + Send + Sync + 'static,
-    RB: RequestBlocks + 'static,
+    RB: LegacyRequestBlocks,
     Message: AlephNetworkMessage
         + std::fmt::Debug
         + Send
@@ -185,7 +185,7 @@ where
     B: BlockT<Hash = BlockHash>,
     B::Header: HeaderT<Number = BlockNumber>,
     C: HeaderBackend<B> + BlockchainEvents<B> + Send + Sync + 'static,
-    RB: RequestBlocks + 'static,
+    RB: LegacyRequestBlocks,
     Message: AlephNetworkMessage
         + std::fmt::Debug
         + Send
@@ -642,7 +642,7 @@ where
     B: BlockT<Hash = BlockHash>,
     B::Header: HeaderT<Number = BlockNumber>,
     C: HeaderBackend<B> + BlockchainEvents<B> + Send + Sync + 'static,
-    RB: RequestBlocks + 'static,
+    RB: LegacyRequestBlocks,
     Message: AlephNetworkMessage
         + std::fmt::Debug
         + Send

--- a/finality-aleph/src/party/manager/mod.rs
+++ b/finality-aleph/src/party/manager/mod.rs
@@ -54,7 +54,7 @@ pub use task::{Handle, Runnable, Task, TaskCommon};
 
 use crate::{
     abft::{CURRENT_VERSION, LEGACY_VERSION},
-    sync::RequestBlocks,
+    sync::{LegacyRequestBlocks, RequestBlocks},
 };
 
 #[cfg(feature = "only_legacy")]
@@ -102,7 +102,7 @@ where
     C: crate::ClientForAleph<B, BE> + Send + Sync + 'static,
     BE: Backend<B> + 'static,
     SC: SelectChain<B> + 'static,
-    RB: RequestBlocks,
+    RB: RequestBlocks<B::Header> + LegacyRequestBlocks,
     SM: SessionManager<VersionedNetworkData<B::Header>> + 'static,
     JS: JustificationSubmissions<Justification> + Send + Sync + Clone,
     V: HeaderVerifier<B::Header>,
@@ -130,7 +130,7 @@ where
     C::Api: crate::aleph_primitives::AlephSessionApi<B>,
     BE: Backend<B> + 'static,
     SC: SelectChain<B> + 'static,
-    RB: RequestBlocks,
+    RB: RequestBlocks<B::Header> + LegacyRequestBlocks,
     SM: SessionManager<VersionedNetworkData<B::Header>>,
     JS: JustificationSubmissions<Justification> + Send + Sync + Clone + 'static,
     V: HeaderVerifier<B::Header>,
@@ -426,7 +426,7 @@ where
     C::Api: crate::aleph_primitives::AlephSessionApi<B>,
     BE: Backend<B> + 'static,
     SC: SelectChain<B> + 'static,
-    RB: RequestBlocks,
+    RB: RequestBlocks<B::Header> + LegacyRequestBlocks,
     SM: SessionManager<VersionedNetworkData<B::Header>>,
     JS: JustificationSubmissions<Justification> + Send + Sync + Clone + 'static,
     V: HeaderVerifier<B::Header>,

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -8,13 +8,13 @@ use std::{
 
 use crate::{
     block::{
-        Block, BlockImport, BlockStatus, ChainStatus, Finalizer, Header, HeaderVerifier,
-        Justification, JustificationVerifier, UnverifiedHeader, UnverifiedHeaderFor,
-        UnverifiedJustification, VerifiedHeader,
+        Block, BlockImport, ChainStatus, Finalizer, Header, HeaderVerifier, Justification,
+        JustificationVerifier, UnverifiedHeader, UnverifiedHeaderFor, UnverifiedJustification,
+        VerifiedHeader,
     },
     session::{SessionBoundaryInfo, SessionId},
     sync::{
-        data::{BranchKnowledge, NetworkData, Request, State},
+        data::{BranchKnowledge, MaybeHeader, NetworkData, Request, State},
         forest::{
             Error as ForestError, ExtensionRequest, Forest,
             InitializationError as ForestInitializationError, Interest,
@@ -77,7 +77,7 @@ where
     I: PeerId,
     J: Justification,
 {
-    pub fn get(&self, id: &BlockId) -> Interest<I> {
+    pub fn get(&self, id: &BlockId) -> Interest<UnverifiedHeaderFor<J>, I> {
         self.forest.request_interest(id)
     }
 }
@@ -240,6 +240,14 @@ type HandleOwnBlockOutput<B, J, V> = (
     Vec<ResponseItem<B, J>>,
     Option<<V as HeaderVerifier<<J as Justification>::Header>>::EquivocationProof>,
 );
+type HandleRequestOutput<B, J, V> = (
+    Action<B, J>,
+    Option<<V as HeaderVerifier<<J as Justification>::Header>>::EquivocationProof>,
+);
+type HandleInternalRequestOutput<J, V> = (
+    bool,
+    Option<<V as HeaderVerifier<<J as Justification>::Header>>::EquivocationProof>,
+);
 
 impl<B, J> HandleStateAction<B, J>
 where
@@ -281,7 +289,6 @@ where
     MissingJustification,
     BlockNotImportable,
     HeaderNotRequired,
-    MissingFavouriteBlock,
 }
 
 impl<B, J, CS, V, F> Display for Error<B, J, CS, V, F>
@@ -310,9 +317,6 @@ where
                 write!(f, "cannot import a block that we do not consider required")
             }
             HeaderNotRequired => write!(f, "header was not required, but it should have been"),
-            MissingFavouriteBlock => {
-                write!(f, "the favourite block is not present in the database")
-            }
         }
     }
 }
@@ -509,16 +513,30 @@ where
     pub fn handle_request(
         &mut self,
         request: Request<J>,
-    ) -> Result<Action<B, J>, <Self as HandlerTypes>::Error> {
+    ) -> Result<HandleRequestOutput<B, J, V>, <Self as HandlerTypes>::Error> {
         let request_handler = RequestHandler::new(&self.chain_status, &self.session_info);
+        let mut equivocation_proof = None;
 
         Ok(match request_handler.action(request)? {
-            Action::RequestBlock(id)
-                if !self.forest.update_block_identifier(&id, None, true)? =>
+            Action::RequestBlock(maybe_header)
+                if match &maybe_header {
+                    MaybeHeader::Header(header) => {
+                        let VerifiedHeader {
+                            header,
+                            maybe_equivocation_proof,
+                        } = self
+                            .verifier
+                            .verify_header(header.clone(), false)
+                            .map_err(Error::HeaderVerifier)?;
+                        equivocation_proof = maybe_equivocation_proof;
+                        !self.forest.update_header(&header, None, true)?
+                    }
+                    MaybeHeader::Id(id) => !self.forest.update_block_identifier(id, None, true)?,
+                } =>
             {
-                Action::Noop
+                (Action::Noop, equivocation_proof)
             }
-            action => action,
+            action => (action, equivocation_proof),
         })
     }
 
@@ -533,24 +551,25 @@ where
         state: State<J>,
     ) -> Result<Action<B, J>, <Self as HandlerTypes>::Error> {
         let request = Request::new(
-            self.forest.favourite_block(),
+            MaybeHeader::Header(self.forest.favourite_block().into_unverified()),
             BranchKnowledge::TopImported(state.favourite_block().id()),
             state.clone(),
         );
+        // No need to check for equivocations, as this is a header we already checked.
         match self.handle_request(request) {
             // Either we were trying to send too far in the future
             // or our favourite is not a descendant of theirs.
             // Either way, at least try sending some justifications.
-            Ok(Action::Noop)
+            Ok((Action::Noop, _))
             | Err(Error::RequestHandlerError(RequestHandlerError::RootMismatch)) => {
                 let request = Request::new(
-                    state.top_justification().header().id(),
+                    MaybeHeader::Header(state.top_justification().header().clone()),
                     BranchKnowledge::TopImported(state.top_justification().header().id()),
                     state,
                 );
-                self.handle_request(request)
+                self.handle_request(request).map(|(action, _)| action)
             }
-            result => result,
+            result => result.map(|(action, _)| action),
         }
     }
 
@@ -773,21 +792,12 @@ where
 
     /// The current state of our database.
     pub fn state(&self) -> Result<State<J>, <Self as HandlerTypes>::Error> {
-        use BlockStatus::*;
         let top_justification = self
             .chain_status
             .top_finalized()
             .map_err(Error::ChainStatus)?
             .into_unverified();
-        let favourite_block = match self
-            .chain_status
-            .status_of(self.forest.favourite_block())
-            .map_err(Error::ChainStatus)?
-        {
-            Justified(justification) => justification.header().clone().into_unverified(),
-            Present(header) => header.into_unverified(),
-            Unknown => return Err(Error::MissingFavouriteBlock),
-        };
+        let favourite_block = self.forest.favourite_block().into_unverified();
         Ok(State::new(top_justification, favourite_block))
     }
 
@@ -800,7 +810,8 @@ where
 
     /// Handle an internal block request.
     /// Returns `true` if this was the first time something indicated interest in this block.
-    pub fn handle_internal_request(
+    // TODO(A0-3494): Only needed for compatibility.
+    pub fn handle_legacy_internal_request(
         &mut self,
         id: &BlockId,
     ) -> Result<bool, <Self as HandlerTypes>::Error> {
@@ -809,8 +820,26 @@ where
         Ok(should_request)
     }
 
+    /// Handle an internal block request.
+    /// Returns `true` if this was the first time something indicated interest in this block.
+    pub fn handle_internal_request(
+        &mut self,
+        header: B::UnverifiedHeader,
+    ) -> Result<HandleInternalRequestOutput<J, V>, <Self as HandlerTypes>::Error> {
+        let VerifiedHeader {
+            header,
+            maybe_equivocation_proof,
+        } = self
+            .verifier
+            .verify_header(header, false)
+            .map_err(Error::HeaderVerifier)?;
+        let should_request = self.forest.update_header(&header, None, true)?;
+
+        Ok((should_request, maybe_equivocation_proof))
+    }
+
     /// Returns the extension request we could be making right now.
-    pub fn extension_request(&self) -> ExtensionRequest<I> {
+    pub fn extension_request(&self) -> ExtensionRequest<J::Header, I> {
         self.forest.extension_request()
     }
 
@@ -838,7 +867,10 @@ mod tests {
         },
         session::{SessionBoundaryInfo, SessionId},
         sync::{
-            data::{BranchKnowledge::*, NetworkData, Request, ResponseItem, ResponseItems, State},
+            data::{
+                BranchKnowledge::*, MaybeHeader, NetworkData, Request, ResponseItem, ResponseItems,
+                State,
+            },
             forest::{ExtensionRequest, Interest},
             handler::Action,
             Justification, MockPeerId,
@@ -890,21 +922,26 @@ mod tests {
         handler: &TestHandler,
         top: &BlockId,
         bottom: &BlockId,
-        know_most: HashSet<MockPeerId>,
+        expected_know_most: HashSet<MockPeerId>,
     ) {
-        assert_eq!(
-            handler.interest_provider().get(bottom),
-            Interest::Uninterested,
+        assert!(
+            matches!(
+                handler.interest_provider().get(bottom),
+                Interest::Uninterested
+            ),
             "should not be interested in the bottom"
         );
-        assert_eq!(
-            handler.interest_provider().get(top),
+        match handler.interest_provider().get(top) {
             Interest::Required {
+                header: _,
                 know_most,
-                branch_knowledge: LowestId(bottom.clone()),
-            },
-            "should require the top"
-        );
+                branch_knowledge,
+            } => {
+                assert_eq!(branch_knowledge, LowestId(bottom.clone()));
+                assert_eq!(know_most, expected_know_most);
+            }
+            interest => panic!("expected top to be required, got {:?}", interest),
+        }
     }
 
     fn grow_light_branch_till(
@@ -924,20 +961,27 @@ mod tests {
         peer_id: MockPeerId,
     ) -> Vec<MockHeader> {
         let branch: Vec<_> = bottom.random_branch().take(length).collect();
-        let top = branch.last().expect("branch should not be empty").id();
+        let top = branch.last().expect("branch should not be empty");
 
-        assert!(
-            handler.handle_internal_request(&top).expect("should work"),
-            "should be newly required"
-        );
-        assert_eq!(
-            handler.interest_provider().get(&top),
+        let (newly_required, equivocation) = handler
+            .handle_internal_request(top.clone())
+            .expect("should work");
+        assert!(equivocation.is_none());
+        assert!(newly_required, "should be newly required");
+        match handler.interest_provider().get(&top.id()) {
             Interest::Required {
-                know_most: HashSet::new(),
-                branch_knowledge: LowestId(top.clone()),
-            },
-            "should be required"
-        );
+                header: _,
+                know_most,
+                branch_knowledge,
+            } => {
+                assert_eq!(
+                    branch_knowledge,
+                    LowestId(top.parent_id().expect("there was a header"))
+                );
+                assert!(know_most.is_empty());
+            }
+            interest => panic!("expected top to be required, got {:?}", interest),
+        }
 
         let (new_highest_justified, _, maybe_error) = handler.handle_request_response(
             branch
@@ -1412,7 +1456,10 @@ mod tests {
 
         // check that still not finalized
         assert!(
-            handler.interest_provider().get(&top) != Interest::Uninterested,
+            !matches!(
+                handler.interest_provider().get(&top),
+                Interest::Uninterested
+            ),
             "should still be interested"
         );
 
@@ -1422,9 +1469,11 @@ mod tests {
         }
 
         // check if dangling branch was pruned
-        assert_eq!(
-            handler.interest_provider().get(&top),
-            Interest::Uninterested,
+        assert!(
+            matches!(
+                handler.interest_provider().get(&top),
+                Interest::Uninterested
+            ),
             "should be uninterested"
         );
     }
@@ -1466,14 +1515,17 @@ mod tests {
         }
 
         // check that the fork is still interesting
-        assert_eq!(
-            handler.interest_provider().get(&fork_top),
+        match handler.interest_provider().get(&fork_top) {
             Interest::Required {
-                know_most: HashSet::from_iter(vec![fork_peer]),
-                branch_knowledge: LowestId(fork_child.id()),
-            },
-            "should be required"
-        );
+                header: _,
+                know_most,
+                branch_knowledge,
+            } => {
+                assert_eq!(branch_knowledge, LowestId(fork_child.id()));
+                assert_eq!(know_most, HashSet::from_iter(vec![fork_peer]));
+            }
+            interest => panic!("expected fork top to be required, got {:?}", interest),
+        }
 
         // import fork_child that connects the fork to fork_bottom,
         // which is at the same height as an already finalized block
@@ -1493,9 +1545,11 @@ mod tests {
         }
 
         // check that the fork is pruned
-        assert_eq!(
-            handler.interest_provider().get(&fork_top),
-            Interest::Uninterested,
+        assert!(
+            matches!(
+                handler.interest_provider().get(&fork_top),
+                Interest::Uninterested
+            ),
             "should be uninterested"
         );
     }
@@ -1541,21 +1595,26 @@ mod tests {
         }
 
         // check if the bottom part of the fork was pruned
-        assert_eq!(
-            handler.interest_provider().get(&further_fork_bottom),
-            Interest::Uninterested,
+        assert!(
+            matches!(
+                handler.interest_provider().get(&further_fork_bottom),
+                Interest::Uninterested
+            ),
             "should be uninterested"
         );
 
         // check that the fork is still interesting
-        assert_eq!(
-            handler.interest_provider().get(&fork_top),
+        match handler.interest_provider().get(&fork_top) {
             Interest::Required {
-                know_most: HashSet::from_iter(vec![fork_peer]),
-                branch_knowledge: LowestId(further_fork_child.id()),
-            },
-            "should be required"
-        );
+                header: _,
+                know_most,
+                branch_knowledge,
+            } => {
+                assert_eq!(branch_knowledge, LowestId(further_fork_child.id()));
+                assert_eq!(know_most, HashSet::from_iter(vec![fork_peer]));
+            }
+            interest => panic!("expected fork top to be required, got {:?}", interest),
+        }
 
         // check that further_fork_child is higher than top finalized
         assert!(
@@ -1587,9 +1646,11 @@ mod tests {
         }
 
         // check that the fork is pruned
-        assert_eq!(
-            handler.interest_provider().get(&fork_top),
-            Interest::Uninterested,
+        assert!(
+            matches!(
+                handler.interest_provider().get(&fork_top),
+                Interest::Uninterested
+            ),
             "should be uninterested"
         );
     }
@@ -1631,23 +1692,23 @@ mod tests {
                 syncing_handler.handle_state_response(justification, maybe_justification, peer_id);
             assert!(maybe_error.is_none(), "should work");
             assert!(new_info, "should want to request");
-            let branch_knowledge = match syncing_handler.extension_request() {
+            let (header, branch_knowledge) = match syncing_handler.extension_request() {
                 ExtensionRequest::HighestJustified {
-                    id,
+                    header,
                     branch_knowledge,
                     ..
                 } => {
-                    assert_eq!(id, target_id, "should want to request target_id");
-                    branch_knowledge
+                    assert_eq!(header.id(), target_id, "should want to request target_id");
+                    (header, branch_knowledge)
                 }
                 _ => panic!("should want to extend"),
             };
             let state = syncing_handler.state().expect("should work");
-            let request = Request::new(target_id.clone(), branch_knowledge, state);
+            let request = Request::new(MaybeHeader::Header(header), branch_knowledge, state);
 
             // peer responds
             let response_items = match handler.handle_request(request).expect("should work") {
-                Action::Response(items) => items,
+                (Action::Response(items), None) => items,
                 _ => panic!("should prepare response"),
             };
 
@@ -2003,11 +2064,15 @@ mod tests {
 
         let (justifications, _) = setup_request_tests(&mut handler, &mut backend, 100, 100);
 
-        let requested_id = justifications.last().unwrap().header().id();
-        let request = Request::new(requested_id.clone(), LowestId(requested_id), initial_state);
+        let requested_header = justifications.last().unwrap().header();
+        let request = Request::new(
+            MaybeHeader::Header(requested_header.clone()),
+            LowestId(requested_header.id()),
+            initial_state,
+        );
 
         match handler.handle_request(request).expect("correct request") {
-            Action::Noop => {}
+            (Action::Noop, None) => {}
             other_action => panic!("expected a response with justifications, got {other_action:?}"),
         }
     }
@@ -2040,11 +2105,15 @@ mod tests {
 
         let (_, blocks) = setup_request_tests(&mut handler, &mut backend, 100, 20);
 
-        let requested_id = blocks[30].clone().id();
+        let requested_header = blocks[30].header().clone();
         let lowest_id = blocks[25].clone().id();
 
         // request block #31, with the last known header equal to block #26
-        let request = Request::new(requested_id, LowestId(lowest_id), initial_state);
+        let request = Request::new(
+            MaybeHeader::Header(requested_header),
+            LowestId(lowest_id),
+            initial_state,
+        );
 
         let expected_response_items = vec![
             J(1),
@@ -2106,7 +2175,7 @@ mod tests {
             B(31),
         ];
         match handler.handle_request(request).expect("correct request") {
-            Action::Response(response_items) => {
+            (Action::Response(response_items), None) => {
                 assert_eq!(
                     SimplifiedItem::from_response_items(response_items),
                     expected_response_items
@@ -2117,19 +2186,25 @@ mod tests {
     }
 
     #[test]
-    fn handles_request_with_unknown_id() {
+    fn handles_request_with_unknown_header() {
         let (mut handler, mut backend, _keep, _genesis) = setup();
         setup_request_tests(&mut handler, &mut backend, 100, 20);
 
         let header = MockHeader::random_parentless(105);
         let state = State::new(MockJustification::for_header(header.clone()), header);
-        let requested_id = BlockId::new_random(120);
+        let requested_header = BlockId::new_random(119).random_child();
         let lowest_id = BlockId::new_random(110);
 
-        let request = Request::new(requested_id.clone(), LowestId(lowest_id), state);
+        let request = Request::new(
+            MaybeHeader::Header(requested_header.clone()),
+            LowestId(lowest_id),
+            state,
+        );
 
         match handler.handle_request(request).expect("correct request") {
-            Action::RequestBlock(id) => assert_eq!(id, requested_id),
+            (Action::RequestBlock(MaybeHeader::Header(header)), None) => {
+                assert_eq!(header, requested_header)
+            }
             other_action => panic!("expected a response with justifications, got {other_action:?}"),
         }
     }
@@ -2142,11 +2217,15 @@ mod tests {
 
         let (_, blocks) = setup_request_tests(&mut handler, &mut backend, 100, 20);
 
-        let requested_id = blocks[30].clone().id();
+        let requested_header = blocks[30].header().clone();
         let top_imported = blocks[25].clone().id();
 
         // request block #31, with the top imported block equal to block #26
-        let request = Request::new(requested_id, TopImported(top_imported), initial_state);
+        let request = Request::new(
+            MaybeHeader::Header(requested_header),
+            TopImported(top_imported),
+            initial_state,
+        );
 
         let expected_response_items = vec![
             J(1),
@@ -2167,7 +2246,7 @@ mod tests {
         ];
 
         match handler.handle_request(request).expect("correct request") {
-            Action::Response(response_items) => {
+            (Action::Response(response_items), None) => {
                 assert_eq!(
                     SimplifiedItem::from_response_items(response_items),
                     expected_response_items
@@ -2434,8 +2513,18 @@ mod tests {
         let _ = handler.state().expect("state works");
         let headers = import_branch(&mut backend, 2);
 
-        assert!(handler.handle_internal_request(&headers[1].id()).unwrap());
-        assert!(!handler.handle_internal_request(&headers[1].id()).unwrap());
+        assert!(
+            handler
+                .handle_internal_request(headers[1].clone())
+                .unwrap()
+                .0
+        );
+        assert!(
+            !handler
+                .handle_internal_request(headers[1].clone())
+                .unwrap()
+                .0
+        );
     }
 
     #[test]

--- a/finality-aleph/src/sync/mod.rs
+++ b/finality-aleph/src/sync/mod.rs
@@ -4,7 +4,10 @@ use std::{
     marker::Send,
 };
 
-use crate::{block::Justification, BlockId};
+use crate::{
+    block::{Justification, UnverifiedHeader},
+    BlockId,
+};
 
 mod data;
 mod forest;
@@ -39,7 +42,17 @@ pub trait JustificationSubmissions<J: Justification>: Clone + Send + 'static {
 
 /// An interface for requesting specific blocks from the block sync.
 /// Required by the data availability mechanism in ABFT.
-pub trait RequestBlocks: Clone + Send + Sync + 'static {
+pub trait RequestBlocks<UH: UnverifiedHeader>: Clone + Send + Sync + 'static {
+    type Error: Display;
+
+    /// Request the given block.
+    fn request_block(&self, header: UH) -> Result<(), Self::Error>;
+}
+
+/// An interface for requesting specific blocks from the block sync.
+/// Required by the data availability mechanism in ABFT.
+// TODO(A0-3494): Remove this after support for headerless proposals gets dropped.
+pub trait LegacyRequestBlocks: Clone + Send + Sync + 'static {
     type Error: Display;
 
     /// Request the given block.

--- a/finality-aleph/src/sync/service.rs
+++ b/finality-aleph/src/sync/service.rs
@@ -7,7 +7,7 @@ use substrate_prometheus_endpoint::Registry;
 use crate::{
     block::{
         Block, BlockImport, ChainStatus, ChainStatusNotification, ChainStatusNotifier,
-        EquivocationProof, Finalizer, HeaderVerifier, Justification, JustificationVerifier,
+        EquivocationProof, Finalizer, Header, HeaderVerifier, Justification, JustificationVerifier,
         UnverifiedHeader, UnverifiedHeaderFor,
     },
     network::GossipNetwork,
@@ -24,7 +24,7 @@ use crate::{
         task_queue::TaskQueue,
         tasks::{Action as TaskAction, RequestTask},
         ticker::Ticker,
-        BlockId, JustificationSubmissions, RequestBlocks, LOG_TARGET,
+        BlockId, JustificationSubmissions, LegacyRequestBlocks, RequestBlocks, LOG_TARGET,
     },
     SyncOracle,
 };
@@ -100,7 +100,8 @@ where
     chain_events: CE,
     justifications_from_user: mpsc::UnboundedReceiver<J::Unverified>,
     additional_justifications_from_user: mpsc::UnboundedReceiver<J::Unverified>,
-    block_requests_from_user: mpsc::UnboundedReceiver<BlockId>,
+    block_requests_from_user: mpsc::UnboundedReceiver<B::UnverifiedHeader>,
+    legacy_block_requests_from_user: mpsc::UnboundedReceiver<BlockId>,
     blocks_from_creator: mpsc::UnboundedReceiver<B>,
     metrics: Metrics,
 }
@@ -113,11 +114,26 @@ impl<J: Justification> JustificationSubmissions<J> for mpsc::UnboundedSender<J::
     }
 }
 
-impl RequestBlocks for mpsc::UnboundedSender<BlockId> {
+// TODO(A0-3494): This will be unnecessary, just impl the trait for the sender.
+#[derive(Clone)]
+struct CompatibilityRequestBlocks<UH: UnverifiedHeader> {
+    current: mpsc::UnboundedSender<UH>,
+    legacy: mpsc::UnboundedSender<BlockId>,
+}
+
+impl<UH: UnverifiedHeader> LegacyRequestBlocks for CompatibilityRequestBlocks<UH> {
     type Error = mpsc::TrySendError<BlockId>;
 
     fn request_block(&self, block_id: BlockId) -> Result<(), Self::Error> {
-        self.unbounded_send(block_id)
+        self.legacy.unbounded_send(block_id)
+    }
+}
+
+impl<UH: UnverifiedHeader> RequestBlocks<UH> for CompatibilityRequestBlocks<UH> {
+    type Error = mpsc::TrySendError<UH>;
+
+    fn request_block(&self, header: UH) -> Result<(), Self::Error> {
+        self.current.unbounded_send(header)
     }
 }
 
@@ -144,7 +160,7 @@ where
         (
             Self,
             impl JustificationSubmissions<J> + Clone,
-            impl RequestBlocks,
+            impl RequestBlocks<B::UnverifiedHeader> + LegacyRequestBlocks,
         ),
         HandlerError<B, J, CS, V, F>,
     > {
@@ -163,6 +179,7 @@ where
         let chain_extension_ticker = Ticker::new(TICK_PERIOD, CHAIN_EXTENSION_COOLDOWN);
         let (justifications_for_sync, justifications_from_user) = mpsc::unbounded();
         let (block_requests_for_sync, block_requests_from_user) = mpsc::unbounded();
+        let (legacy_block_requests_for_sync, legacy_block_requests_from_user) = mpsc::unbounded();
         let metrics = match Metrics::new(metrics_registry) {
             Ok(metrics) => metrics,
             Err(e) => {
@@ -183,10 +200,14 @@ where
                 additional_justifications_from_user,
                 blocks_from_creator,
                 block_requests_from_user,
+                legacy_block_requests_from_user,
                 metrics,
             },
             justifications_for_sync,
-            block_requests_for_sync,
+            CompatibilityRequestBlocks {
+                current: block_requests_for_sync,
+                legacy: legacy_block_requests_for_sync,
+            },
         ))
     }
 
@@ -252,11 +273,15 @@ where
         match self.handler.extension_request() {
             FavouriteBlock { know_most } => self.request_favourite_extension(know_most),
             HighestJustified {
-                id,
+                header,
                 know_most,
                 branch_knowledge,
             } => {
-                self.send_request(PreRequest::new(id, branch_knowledge, know_most));
+                self.send_request(PreRequest::new(
+                    header.into_unverified(),
+                    branch_knowledge,
+                    know_most,
+                ));
                 self.chain_extension_ticker.reset();
             }
             Noop => {
@@ -273,7 +298,7 @@ where
         }
     }
 
-    fn send_request(&mut self, pre_request: PreRequest<N::PeerId>) {
+    fn send_request(&mut self, pre_request: PreRequest<UnverifiedHeaderFor<J>, N::PeerId>) {
         self.metrics.report_event(Event::SendRequest);
         let state = match self.handler.state() {
             Ok(state) => state,
@@ -310,7 +335,7 @@ where
         }
     }
 
-    fn process_equivocation_proofs(&self, proofs: Vec<V::EquivocationProof>) {
+    fn process_equivocation_proofs<I: IntoIterator<Item = V::EquivocationProof>>(&self, proofs: I) {
         for proof in proofs {
             warn!(target: LOG_TARGET, "Equivocation detected: {proof}");
             if proof.are_we_equivocating() {
@@ -330,7 +355,7 @@ where
         );
         match self.handler.handle_state(state, peer.clone()) {
             Ok((action, maybe_proof)) => {
-                self.process_equivocation_proofs(maybe_proof.into_iter().collect());
+                self.process_equivocation_proofs(maybe_proof);
                 match action {
                     Response(data) => self.send_to(data, peer),
                     ExtendChain => self.try_request_chain_extension(),
@@ -484,16 +509,22 @@ where
         self.metrics.report_event(Event::HandleRequest);
 
         match self.handler.handle_request(request) {
-            Ok(Action::Response(response_items)) => {
-                if let Err(e) = self.send_big_response(&response_items, peer) {
-                    error!(
-                        target: LOG_TARGET,
-                        "Error while sending request response: {}.", e
-                    );
-                    self.metrics.report_event_error(Event::HandleRequest);
+            Ok((action, maybe_equivocation_proof)) => {
+                self.process_equivocation_proofs(maybe_equivocation_proof);
+                match action {
+                    Action::Response(response_items) => {
+                        if let Err(e) = self.send_big_response(&response_items, peer) {
+                            error!(
+                                target: LOG_TARGET,
+                                "Error while sending request response: {}.", e
+                            );
+                            self.metrics.report_event_error(Event::HandleRequest);
+                        }
+                    }
+                    Action::RequestBlock(header) => self.request_block(header.id()),
+                    _ => {}
                 }
             }
-            Ok(Action::RequestBlock(id)) => self.request_block(id),
             Err(e) => {
                 self.metrics.report_event_error(Event::HandleRequest);
                 match e {
@@ -511,7 +542,6 @@ where
                     ),
                 }
             }
-            _ => {}
         }
     }
 
@@ -553,25 +583,24 @@ where
         }
     }
 
-    fn handle_internal_request(&mut self, id: BlockId) {
+    fn handle_internal_request(&mut self, header: B::UnverifiedHeader) {
+        let id = header.id();
         trace!(
             target: LOG_TARGET,
             "Handling an internal request for block {:?}.",
             id,
         );
         self.metrics.report_event(Event::HandleInternalRequest);
-        match self.handler.handle_internal_request(&id) {
-            Ok(true) => self.request_block(id),
-
-            Ok(_) => debug!(target: LOG_TARGET, "Already requested block {:?}.", id),
-
+        match self.handler.handle_internal_request(header) {
+            Ok((request, maybe_equivocation)) => {
+                if request {
+                    self.request_block(id);
+                }
+                self.process_equivocation_proofs(maybe_equivocation);
+            }
             Err(e) => {
                 self.metrics.report_event(Event::HandleInternalRequest);
                 match e {
-                    HandlerError::JustificationVerifier(e) => debug!(
-                        target: LOG_TARGET,
-                        "Could not verify justification from user: {}", e
-                    ),
                     HandlerError::HeaderVerifier(e) => debug!(
                         target: LOG_TARGET,
                         "Could not verify header from user: {}", e
@@ -581,6 +610,28 @@ where
                         "Error handling internal request for block {:?}: {}.", id, e
                     ),
                 }
+            }
+        }
+    }
+
+    fn handle_legacy_internal_request(&mut self, id: BlockId) {
+        trace!(
+            target: LOG_TARGET,
+            "Handling a legacy internal request for block {:?}.",
+            id,
+        );
+        self.metrics.report_event(Event::HandleInternalRequest);
+        match self.handler.handle_legacy_internal_request(&id) {
+            Ok(true) => self.request_block(id),
+
+            Ok(_) => debug!(target: LOG_TARGET, "Already requested block {:?}.", id),
+
+            Err(e) => {
+                self.metrics.report_event(Event::HandleInternalRequest);
+                warn!(
+                    target: LOG_TARGET,
+                    "Error handling legacy internal request for block {:?}: {}.", id, e
+                )
             }
         }
     }
@@ -598,7 +649,7 @@ where
                         .report_event_error(Event::HandleExtensionRequest);
                 }
             }
-            Ok(Action::RequestBlock(id)) => self.request_block(id),
+            Ok(Action::RequestBlock(header)) => self.request_block(header.id()),
             Ok(Action::Noop) => {}
             Err(e) => {
                 self.metrics
@@ -641,7 +692,7 @@ where
     fn handle_own_block(&mut self, block: B) {
         match self.handler.handle_own_block(block) {
             Ok((broadcast, maybe_proof)) => {
-                self.process_equivocation_proofs(maybe_proof.into_iter().collect());
+                self.process_equivocation_proofs(maybe_proof);
                 if let Err(e) = self
                     .network
                     .broadcast(NetworkData::RequestResponse(broadcast))
@@ -690,12 +741,19 @@ where
                     },
                     None => warn!(target: LOG_TARGET, "Channel with additional justifications from user closed."),
                 },
-                maybe_block_id = self.block_requests_from_user.next() => match maybe_block_id {
-                    Some(block_id) => {
-                        debug!(target: LOG_TARGET, "Received new internal block request from user: {:?}.", block_id);
-                        self.handle_internal_request(block_id)
+                maybe_header = self.block_requests_from_user.next() => match maybe_header {
+                    Some(header) => {
+                        debug!(target: LOG_TARGET, "Received new internal block request from user: {:?}.", header);
+                        self.handle_internal_request(header)
                     },
                     None => warn!(target: LOG_TARGET, "Channel with internal block request from user closed."),
+                },
+                maybe_block_id = self.legacy_block_requests_from_user.next() => match maybe_block_id {
+                    Some(block_id) => {
+                        debug!(target: LOG_TARGET, "Received new internal block request from user: {:?}.", block_id);
+                        self.handle_legacy_internal_request(block_id)
+                    },
+                    None => warn!(target: LOG_TARGET, "Channel with legacy internal block request from user closed."),
                 },
                 maybe_own_block = self.blocks_from_creator.next() => match maybe_own_block {
                     Some(block) => {

--- a/finality-aleph/src/testing/data_store.rs
+++ b/finality-aleph/src/testing/data_store.rs
@@ -13,6 +13,7 @@ use tokio::time::timeout;
 
 use crate::{
     aleph_primitives::BlockNumber,
+    block::Header as _,
     data_io::{AlephData, AlephNetworkMessage, DataStore, DataStoreConfig, MAX_DATA_BRANCH_LEN},
     network::{
         data::{component::Network as ComponentNetwork, Network as DataNetwork},
@@ -42,10 +43,10 @@ impl TestBlockRequester {
     }
 }
 
-impl RequestBlocks for TestBlockRequester {
+impl RequestBlocks<THeader> for TestBlockRequester {
     type Error = TrySendError<BlockId>;
-    fn request_block(&self, block_id: BlockId) -> Result<(), Self::Error> {
-        self.blocks.unbounded_send(block_id)
+    fn request_block(&self, header: THeader) -> Result<(), Self::Error> {
+        self.blocks.unbounded_send(header.id())
     }
 }
 


### PR DESCRIPTION
# Description

Introduce verifiable requests. For backwards compatibility reasons they cannot be fully enforced yet, that will require a separate update.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have added tests
- I have made corresponding changes to the existing documentation
- I have created new documentation
