### PR TITLE
A0-3520: Run deploy to devnet daily at Midnight

### DIFF
--- a/.github/workflows/deploy-to-devnet.yml
+++ b/.github/workflows/deploy-to-devnet.yml
@@ -9,6 +9,8 @@ name: Deploy to Devnet
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '00 00 * * *'
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}


### PR DESCRIPTION
# Description

We should run deploy-to-devnet.yml workflow in aleph-node as frequently as possible, but not on every commit to main so as to have at least a few hours of this environment stability. The reason we want this is that some devs use dev.azero.dev which has Devnet as the default chain connected to, so humans can spot some errors before the release with more probability. 

Remark: Devnet will be deprecated in 2024 when features are rolled out, yet behavior would be similiar: there would be a long running feturenet updated every 24 hours from aleph-node main etc; till now then I'll change Devnet to be deployed every night from aleph-node main

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
