### PR TITLE
A0-3550: Better constants for libp2p message sizes

### DIFF
--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -34,8 +34,9 @@ use crate::{
     aggregation::{CurrentRmcNetworkData, LegacyRmcNetworkData},
     block::UnverifiedHeader,
     compatibility::{Version, Versioned},
-    network::data::split::Split,
+    network::{data::split::Split, session::MAX_MESSAGE_SIZE as MAX_AUTHENTICATION_MESSAGE_SIZE},
     session::{SessionBoundaries, SessionBoundaryInfo, SessionId},
+    sync::MAX_MESSAGE_SIZE as MAX_BLOCK_SYNC_MESSAGE_SIZE,
     VersionedTryFromError::{ExpectedNewGotOld, ExpectedOldGotNew},
 };
 
@@ -81,6 +82,13 @@ pub use crate::{
 /// Constant defining how often components of finality-aleph should report their state
 const STATUS_REPORT_INTERVAL: Duration = Duration::from_secs(20);
 
+fn max_message_size(protocol: Protocol) -> u64 {
+    match protocol {
+        Protocol::Authentication => MAX_AUTHENTICATION_MESSAGE_SIZE,
+        Protocol::BlockSync => MAX_BLOCK_SYNC_MESSAGE_SIZE,
+    }
+}
+
 /// Returns a NonDefaultSetConfig for the specified protocol.
 pub fn peers_set_config(
     naming: ProtocolNaming,
@@ -88,11 +96,7 @@ pub fn peers_set_config(
 ) -> sc_network::config::NonDefaultSetConfig {
     let mut config = sc_network::config::NonDefaultSetConfig::new(
         naming.protocol_name(&protocol),
-        // max_notification_size should be larger than the maximum possible honest message size (in bytes).
-        // Max size of alert is UNIT_SIZE * MAX_UNITS_IN_ALERT ~ 100 * 5000 = 50000 bytes
-        // Max size of parents response UNIT_SIZE * N_MEMBERS ~ 100 * N_MEMBERS
-        // When adding other (large) message types we need to make sure this limit is fine.
-        1024 * 1024,
+        max_message_size(protocol),
     );
 
     config.set_config = sc_network::config::SetConfig::default();

--- a/finality-aleph/src/network/session/mod.rs
+++ b/finality-aleph/src/network/session/mod.rs
@@ -34,6 +34,12 @@ pub use handler::tests::authentication;
 pub use handler::{Handler as SessionHandler, HandlerError as SessionHandlerError};
 pub use service::{Config as ConnectionManagerConfig, ManagerError, Service as ConnectionManager};
 
+/// The maximum size an authentication can have and be accepted.
+/// This leaves a generous margin of error, as the signature is 64 bytes,
+/// the public key of the peer is 32 bytes, a single IP/DNS address
+/// at most ~260 and no one should need more than a couple of these.
+pub const MAX_MESSAGE_SIZE: u64 = 1024 * 1024;
+
 /// Data validators use to authenticate themselves for a single session
 /// and disseminate their addresses.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Encode, Decode)]

--- a/finality-aleph/src/network/substrate.rs
+++ b/finality-aleph/src/network/substrate.rs
@@ -22,10 +22,6 @@ use crate::network::gossip::{Event, EventStream, NetworkSender, Protocol, RawNet
 /// authentications.
 const AUTHENTICATION_PROTOCOL_NAME: &str = "/auth/0";
 
-/// Legacy name of the network protocol used by Aleph Zero to disseminate validator
-/// authentications. Might be removed after some updates.
-const LEGACY_AUTHENTICATION_PROTOCOL_NAME: &str = "/aleph/1";
-
 /// Name of the network protocol used by Aleph Zero to synchronize the block state.
 const BLOCK_SYNC_PROTOCOL_NAME: &str = "/sync/0";
 
@@ -33,7 +29,6 @@ const BLOCK_SYNC_PROTOCOL_NAME: &str = "/sync/0";
 #[derive(Clone)]
 pub struct ProtocolNaming {
     authentication_name: ProtocolName,
-    authentication_fallback_names: Vec<ProtocolName>,
     block_sync_name: ProtocolName,
     protocols_by_name: HashMap<ProtocolName, Protocol>,
 }
@@ -45,17 +40,11 @@ impl ProtocolNaming {
             format!("{chain_prefix}{AUTHENTICATION_PROTOCOL_NAME}").into();
         let mut protocols_by_name = HashMap::new();
         protocols_by_name.insert(authentication_name.clone(), Protocol::Authentication);
-        let authentication_fallback_names: Vec<ProtocolName> =
-            vec![LEGACY_AUTHENTICATION_PROTOCOL_NAME.into()];
-        for protocol_name in &authentication_fallback_names {
-            protocols_by_name.insert(protocol_name.clone(), Protocol::Authentication);
-        }
         let block_sync_name: ProtocolName =
             format!("{chain_prefix}{BLOCK_SYNC_PROTOCOL_NAME}").into();
         protocols_by_name.insert(block_sync_name.clone(), Protocol::BlockSync);
         ProtocolNaming {
             authentication_name,
-            authentication_fallback_names,
             block_sync_name,
             protocols_by_name,
         }
@@ -71,12 +60,8 @@ impl ProtocolNaming {
     }
 
     /// Returns the fallback names of the protocol.
-    pub fn fallback_protocol_names(&self, protocol: &Protocol) -> Vec<ProtocolName> {
-        use Protocol::*;
-        match protocol {
-            Authentication => self.authentication_fallback_names.clone(),
-            _ => Vec::new(),
-        }
+    pub fn fallback_protocol_names(&self, _protocol: &Protocol) -> Vec<ProtocolName> {
+        Vec::new()
     }
 
     /// Attempts to convert the protocol name to a protocol.

--- a/finality-aleph/src/sync/data.rs
+++ b/finality-aleph/src/sync/data.rs
@@ -351,7 +351,7 @@ const_assert!(MAX_SYNC_MESSAGE_SIZE > 3 * MAX_BLOCK_SIZE);
 /// The toal maximal message size that should be accepted, slighly
 /// larger than the above to include the version plus some wiggle-room.
 pub const MAX_MESSAGE_SIZE: u64 = 16 * 1024 * 1024;
-const_assert!(MAX_MESSAGE_SIZE > MAX_SYNC_MESSAGE_SIZE + 128);
+const_assert!(MAX_MESSAGE_SIZE > MAX_SYNC_MESSAGE_SIZE as u64 + 128);
 
 fn encode_with_version(version: Version, payload: &[u8]) -> Vec<u8> {
     let size = payload.len().try_into().unwrap_or(ByteCount::MAX);

--- a/finality-aleph/src/sync/data.rs
+++ b/finality-aleph/src/sync/data.rs
@@ -351,6 +351,7 @@ const_assert!(MAX_SYNC_MESSAGE_SIZE > 3 * MAX_BLOCK_SIZE);
 /// The toal maximal message size that should be accepted, slighly
 /// larger than the above to include the version plus some wiggle-room.
 pub const MAX_MESSAGE_SIZE: u64 = 16 * 1024 * 1024;
+const_assert!(MAX_MESSAGE_SIZE > MAX_SYNC_MESSAGE_SIZE + 128);
 
 fn encode_with_version(version: Version, payload: &[u8]) -> Vec<u8> {
     let size = payload.len().try_into().unwrap_or(ByteCount::MAX);

--- a/finality-aleph/src/sync/data.rs
+++ b/finality-aleph/src/sync/data.rs
@@ -348,6 +348,9 @@ type ByteCount = u32;
 // Maximum block size is 5mb so we have spare for at least 3 blocks.
 pub const MAX_SYNC_MESSAGE_SIZE: u32 = 15 * 1024 * 1024 + 1024;
 const_assert!(MAX_SYNC_MESSAGE_SIZE > 3 * MAX_BLOCK_SIZE);
+/// The toal maximal message size that should be accepted, slighly
+/// larger than the above to include the version plus some wiggle-room.
+pub const MAX_MESSAGE_SIZE: u64 = 16 * 1024 * 1024;
 
 fn encode_with_version(version: Version, payload: &[u8]) -> Vec<u8> {
     let size = payload.len().try_into().unwrap_or(ByteCount::MAX);

--- a/finality-aleph/src/sync/mod.rs
+++ b/finality-aleph/src/sync/mod.rs
@@ -19,6 +19,7 @@ mod task_queue;
 mod tasks;
 mod ticker;
 
+pub use data::MAX_MESSAGE_SIZE;
 pub use handler::DatabaseIO;
 pub use service::{Service, IO};
 


### PR DESCRIPTION
# Description

Sync messages can be bigger, so increased the constant for them. Also moved some code around to lower the likelyhood of making this code in the future.

I also found some old compatibility code while going through this, so I removed in on the way, it's definitely not needed any more.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- I have made corresponding changes to the existing documentation
- I have created new documentation
