### PR TITLE
A0-3015: Introduce AllBlockMetrics wrapper

### DIFF
--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -7,10 +7,10 @@ use std::{
 
 use aleph_runtime::{self, opaque::Block, RuntimeApi};
 use finality_aleph::{
-    run_validator_node, AlephBlockImport, AlephConfig, BlockImporter, Justification,
-    JustificationTranslator, MillisecsPerBlock, Protocol, ProtocolNaming, RateLimiterConfig,
-    RedirectingBlockImport, SessionPeriod, SubstrateChainStatus, SyncOracle, TimingBlockMetrics,
-    TracingBlockImport, ValidatorAddressCache,
+    run_validator_node, AlephBlockImport, AlephConfig, AllBlockMetrics, BlockImporter,
+    DefaultClock, Justification, JustificationTranslator, MillisecsPerBlock, Protocol,
+    ProtocolNaming, RateLimiterConfig, RedirectingBlockImport, SessionPeriod, SubstrateChainStatus,
+    SyncOracle, TimingBlockMetrics, TracingBlockImport, ValidatorAddressCache,
 };
 use futures::channel::mpsc;
 use log::warn;
@@ -92,7 +92,7 @@ pub fn new_partial(
             mpsc::UnboundedSender<Justification>,
             mpsc::UnboundedReceiver<Justification>,
             Option<Telemetry>,
-            TimingBlockMetrics,
+            AllBlockMetrics,
         ),
     >,
     ServiceError,
@@ -136,13 +136,18 @@ pub fn new_partial(
         client.clone(),
     );
 
-    let metrics = match TimingBlockMetrics::new(config.prometheus_registry()) {
-        Ok(metrics) => metrics,
+    let timing_metrics = match TimingBlockMetrics::<DefaultClock>::new(config.prometheus_registry())
+    {
+        Ok(timing_metrics) => timing_metrics,
         Err(e) => {
-            warn!("Failed to register Prometheus metrics: {:?}.", e);
-            TimingBlockMetrics::noop()
+            warn!(
+                "Failed to register Prometheus block timing metrics: {:?}.",
+                e
+            );
+            TimingBlockMetrics::<DefaultClock>::noop()
         }
     };
+    let metrics = AllBlockMetrics::new(timing_metrics);
 
     let (justification_tx, justification_rx) = mpsc::unbounded();
     let tracing_block_import = TracingBlockImport::new(client.clone(), metrics.clone());

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -136,8 +136,7 @@ pub fn new_partial(
         client.clone(),
     );
 
-    let timing_metrics = match TimingBlockMetrics::new(config.prometheus_registry(), DefaultClock)
-    {
+    let timing_metrics = match TimingBlockMetrics::new(config.prometheus_registry(), DefaultClock) {
         Ok(timing_metrics) => timing_metrics,
         Err(e) => {
             warn!(

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -136,7 +136,7 @@ pub fn new_partial(
         client.clone(),
     );
 
-    let timing_metrics = match TimingBlockMetrics::<DefaultClock>::new(config.prometheus_registry())
+    let timing_metrics = match TimingBlockMetrics::new(config.prometheus_registry(), DefaultClock)
     {
         Ok(timing_metrics) => timing_metrics,
         Err(e) => {
@@ -144,7 +144,7 @@ pub fn new_partial(
                 "Failed to register Prometheus block timing metrics: {:?}.",
                 e
             );
-            TimingBlockMetrics::<DefaultClock>::noop()
+            TimingBlockMetrics::noop()
         }
     };
     let metrics = AllBlockMetrics::new(timing_metrics);

--- a/finality-aleph/src/data_io/data_provider.rs
+++ b/finality-aleph/src/data_io/data_provider.rs
@@ -355,7 +355,7 @@ mod tests {
             data_provider::{ChainTracker, ChainTrackerConfig},
             DataProvider, MAX_DATA_BRANCH_LEN,
         },
-        metrics::{AllBlockMetrics, DefaultClock},
+        metrics::AllBlockMetrics,
         testing::{
             client_chain_builder::ClientChainBuilder,
             mocks::{aleph_data_from_blocks, THeader, TestClientBuilder, TestClientBuilderExt},
@@ -391,7 +391,7 @@ mod tests {
             client,
             session_boundaries,
             config,
-            AllBlockMetrics::new(TimingBlockMetrics::<DefaultClock>::noop()),
+            AllBlockMetrics::new(TimingBlockMetrics::noop()),
         );
 
         let (exit_chain_tracker_tx, exit_chain_tracker_rx) = oneshot::channel();

--- a/finality-aleph/src/data_io/data_provider.rs
+++ b/finality-aleph/src/data_io/data_provider.rs
@@ -14,9 +14,9 @@ use crate::{
     aleph_primitives::{BlockHash, BlockNumber},
     block::UnverifiedHeader,
     data_io::{proposal::UnvalidatedAlephProposal, AlephData, MAX_DATA_BRANCH_LEN},
-    metrics::Checkpoint,
+    metrics::{AllBlockMetrics, Checkpoint},
     party::manager::Runnable,
-    BlockId, SessionBoundaries, TimingBlockMetrics,
+    BlockId, SessionBoundaries,
 };
 
 // Reduce block header to the level given by num, by traversing down via parents.
@@ -157,7 +157,7 @@ where
         client: Arc<C>,
         session_boundaries: SessionBoundaries,
         config: ChainTrackerConfig,
-        metrics: TimingBlockMetrics,
+        metrics: AllBlockMetrics,
     ) -> (Self, DataProvider<B::Header>) {
         let data_to_propose = Arc::new(Mutex::new(None));
         (
@@ -318,7 +318,7 @@ where
 #[derive(Clone)]
 pub struct DataProvider<UH: UnverifiedHeader> {
     data_to_propose: Arc<Mutex<Option<AlephData<UH>>>>,
-    metrics: TimingBlockMetrics,
+    metrics: AllBlockMetrics,
 }
 
 // Honest nodes propose data in session `k` as follows:
@@ -334,11 +334,8 @@ impl<UH: UnverifiedHeader> DataProvider<UH> {
         let data_to_propose = (*self.data_to_propose.lock()).take();
 
         if let Some(data) = &data_to_propose {
-            self.metrics.report_block_if_not_present(
-                data.head_proposal.top_block().hash(),
-                std::time::Instant::now(),
-                Checkpoint::Proposed,
-            );
+            self.metrics
+                .report_block(data.head_proposal.top_block().hash(), Checkpoint::Proposed);
             debug!(target: "aleph-data-store", "Outputting {:?} in get_data", data);
         };
 
@@ -358,6 +355,7 @@ mod tests {
             data_provider::{ChainTracker, ChainTrackerConfig},
             DataProvider, MAX_DATA_BRANCH_LEN,
         },
+        metrics::{AllBlockMetrics, DefaultClock},
         testing::{
             client_chain_builder::ClientChainBuilder,
             mocks::{aleph_data_from_blocks, THeader, TestClientBuilder, TestClientBuilderExt},
@@ -393,7 +391,7 @@ mod tests {
             client,
             session_boundaries,
             config,
-            TimingBlockMetrics::noop(),
+            AllBlockMetrics::new(TimingBlockMetrics::<DefaultClock>::noop()),
         );
 
         let (exit_chain_tracker_tx, exit_chain_tracker_rx) = oneshot::channel();

--- a/finality-aleph/src/data_io/legacy/data_provider.rs
+++ b/finality-aleph/src/data_io/legacy/data_provider.rs
@@ -349,7 +349,7 @@ mod tests {
             test::aleph_data_from_blocks,
             DataProvider, MAX_DATA_BRANCH_LEN,
         },
-        metrics::{AllBlockMetrics, DefaultClock},
+        metrics::AllBlockMetrics,
         testing::{
             client_chain_builder::ClientChainBuilder,
             mocks::{TestClientBuilder, TestClientBuilderExt},
@@ -385,7 +385,7 @@ mod tests {
             client,
             session_boundaries,
             config,
-            AllBlockMetrics::new(TimingBlockMetrics::<DefaultClock>::noop()),
+            AllBlockMetrics::new(TimingBlockMetrics::noop()),
         );
 
         let (exit_chain_tracker_tx, exit_chain_tracker_rx) = oneshot::channel();

--- a/finality-aleph/src/data_io/legacy/data_provider.rs
+++ b/finality-aleph/src/data_io/legacy/data_provider.rs
@@ -13,9 +13,9 @@ use sp_runtime::{
 use crate::{
     aleph_primitives::{BlockHash, BlockNumber},
     data_io::legacy::{proposal::UnvalidatedAlephProposal, AlephData, MAX_DATA_BRANCH_LEN},
-    metrics::Checkpoint,
+    metrics::{AllBlockMetrics, Checkpoint},
     party::manager::Runnable,
-    BlockId, SessionBoundaries, TimingBlockMetrics,
+    BlockId, SessionBoundaries,
 };
 
 // Reduce block header to the level given by num, by traversing down via parents.
@@ -143,7 +143,7 @@ where
         client: Arc<C>,
         session_boundaries: SessionBoundaries,
         config: ChainTrackerConfig,
-        metrics: TimingBlockMetrics,
+        metrics: AllBlockMetrics,
     ) -> (Self, DataProvider) {
         let data_to_propose = Arc::new(Mutex::new(None));
         (
@@ -309,7 +309,7 @@ where
 #[derive(Clone)]
 pub struct DataProvider {
     data_to_propose: Arc<Mutex<Option<AlephData>>>,
-    metrics: TimingBlockMetrics,
+    metrics: AllBlockMetrics,
 }
 
 // Honest nodes propose data in session `k` as follows:
@@ -325,9 +325,8 @@ impl DataProvider {
         let data_to_propose = (*self.data_to_propose.lock()).take();
 
         if let Some(data) = &data_to_propose {
-            self.metrics.report_block_if_not_present(
+            self.metrics.report_block(
                 *data.head_proposal.branch.last().unwrap(),
-                std::time::Instant::now(),
                 Checkpoint::Proposed,
             );
             debug!(target: "aleph-data-store", "Outputting {:?} in get_data", data);
@@ -350,6 +349,7 @@ mod tests {
             test::aleph_data_from_blocks,
             DataProvider, MAX_DATA_BRANCH_LEN,
         },
+        metrics::{AllBlockMetrics, DefaultClock},
         testing::{
             client_chain_builder::ClientChainBuilder,
             mocks::{TestClientBuilder, TestClientBuilderExt},
@@ -385,7 +385,7 @@ mod tests {
             client,
             session_boundaries,
             config,
-            TimingBlockMetrics::noop(),
+            AllBlockMetrics::new(TimingBlockMetrics::<DefaultClock>::noop()),
         );
 
         let (exit_chain_tracker_tx, exit_chain_tracker_rx) = oneshot::channel();

--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -69,7 +69,7 @@ pub use crate::{
     },
     import::{AlephBlockImport, RedirectingBlockImport, TracingBlockImport},
     justification::AlephJustification,
-    metrics::TimingBlockMetrics,
+    metrics::{AllBlockMetrics, DefaultClock, TimingBlockMetrics},
     network::{
         address_cache::{ValidatorAddressCache, ValidatorAddressingInfo},
         Protocol, ProtocolNaming,
@@ -261,7 +261,7 @@ pub struct AlephConfig<C, SC> {
     pub keystore: Arc<dyn Keystore>,
     pub justification_rx: mpsc::UnboundedReceiver<Justification>,
     pub block_rx: mpsc::UnboundedReceiver<AlephBlock>,
-    pub metrics: TimingBlockMetrics,
+    pub metrics: AllBlockMetrics,
     pub registry: Option<Registry>,
     pub session_period: SessionPeriod,
     pub millisecs_per_block: MillisecsPerBlock,

--- a/finality-aleph/src/metrics/all_block.rs
+++ b/finality-aleph/src/metrics/all_block.rs
@@ -3,6 +3,7 @@ use primitives::BlockHash;
 use super::{timing::DefaultClock, Checkpoint};
 use crate::TimingBlockMetrics;
 
+/// Wrapper around various block-related metrics.
 #[derive(Clone)]
 pub struct AllBlockMetrics {
     timing_metrics: TimingBlockMetrics<DefaultClock>,
@@ -13,6 +14,7 @@ impl AllBlockMetrics {
         AllBlockMetrics { timing_metrics }
     }
 
+    /// Triggers all contained block metrics.
     pub fn report_block(&self, hash: BlockHash, checkpoint: Checkpoint) {
         self.timing_metrics.report_block(hash, checkpoint);
     }

--- a/finality-aleph/src/metrics/all_block.rs
+++ b/finality-aleph/src/metrics/all_block.rs
@@ -1,0 +1,19 @@
+use primitives::BlockHash;
+
+use super::{timing::DefaultClock, Checkpoint};
+use crate::TimingBlockMetrics;
+
+#[derive(Clone)]
+pub struct AllBlockMetrics {
+    timing_metrics: TimingBlockMetrics<DefaultClock>,
+}
+
+impl AllBlockMetrics {
+    pub fn new(timing_metrics: TimingBlockMetrics<DefaultClock>) -> Self {
+        AllBlockMetrics { timing_metrics }
+    }
+
+    pub fn report_block(&self, hash: BlockHash, checkpoint: Checkpoint) {
+        self.timing_metrics.report_block(hash, checkpoint);
+    }
+}

--- a/finality-aleph/src/metrics/mod.rs
+++ b/finality-aleph/src/metrics/mod.rs
@@ -1,6 +1,8 @@
+mod all_block;
 mod chain_state;
 mod timing;
 
+pub use all_block::AllBlockMetrics;
 pub use chain_state::run_chain_state_metrics;
-pub use timing::{Checkpoint, TimingBlockMetrics};
+pub use timing::{Checkpoint, DefaultClock, TimingBlockMetrics};
 const LOG_TARGET: &str = "aleph-metrics";

--- a/finality-aleph/src/metrics/timing.rs
+++ b/finality-aleph/src/metrics/timing.rs
@@ -16,6 +16,18 @@ use substrate_prometheus_endpoint::{
 
 use crate::{aleph_primitives::BlockHash, metrics::LOG_TARGET, Display};
 
+pub trait Clock {
+    fn now(&self) -> Instant;
+}
+
+#[derive(Clone)]
+pub struct DefaultClock;
+impl Clock for DefaultClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
 // How many entries (block hash + timestamp) we keep in memory per one checkpoint type.
 // Each entry takes 32B (Hash) + 16B (Instant), so a limit of 5000 gives ~234kB (per checkpoint).
 // Notice that some issues like finalization stall may lead to incomplete metrics
@@ -23,17 +35,20 @@ use crate::{aleph_primitives::BlockHash, metrics::LOG_TARGET, Display};
 const MAX_BLOCKS_PER_CHECKPOINT: usize = 5000;
 
 #[derive(Clone)]
-pub enum TimingBlockMetrics {
+pub enum TimingBlockMetrics<C: Clock> {
     Prometheus {
         time_since_prev_checkpoint: HashMap<Checkpoint, Histogram>,
         imported_to_finalized: Histogram,
         starts: Arc<Mutex<HashMap<Checkpoint, LruCache<BlockHash, Instant>>>>,
+        clock: C,
     },
     Noop,
 }
 
-impl TimingBlockMetrics {
-    pub fn new(registry: Option<&Registry>) -> Result<Self, PrometheusError> {
+impl<C: Clock> TimingBlockMetrics<C> {
+    pub fn new(
+        registry: Option<&Registry>,
+    ) -> Result<TimingBlockMetrics<DefaultClock>, PrometheusError> {
         use Checkpoint::*;
         let keys = [Importing, Imported, Proposed, Ordered, Finalized];
         let target_time_since_prev_checkpoint = HashMap::from([
@@ -46,7 +61,7 @@ impl TimingBlockMetrics {
         const BUCKETS_FACTOR: f64 = 1.5;
 
         let registry = match registry {
-            None => return Ok(Self::Noop),
+            None => return Ok(TimingBlockMetrics::Noop),
             Some(registry) => registry,
         };
 
@@ -77,7 +92,7 @@ impl TimingBlockMetrics {
             );
         }
 
-        Ok(Self::Prometheus {
+        Ok(TimingBlockMetrics::Prometheus {
             time_since_prev_checkpoint,
             imported_to_finalized: register(
                 Histogram::with_opts(
@@ -96,59 +111,49 @@ impl TimingBlockMetrics {
                     })
                     .collect(),
             )),
+            clock: DefaultClock,
         })
     }
 
-    pub fn noop() -> Self {
-        Self::Noop
+    pub fn noop() -> TimingBlockMetrics<DefaultClock> {
+        TimingBlockMetrics::Noop
     }
 
-    pub fn report_block_if_not_present(
-        &self,
-        hash: BlockHash,
-        checkpoint_time: Instant,
-        checkpoint_type: Checkpoint,
-    ) {
-        let starts = match self {
-            TimingBlockMetrics::Noop => return,
-            TimingBlockMetrics::Prometheus { starts, .. } => starts,
-        };
-        if !starts
-            .lock()
-            .get_mut(&checkpoint_type)
-            .expect("All checkpoint types were initialized")
-            .contains(&hash)
-        {
-            self.report_block(hash, checkpoint_time, checkpoint_type);
-        }
-    }
-
-    pub fn report_block(
-        &self,
-        hash: BlockHash,
-        checkpoint_time: Instant,
-        checkpoint_type: Checkpoint,
-    ) {
-        trace!(
-            target: LOG_TARGET,
-            "Reporting block stage: {:?} (hash: {:?}, at: {:?}",
-            checkpoint_type,
-            hash,
-            checkpoint_time
-        );
-        let (time_since_prev_checkpoint, imported_to_finalized, starts) = match self {
+    /// Reports a block at the given [`Checkpoint`] if it hasn't been done before.
+    pub fn report_block(&self, hash: BlockHash, checkpoint_type: Checkpoint) {
+        let (time_since_prev_checkpoint, imported_to_finalized, starts, clock) = match self {
             TimingBlockMetrics::Noop => return,
             TimingBlockMetrics::Prometheus {
                 time_since_prev_checkpoint,
                 imported_to_finalized,
                 starts,
-            } => (time_since_prev_checkpoint, imported_to_finalized, starts),
+                clock,
+            } => (
+                time_since_prev_checkpoint,
+                imported_to_finalized,
+                starts,
+                clock,
+            ),
         };
 
         let starts = &mut *starts.lock();
-        starts.entry(checkpoint_type).and_modify(|starts| {
-            starts.put(hash, checkpoint_time);
-        });
+        let checkpoint_lru = starts
+            .get_mut(&checkpoint_type)
+            .expect("All checkpoint types were initialized");
+        if checkpoint_lru.contains(&hash) {
+            return;
+        }
+
+        let checkpoint_time = clock.now();
+        trace!(
+            target: LOG_TARGET,
+            "Reporting timing of block at stage: {:?} (hash: {:?}, time: {:?}",
+            checkpoint_type,
+            hash,
+            checkpoint_time
+        );
+
+        checkpoint_lru.put(hash, checkpoint_time);
 
         if let Some(prev_checkpoint_type) = checkpoint_type.prev() {
             if let Some(start) = starts
@@ -173,6 +178,7 @@ impl TimingBlockMetrics {
                     .observe(duration.as_secs_f64() * 1000.);
             }
         }
+
         if checkpoint_type == Checkpoint::Finalized {
             if let Some(start) = starts
                 .get_mut(&Checkpoint::Imported)
@@ -263,26 +269,74 @@ fn exponential_buckets_two_sided(
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::min;
+    use std::{cell::RefCell, cmp::min};
 
     use Checkpoint::*;
 
     use super::*;
 
-    fn register_prometheus_metrics_with_dummy_registry() -> TimingBlockMetrics {
-        TimingBlockMetrics::new(Some(&Registry::new())).unwrap()
+    struct TestClock {
+        step: RefCell<usize>,
+        times: Vec<Instant>,
     }
 
-    fn starts_for(m: &TimingBlockMetrics, c: Checkpoint) -> usize {
+    impl TestClock {
+        fn from_times(times: Vec<Instant>) -> Self {
+            TestClock {
+                step: 0.into(),
+                times,
+            }
+        }
+    }
+
+    impl Clock for TestClock {
+        fn now(&self) -> Instant {
+            let instant = self
+                .times
+                .get(*self.step.borrow())
+                .expect("TestClock should be properly initialized");
+            *self.step.borrow_mut() += 1;
+            *instant
+        }
+    }
+
+    impl<C: Clock> TimingBlockMetrics<C> {
+        fn from_test_clock(test_clock: TestClock) -> TimingBlockMetrics<TestClock> {
+            let metrics = register_prometheus_metrics_with_dummy_registry();
+            match metrics {
+                TimingBlockMetrics::Prometheus {
+                    time_since_prev_checkpoint,
+                    imported_to_finalized,
+                    starts,
+                    ..
+                } => TimingBlockMetrics::Prometheus {
+                    time_since_prev_checkpoint,
+                    imported_to_finalized,
+                    starts,
+                    clock: test_clock,
+                },
+                _ => panic!("Should be Prometheus"),
+            }
+        }
+    }
+
+    fn register_prometheus_metrics_with_dummy_registry() -> TimingBlockMetrics<DefaultClock> {
+        TimingBlockMetrics::<DefaultClock>::new(Some(&Registry::new())).unwrap()
+    }
+
+    fn starts_for<C: Clock>(m: &TimingBlockMetrics<C>, c: Checkpoint) -> usize {
         match &m {
             TimingBlockMetrics::Prometheus { starts, .. } => starts.lock().get(&c).unwrap().len(),
             _ => 0,
         }
     }
 
-    fn check_reporting_with_memory_excess(metrics: &TimingBlockMetrics, checkpoint: Checkpoint) {
+    fn check_reporting_with_memory_excess<C: Clock>(
+        metrics: &TimingBlockMetrics<C>,
+        checkpoint: Checkpoint,
+    ) {
         for i in 1..(MAX_BLOCKS_PER_CHECKPOINT + 10) {
-            metrics.report_block(BlockHash::random(), Instant::now(), checkpoint);
+            metrics.report_block(BlockHash::random(), checkpoint);
             assert_eq!(
                 min(i, MAX_BLOCKS_PER_CHECKPOINT),
                 starts_for(metrics, checkpoint)
@@ -292,8 +346,8 @@ mod tests {
 
     #[test]
     fn noop_metrics() {
-        let m = TimingBlockMetrics::noop();
-        m.report_block(BlockHash::random(), Instant::now(), Ordered);
+        let m = TimingBlockMetrics::<DefaultClock>::noop();
+        m.report_block(BlockHash::random(), Ordered);
         assert!(matches!(m, TimingBlockMetrics::Noop));
     }
 
@@ -312,23 +366,28 @@ mod tests {
 
     #[test]
     fn given_not_monotonic_clock_when_report_block_is_called_repeatedly_code_does_not_panic() {
-        let metrics = register_prometheus_metrics_with_dummy_registry();
         let earlier_timestamp = Instant::now();
         let later_timestamp = earlier_timestamp + Duration::new(0, 5);
+        let timestamps = vec![later_timestamp, earlier_timestamp];
+        let test_clock = TestClock::from_times(timestamps);
+        let metrics = TimingBlockMetrics::<TestClock>::from_test_clock(test_clock);
+
         let hash = BlockHash::random();
-        metrics.report_block(hash, later_timestamp, Proposed);
-        metrics.report_block(hash, earlier_timestamp, Ordered);
+        metrics.report_block(hash, Proposed);
+        metrics.report_block(hash, Ordered);
     }
 
     #[test]
     fn test_report_block_if_not_present() {
-        let metrics = register_prometheus_metrics_with_dummy_registry();
         let earlier_timestamp = Instant::now();
         let later_timestamp = earlier_timestamp + Duration::new(0, 5);
-        let hash = BlockHash::random();
+        let timestamps = vec![earlier_timestamp, later_timestamp];
+        let test_clock = TestClock::from_times(timestamps);
+        let metrics = TimingBlockMetrics::<TestClock>::from_test_clock(test_clock);
 
-        metrics.report_block(hash, earlier_timestamp, Proposed);
-        metrics.report_block_if_not_present(hash, later_timestamp, Proposed);
+        let hash = BlockHash::random();
+        metrics.report_block(hash, Proposed);
+        metrics.report_block(hash, Proposed);
 
         let timestamp = match &metrics {
             TimingBlockMetrics::Prometheus { starts, .. } => starts

--- a/finality-aleph/src/party/manager/mod.rs
+++ b/finality-aleph/src/party/manager/mod.rs
@@ -28,6 +28,7 @@ use crate::{
         },
         ChainTracker, DataStore, OrderedDataInterpreter, SubstrateChainInfoProvider,
     },
+    metrics::AllBlockMetrics,
     mpsc,
     network::{
         data::{
@@ -41,8 +42,8 @@ use crate::{
     },
     sync::JustificationSubmissions,
     AuthorityId, BlockId, CurrentRmcNetworkData, Keychain, LegacyRmcNetworkData, NodeIndex,
-    SessionBoundaries, SessionBoundaryInfo, SessionId, SessionPeriod, TimingBlockMetrics,
-    UnitCreationDelay, VersionedNetworkData,
+    SessionBoundaries, SessionBoundaryInfo, SessionId, SessionPeriod, UnitCreationDelay,
+    VersionedNetworkData,
 };
 
 mod aggregator;
@@ -115,7 +116,7 @@ where
     justifications_for_sync: JS,
     justification_translator: JustificationTranslator,
     block_requester: RB,
-    metrics: TimingBlockMetrics,
+    metrics: AllBlockMetrics,
     spawn_handle: SpawnHandle,
     session_manager: SM,
     keystore: Arc<dyn Keystore>,
@@ -145,7 +146,7 @@ where
         justifications_for_sync: JS,
         justification_translator: JustificationTranslator,
         block_requester: RB,
-        metrics: TimingBlockMetrics,
+        metrics: AllBlockMetrics,
         spawn_handle: SpawnHandle,
         session_manager: SM,
         keystore: Arc<dyn Keystore>,


### PR DESCRIPTION
# Description

Introduce `AllBlockMetrics` which is a wrapper for different types of block metrics.
Currently it only wraps `TimingBlockMetrics` but in future it will contain some other metrics.

Adjustments made to `TimingBlockMetrics`:
* from `report_block` and `report_block_if_not_present` created a single function of semantics equal to `report_block_if_not_present`, but named `report_block`.
* Changed signature of `report_block(hash, timestamp, checkpoint)` to `report_block(hash, checkpoint)` - the timestamp can be inferred inside the function
* Parameterized the struct with newly added `trait Clock` - there were some tests which checked behavior of `TimingBlockMetrics` when manipulating the times of newly appearing reports. After removing `timestamp` from `report_block` signature we needed to somehow be able to manipulate the times - thus parameterization.

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have made neccessary updates to the Infrastructure
- I have made corresponding changes to the existing documentation
- I have created new documentation
