### PR TITLE
A0-3518: Move `verify` weighting to the proper place

### DIFF
--- a/pallets/baby-liminal/src/lib.rs
+++ b/pallets/baby-liminal/src/lib.rs
@@ -277,7 +277,7 @@ pub mod pallet {
         /// system)
         /// - verifying procedure fails (e.g. incompatible verification key and proof)
         /// - proof is incorrect
-        #[pallet::weight(0)]
+        #[pallet::weight(T::WeightInfo::verify())]
         #[pallet::call_index(3)]
         pub fn verify(
             _origin: OriginFor<T>,

--- a/pallets/baby-liminal/src/weights.rs
+++ b/pallets/baby-liminal/src/weights.rs
@@ -31,6 +31,7 @@ pub trait WeightInfo {
     fn overwrite_equal_key(key_length: u32) -> Weight;
     fn overwrite_key(key_length: u32) -> Weight;
     fn delete_key(key_length: u32) -> Weight;
+	fn verify() -> Weight;
 }
 
 impl<I: BenchmarkInfo> WeightInfo for I {
@@ -49,6 +50,10 @@ impl<I: BenchmarkInfo> WeightInfo for I {
     fn delete_key(key_length: u32) -> Weight {
         <I as BenchmarkInfo>::delete_key(key_length)
     }
+
+	fn verify() -> Weight {
+		<I as BenchmarkInfo>::verify()
+	}
 }
 
 /// Benchmark results for pallet_baby_liminal.
@@ -57,6 +62,7 @@ trait BenchmarkInfo {
 	fn overwrite_equal_key(l: u32, ) -> Weight;
 	fn overwrite_key(l: u32, ) -> Weight;
 	fn delete_key(l: u32, ) -> Weight;
+	fn verify() -> Weight;
 }
 
 /// Weights for pallet_baby_liminal using the Substrate node and recommended hardware.
@@ -127,6 +133,10 @@ impl<T: frame_system::Config> BenchmarkInfo for AlephWeight<T> {
 		Weight::from_parts(34_440_507_u64, 0)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
+
+	fn verify() -> Weight {
+		Weight::zero()
 	}
 }
 

--- a/pallets/baby-liminal/src/weights.rs
+++ b/pallets/baby-liminal/src/weights.rs
@@ -31,7 +31,7 @@ pub trait WeightInfo {
     fn overwrite_equal_key(key_length: u32) -> Weight;
     fn overwrite_key(key_length: u32) -> Weight;
     fn delete_key(key_length: u32) -> Weight;
-	fn verify() -> Weight;
+    fn verify() -> Weight;
 }
 
 impl<I: BenchmarkInfo> WeightInfo for I {
@@ -51,18 +51,18 @@ impl<I: BenchmarkInfo> WeightInfo for I {
         <I as BenchmarkInfo>::delete_key(key_length)
     }
 
-	fn verify() -> Weight {
-		<I as BenchmarkInfo>::verify()
-	}
+    fn verify() -> Weight {
+        <I as BenchmarkInfo>::verify() 
+    }
 }
 
 /// Benchmark results for pallet_baby_liminal.
 trait BenchmarkInfo {
-	fn store_key(l: u32, ) -> Weight;
-	fn overwrite_equal_key(l: u32, ) -> Weight;
-	fn overwrite_key(l: u32, ) -> Weight;
-	fn delete_key(l: u32, ) -> Weight;
-	fn verify() -> Weight;
+    fn store_key(l: u32, ) -> Weight;
+    fn overwrite_equal_key(l: u32, ) -> Weight;
+    fn overwrite_key(l: u32, ) -> Weight;
+    fn delete_key(l: u32, ) -> Weight;
+    fn verify() -> Weight;
 }
 
 /// Weights for pallet_baby_liminal using the Substrate node and recommended hardware.

--- a/pallets/baby-liminal/src/weights.rs
+++ b/pallets/baby-liminal/src/weights.rs
@@ -208,4 +208,8 @@ impl BenchmarkInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
+
+	fn verify() -> Weight {
+		Weight::zero()
+	}
 }


### PR DESCRIPTION
# Description

Although we don't have benchmarks for jellyfish verifier (and thus the pallet charges 0 weight for verification), we should enrich `WeightInfo` trait with `verify` method that returns for now `0` and use it in both pallet and the extension.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
