### PR TITLE
A0-3584: Create NetworkEventStream earlier

### DIFF
--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -9,8 +9,8 @@ use aleph_runtime::{self, opaque::Block, RuntimeApi};
 use finality_aleph::{
     run_validator_node, AlephBlockImport, AlephConfig, BlockImporter, Justification,
     JustificationTranslator, MillisecsPerBlock, Protocol, ProtocolNaming, RateLimiterConfig,
-    RedirectingBlockImport, SessionPeriod, SubstrateChainStatus, SyncOracle, TimingBlockMetrics,
-    TracingBlockImport, ValidatorAddressCache,
+    RedirectingBlockImport, SessionPeriod, SubstrateChainStatus, SubstrateNetwork, SyncOracle,
+    TimingBlockMetrics, TracingBlockImport, ValidatorAddressCache,
 };
 use futures::channel::mpsc;
 use log::warn;
@@ -18,8 +18,6 @@ use sc_client_api::{BlockBackend, HeaderBackend};
 use sc_consensus::ImportQueue;
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 use sc_consensus_slots::BackoffAuthoringBlocksStrategy;
-use sc_network::NetworkService;
-use sc_network_sync::SyncingService;
 use sc_service::{
     error::Error as ServiceError, Configuration, KeystoreContainer, NetworkStarter, RpcHandlers,
     TFullClient, TaskManager,
@@ -214,9 +212,7 @@ fn setup(
 ) -> Result<
     (
         RpcHandlers,
-        Arc<NetworkService<Block, BlockHash>>,
-        Arc<SyncingService<Block>>,
-        ProtocolNaming,
+        SubstrateNetwork<Block, BlockHash>,
         NetworkStarter,
         SyncOracle,
         Option<ValidatorAddressCache>,
@@ -298,11 +294,11 @@ fn setup(
         telemetry: telemetry.as_mut(),
     })?;
 
+    let substrate_network = SubstrateNetwork::new(network, sync_network, protocol_naming);
+
     Ok((
         rpc_handlers,
-        network,
-        sync_network,
-        protocol_naming,
+        substrate_network,
         network_starter,
         sync_oracle,
         validator_address_cache,
@@ -347,27 +343,20 @@ pub fn new_authority(
 
     let collect_extra_debugging_data = !aleph_config.no_collection_of_extra_debugging_data();
 
-    let (
-        _rpc_handlers,
-        network,
-        sync_network,
-        protocol_naming,
-        network_starter,
-        sync_oracle,
-        validator_address_cache,
-    ) = setup(
-        config,
-        backend,
-        chain_status.clone(),
-        &keystore_container,
-        import_queue,
-        transaction_pool.clone(),
-        &mut task_manager,
-        client.clone(),
-        &mut telemetry,
-        justification_tx,
-        collect_extra_debugging_data,
-    )?;
+    let (_rpc_handlers, substrate_network, network_starter, sync_oracle, validator_address_cache) =
+        setup(
+            config,
+            backend,
+            chain_status.clone(),
+            &keystore_container,
+            import_queue,
+            transaction_pool.clone(),
+            &mut task_manager,
+            client.clone(),
+            &mut telemetry,
+            justification_tx,
+            collect_extra_debugging_data,
+        )?;
 
     let mut proposer_factory = sc_basic_authorship::ProposerFactory::new(
         task_manager.spawn_handle(),
@@ -426,8 +415,8 @@ pub fn new_authority(
     };
 
     let aleph_config = AlephConfig {
-        network,
-        sync_network,
+        network: substrate_network.clone(),
+        network_event_stream: substrate_network.event_stream(),
         client,
         chain_status,
         import_queue_handle,
@@ -444,7 +433,6 @@ pub fn new_authority(
         backup_saving_path: backup_path,
         external_addresses: aleph_config.external_addresses(),
         validator_port: aleph_config.validator_port(),
-        protocol_naming,
         rate_limiter_config,
         sync_oracle,
         validator_address_cache,

--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -17,8 +17,6 @@ use sc_client_api::{
     Backend, BlockBackend, BlockchainEvents, Finalizer, LockImportRun, StorageProvider,
 };
 use sc_consensus::BlockImport;
-use sc_network::NetworkService;
-use sc_network_sync::SyncingService;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_keystore::Keystore;
@@ -72,7 +70,7 @@ pub use crate::{
     metrics::TimingBlockMetrics,
     network::{
         address_cache::{ValidatorAddressCache, ValidatorAddressingInfo},
-        Protocol, ProtocolNaming,
+        Protocol, ProtocolNaming, SubstrateNetwork, SubstrateNetworkEventStream,
     },
     nodes::run_validator_node,
     session::SessionPeriod,
@@ -251,8 +249,8 @@ pub struct RateLimiterConfig {
 }
 
 pub struct AlephConfig<C, SC> {
-    pub network: Arc<NetworkService<AlephBlock, AlephHash>>,
-    pub sync_network: Arc<SyncingService<AlephBlock>>,
+    pub network: SubstrateNetwork<AlephBlock, AlephHash>,
+    pub network_event_stream: SubstrateNetworkEventStream<AlephBlock, AlephHash>,
     pub client: Arc<C>,
     pub chain_status: SubstrateChainStatus,
     pub import_queue_handle: BlockImporter,
@@ -269,7 +267,6 @@ pub struct AlephConfig<C, SC> {
     pub backup_saving_path: Option<PathBuf>,
     pub external_addresses: Vec<String>,
     pub validator_port: u16,
-    pub protocol_naming: ProtocolNaming,
     pub rate_limiter_config: RateLimiterConfig,
     pub sync_oracle: SyncOracle,
     pub validator_address_cache: Option<ValidatorAddressCache>,

--- a/finality-aleph/src/network/gossip/mock.rs
+++ b/finality-aleph/src/network/gossip/mock.rs
@@ -74,13 +74,7 @@ impl RawNetwork for MockRawNetwork {
     type EventStream = MockEventStream;
 
     fn event_stream(&self) -> Self::EventStream {
-        let (tx, rx) = mpsc::unbounded();
-        self.event_sinks.lock().push(tx);
-        // Necessary for tests to detect when service takes event_stream
-        if let Some(tx) = self.event_stream_taken_oneshot.lock().take() {
-            tx.send(()).unwrap();
-        }
-        MockEventStream(rx)
+        self.event_stream()
     }
 
     fn sender(
@@ -111,6 +105,16 @@ impl MockRawNetwork {
             create_sender_errors: Arc::new(Mutex::new(VecDeque::new())),
             send_errors: Arc::new(Mutex::new(VecDeque::new())),
         }
+    }
+
+    pub fn event_stream(&self) -> MockEventStream {
+        let (tx, rx) = mpsc::unbounded();
+        self.event_sinks.lock().push(tx);
+        // Necessary for tests to detect when service takes event_stream
+        if let Some(tx) = self.event_stream_taken_oneshot.lock().take() {
+            tx.send(()).unwrap();
+        }
+        MockEventStream(rx)
     }
 
     pub fn emit_event(&mut self, event: MockEvent) {

--- a/finality-aleph/src/network/gossip/mod.rs
+++ b/finality-aleph/src/network/gossip/mod.rs
@@ -91,6 +91,8 @@ pub trait RawNetwork: Clone + Send + Sync + 'static {
     type EventStream: EventStream<Self::PeerId>;
 
     /// Returns a stream of events representing what happens on the network.
+    /// Watch out for race conditions, events that appeared in network before the stream
+    /// was created will not be reported.
     fn event_stream(&self) -> Self::EventStream;
 
     /// Returns a sender to the given peer using a given protocol. Returns Error if not connected to the peer.

--- a/finality-aleph/src/network/gossip/service.rs
+++ b/finality-aleph/src/network/gossip/service.rs
@@ -500,9 +500,7 @@ impl<N: RawNetwork, AD: Data, BSD: Data> Service<N, AD, BSD> {
         info!(target: LOG_TARGET, "{}", status);
     }
 
-    pub async fn run(mut self) {
-        let mut events_from_network = self.network.event_stream();
-
+    pub async fn run(mut self, mut events_from_network: N::EventStream) {
         let mut status_ticker = time::interval(STATUS_REPORT_INTERVAL);
         loop {
             tokio::select! {

--- a/finality-aleph/src/network/mod.rs
+++ b/finality-aleph/src/network/mod.rs
@@ -15,7 +15,9 @@ pub use gossip::{
     Error as GossipError, Network as GossipNetwork, Protocol, Service as GossipService,
 };
 use network_clique::{AddressingInformation, NetworkIdentity, PeerId};
-pub use substrate::{ProtocolNaming, SubstrateNetwork};
+pub use substrate::{
+    NetworkEventStream as SubstrateNetworkEventStream, ProtocolNaming, SubstrateNetwork,
+};
 
 /// A basic alias for properties we expect basic data to satisfy.
 pub trait Data: Clone + Codec + Send + Sync + 'static {}

--- a/finality-aleph/src/testing/network.rs
+++ b/finality-aleph/src/testing/network.rs
@@ -123,10 +123,11 @@ async fn prepare_one_session_test_data() -> TestData {
             _ = network_manager_exit_rx => { },
         };
     };
+    let network_event_stream = network.event_stream();
 
     let gossip_service_task = async move {
         tokio::select! {
-            _ = gossip_service.run() => { },
+            _ = gossip_service.run(network_event_stream) => { },
             _ = gossip_service_exit_rx => { },
         };
     };


### PR DESCRIPTION
# Description

There was a race condition, making our e2e test fail randomly because one node was not finalizing. Namely:
```
    task_manager.spawn_essential_handle().spawn_blocking(
        "aleph",
        None,
        run_validator_node(aleph_config), // registers notification channel from substrate network
    );
    network_starter.start_network(); // start substrate network
```
And the registration could have executed after starting the network, causing missing some notifications.

This PR moves registering `NetworkEventStream` rx so that now it is always created before starting the network, and we get all notifications about `StreamOpened`. 

In `run_validator_node` we create also other notification channels from other network components, but I think the only event that cannot be missed is the mentioned `StreamOpened` event.

Since my proposed solution exposes our facade for `SubstrateNetwork` and creates that component in `bin/`, I also simplified `AlephConfig` a bit.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:
