### PR TITLE
A0-3056: Increase timeout for nightly reorg test

### DIFF
--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -220,7 +220,7 @@ jobs:
           path: target/release/
 
       - name: Run test
-        timeout-minutes: 15
+        timeout-minutes: 25
         run: |
           ./.github/scripts/test_python_general.sh \
             --aleph-node ../target/release/aleph-node \


### PR DESCRIPTION
# Description

Increased timeout from 15 to 25 minutes because that test seems to have failed recently while it was progressing, because of a timeout.

## Type of change

Please delete options that are not relevant.

- None (changes only dev enviromnent)

# Checklist: