### PR TITLE
A0-3618: Leave only proof verification in the chain extension

### DIFF
--- a/baby-liminal-extension/Cargo.lock
+++ b/baby-liminal-extension/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-nomination-pools",
  "pallet-nomination-pools-runtime-api",
+ "pallet-proxy",
  "pallet-scheduler",
  "pallet-session",
  "pallet-staking",
@@ -1510,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "fflonk"
 version = "0.1.0"
-source = "git+https://github.com/w3f/fflonk#1beb0585e1c8488956fac7f05da061f9b41e8948"
+source = "git+https://github.com/w3f/fflonk#1e854f35e9a65d08b11a86291405cdc95baa0a35"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3202,6 +3203,21 @@ dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
  "sp-api",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-proxy"
+version = "4.0.0-dev"
+source = "git+https://github.com/Cardinal-Cryptography/polkadot-sdk.git?branch=aleph-v1.2.0#d9bb021ae2f7d752e1739e72294facf1b5dd2838"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 

--- a/baby-liminal-extension/src/args.rs
+++ b/baby-liminal-extension/src/args.rs
@@ -2,33 +2,9 @@
 //! proper argument encoding. On the runtime side, they can be used for decoding the arguments.
 
 #[cfg(feature = "ink")]
-use {crate::VerificationKeyIdentifier, ink::prelude::vec::Vec, ink::primitives::AccountId};
+use {crate::VerificationKeyIdentifier, ink::prelude::vec::Vec};
 #[cfg(feature = "runtime")]
-use {
-    frame_support::sp_runtime::AccountId32 as AccountId,
-    pallet_baby_liminal::VerificationKeyIdentifier, sp_std::vec::Vec,
-};
-
-/// A struct describing layout for the `store_key` chain extension.
-#[derive(Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
-pub struct StoreKeyArgs {
-    /// The account ID of the key depositor.
-    pub depositor: AccountId,
-    /// The identifier of the key.
-    pub identifier: VerificationKeyIdentifier,
-    /// The key itself.
-    pub key: Vec<u8>,
-}
-
-impl StoreKeyArgs {
-    /// Returns the approximate size of the encoded key. It is an upper bound, because the
-    /// encoding must also include the vector length.
-    #[cfg(feature = "runtime")]
-    pub fn approximate_key_size(encoded_len: usize) -> usize {
-        use sp_std::mem::size_of;
-        encoded_len - size_of::<AccountId>() - size_of::<VerificationKeyIdentifier>()
-    }
-}
+use {pallet_baby_liminal::VerificationKeyIdentifier, sp_std::vec::Vec};
 
 /// A struct describing layout for the `verify` chain extension.
 #[derive(Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode)]

--- a/baby-liminal-extension/src/backend/executor.rs
+++ b/baby-liminal-extension/src/backend/executor.rs
@@ -3,7 +3,7 @@ use frame_system::Config as SystemConfig;
 use pallet_baby_liminal::{Config as BabyLiminalConfig, Error as PalletError, Pallet};
 use pallet_contracts::Config as ContractsConfig;
 
-use crate::args::{StoreKeyArgs, VerifyArgs};
+use crate::args::VerifyArgs;
 
 /// Minimal runtime configuration required by the chain extension executor.
 pub trait MinimalRuntime: SystemConfig + BabyLiminalConfig + ContractsConfig {}
@@ -16,8 +16,6 @@ pub trait BackendExecutor {
     /// context it will be enough to instantiate it with `()`.
     type ErrorGenericType;
 
-    fn store_key(args: StoreKeyArgs) -> Result<(), PalletError<Self::ErrorGenericType>>;
-
     fn verify(
         args: VerifyArgs,
     ) -> Result<(), (PalletError<Self::ErrorGenericType>, Option<Weight>)>;
@@ -29,10 +27,6 @@ where
     <Runtime as SystemConfig>::RuntimeOrigin: From<Option<AccountId32>>,
 {
     type ErrorGenericType = Runtime;
-
-    fn store_key(args: StoreKeyArgs) -> Result<(), PalletError<Self::ErrorGenericType>> {
-        Pallet::<Runtime>::bare_store_key(Some(args.depositor).into(), args.identifier, args.key)
-    }
 
     fn verify(
         args: VerifyArgs,

--- a/baby-liminal-extension/src/backend/tests.rs
+++ b/baby-liminal-extension/src/backend/tests.rs
@@ -8,33 +8,17 @@ use pallet_baby_liminal::{Error::*, WeightInfo};
 use pallet_contracts::chain_extension::{ChainExtension, RetVal};
 
 use crate::{
-    args::StoreKeyArgs,
     backend::{
         executor::BackendExecutor,
         tests::{
-            arguments::{store_key_args, verify_args, VK},
-            environment::{
-                CorruptedMode, MockedEnvironment, StandardMode, StoreKeyMode, VerifyMode,
-            },
-            executor::{Panicker, StoreKeyErrorer, StoreKeyOkayer, VerifyErrorer, VerifyOkayer},
+            arguments::verify_args,
+            environment::{CorruptedMode, MockedEnvironment, StandardMode, VerifyMode},
+            executor::{Panicker, VerifyErrorer, VerifyOkayer},
         },
     },
     status_codes::*,
     BabyLiminalChainExtension,
 };
-
-fn simulate_store_key<Exc: BackendExecutor>(expected_ret_val: u32) {
-    let mut charged = Weight::zero();
-    let env = MockedEnvironment::<StoreKeyMode, StandardMode>::new(
-        &mut charged,
-        store_key_args().clone(),
-    );
-
-    let result = BabyLiminalChainExtension::<AlephRuntime>::store_key::<Exc, _, ()>(env);
-
-    assert!(matches!(result, Ok(RetVal::Converging(ret_val)) if ret_val == expected_ret_val));
-    assert_eq!(charged, <()>::store_key(VK.len() as u32));
-}
 
 fn simulate_verify<Exc: BackendExecutor>(expected_ret_val: u32) {
     let mut charged = Weight::zero();
@@ -49,42 +33,6 @@ fn simulate_verify<Exc: BackendExecutor>(expected_ret_val: u32) {
 #[test]
 fn extension_is_enabled() {
     assert!(BabyLiminalChainExtension::<AlephRuntime>::enabled())
-}
-
-#[test]
-#[allow(non_snake_case)]
-fn store_key__charges_before_reading_arguments() {
-    let mut charged = Weight::zero();
-    let in_len = 41;
-    // `CorruptedMode` ensures that the CE call will fail at argument reading/decoding phase.
-    let env = MockedEnvironment::<StoreKeyMode, CorruptedMode>::new(&mut charged, in_len);
-
-    // `Panicker` ensures that the call will not be forwarded to the pallet.
-    let result = BabyLiminalChainExtension::<AlephRuntime>::store_key::<Panicker, _, ()>(env);
-
-    assert!(matches!(result, Err(_)));
-    assert_eq!(
-        charged,
-        <()>::store_key(StoreKeyArgs::approximate_key_size(in_len as usize) as u32)
-    );
-}
-
-#[test]
-#[allow(non_snake_case)]
-fn store_key__positive_scenario() {
-    simulate_store_key::<StoreKeyOkayer>(STORE_KEY_SUCCESS)
-}
-
-#[test]
-#[allow(non_snake_case)]
-fn store_key__pallet_says_too_long_vk() {
-    simulate_store_key::<StoreKeyErrorer<{ VerificationKeyTooLong }>>(STORE_KEY_TOO_LONG_KEY)
-}
-
-#[test]
-#[allow(non_snake_case)]
-fn store_key__pallet_says_identifier_in_use() {
-    simulate_store_key::<StoreKeyErrorer<{ IdentifierAlreadyInUse }>>(STORE_KEY_IDENTIFIER_IN_USE)
 }
 
 #[test]

--- a/baby-liminal-extension/src/backend/tests/arguments.rs
+++ b/baby-liminal-extension/src/backend/tests/arguments.rs
@@ -1,26 +1,10 @@
-use frame_support::sp_runtime::AccountId32;
 use scale::Encode;
 
-use crate::{
-    args::{StoreKeyArgs, VerifyArgs},
-    VerificationKeyIdentifier,
-};
+use crate::{args::VerifyArgs, VerificationKeyIdentifier};
 
-pub const DEPOSITOR: [u8; 32] = [1; 32];
 pub const IDENTIFIER: VerificationKeyIdentifier = [41; 8];
-pub const VK: [u8; 2] = [4, 1];
 pub const PROOF: [u8; 20] = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3, 8, 4];
 pub const INPUT: [u8; 11] = [0, 5, 7, 7, 2, 1, 5, 6, 6, 4, 9];
-
-/// Returns encoded arguments to `store_key` chain extension call.
-pub fn store_key_args() -> Vec<u8> {
-    StoreKeyArgs {
-        depositor: AccountId32::new(DEPOSITOR),
-        identifier: IDENTIFIER,
-        key: VK.to_vec(),
-    }
-    .encode()
-}
 
 /// Returns encoded arguments to `verify` chain extension call.
 pub fn verify_args() -> Vec<u8> {

--- a/baby-liminal-extension/src/backend/tests/environment.rs
+++ b/baby-liminal-extension/src/backend/tests/environment.rs
@@ -7,9 +7,6 @@ use crate::backend::{environment::Environment, ByteCount};
 
 /// Trait serving as a type-level flag indicating which method we are testing.
 pub trait FunctionMode {}
-/// We are testing `store_key`.
-pub enum StoreKeyMode {}
-impl FunctionMode for StoreKeyMode {}
 /// We are testing `verify`.
 pub enum VerifyMode {}
 impl FunctionMode for VerifyMode {}

--- a/baby-liminal-extension/src/backend/tests/executor.rs
+++ b/baby-liminal-extension/src/backend/tests/executor.rs
@@ -1,10 +1,7 @@
 use frame_support::pallet_prelude::Weight;
 use pallet_baby_liminal::Error as PalletError;
 
-use crate::{
-    args::{StoreKeyArgs, VerifyArgs},
-    backend::executor::BackendExecutor,
-};
+use crate::{args::VerifyArgs, backend::executor::BackendExecutor};
 
 /// Describes how the `Executor` should behave when one of its methods is called.
 #[derive(Clone, Eq, PartialEq)]
@@ -26,37 +23,20 @@ pub const fn make_errorer<const ERROR: PalletError<()>>() -> Responder {
 
 /// A testing counterpart for `Runtime`.
 ///
-/// `STORE_KEY_RESPONDER` instructs how to behave then `store_key` is called.
-/// `VERIFY_RESPONDER` instructs how to behave then `verify` is called.
-pub struct MockedExecutor<const STORE_KEY_RESPONDER: Responder, const VERIFY_RESPONDER: Responder>;
+/// `VERIFY_RESPONDER` instructs how to behave when `verify` is called.
+pub struct MockedExecutor<const VERIFY_RESPONDER: Responder>;
 
-/// Executor that will scream for every associated method.
-pub type Panicker = MockedExecutor<{ Responder::Panicker }, { Responder::Panicker }>;
+/// Executor that will scream when `verify` is called.
+pub type Panicker = MockedExecutor<{ Responder::Panicker }>;
 
-/// Executor that will return `Ok(())` for `store_key` and scream for `verify`.
-pub type StoreKeyOkayer = MockedExecutor<{ Responder::Okayer }, { Responder::Panicker }>;
-/// Executor that will return `Ok(())` for `verify` and scream for `store_key`.
-pub type VerifyOkayer = MockedExecutor<{ Responder::Panicker }, { Responder::Okayer }>;
+/// Executor that will return `Ok(())` for `verify`.
+pub type VerifyOkayer = MockedExecutor<{ Responder::Okayer }>;
 
-/// Executor that will return `Err(ERROR)` for `store_key` and scream for `verify`.
-pub type StoreKeyErrorer<const ERROR: PalletError<()>> =
-    MockedExecutor<{ make_errorer::<ERROR>() }, { Responder::Panicker }>;
-/// Executor that will return `Err(ERROR)` for `verify` and scream for `store_key`.
-pub type VerifyErrorer<const ERROR: PalletError<()>> =
-    MockedExecutor<{ Responder::Panicker }, { make_errorer::<ERROR>() }>;
+/// Executor that will return `Err(ERROR)` for `verify`.
+pub type VerifyErrorer<const ERROR: PalletError<()>> = MockedExecutor<{ make_errorer::<ERROR>() }>;
 
-impl<const STORE_KEY_RESPONDER: Responder, const VERIFY_RESPONDER: Responder> BackendExecutor
-    for MockedExecutor<STORE_KEY_RESPONDER, VERIFY_RESPONDER>
-{
+impl<const VERIFY_RESPONDER: Responder> BackendExecutor for MockedExecutor<VERIFY_RESPONDER> {
     type ErrorGenericType = ();
-
-    fn store_key(_: StoreKeyArgs) -> Result<(), PalletError<()>> {
-        match STORE_KEY_RESPONDER {
-            Responder::Panicker => panic!("Function `store_key` shouldn't have been executed"),
-            Responder::Okayer => Ok(()),
-            Responder::Errorer(e) => Err(e),
-        }
-    }
 
     fn verify(_: VerifyArgs) -> Result<(), (PalletError<()>, Option<Weight>)> {
         match VERIFY_RESPONDER {

--- a/baby-liminal-extension/src/extension_ids.rs
+++ b/baby-liminal-extension/src/extension_ids.rs
@@ -2,7 +2,5 @@
 //!
 //! They must be unique across runtime.
 
-/// Extension ID for the `store_key` extension function.
-pub const STORE_KEY_EXT_ID: u32 = 41;
 /// Extension ID for the `verify` extension function.
-pub const VERIFY_EXT_ID: u32 = 42;
+pub const VERIFY_EXT_ID: u32 = 0;

--- a/baby-liminal-extension/src/frontend.rs
+++ b/baby-liminal-extension/src/frontend.rs
@@ -3,7 +3,6 @@
 use ink::{
     env::{DefaultEnvironment, Environment as EnvironmentT},
     prelude::vec::Vec,
-    primitives::AccountId,
 };
 
 use crate::VerificationKeyIdentifier;
@@ -13,12 +12,7 @@ use crate::VerificationKeyIdentifier;
 #[allow(missing_docs)] // Error variants are self-descriptive.
 /// Chain extension errors enumeration.
 pub enum BabyLiminalError {
-    // `pallet_baby_liminal::store_key` errors
-    VerificationKeyTooLong,
-    IdentifierAlreadyInUse,
-    StoreKeyErrorUnknown,
-
-    // `pallet_baby_liminal::verify` errors
+    // Proof verification errors.
     UnknownVerificationKeyIdentifier,
     DeserializingProofFailed,
     DeserializingPublicInputFailed,
@@ -45,14 +39,9 @@ impl ink::env::chain_extension::FromStatusCode for BabyLiminalError {
 
         match status_code {
             // Success codes
-            STORE_KEY_SUCCESS | VERIFY_SUCCESS => Ok(()),
+            VERIFY_SUCCESS => Ok(()),
 
-            // `pallet_baby_liminal::store_key` errors
-            STORE_KEY_TOO_LONG_KEY => Err(Self::VerificationKeyTooLong),
-            STORE_KEY_IDENTIFIER_IN_USE => Err(Self::IdentifierAlreadyInUse),
-            STORE_KEY_ERROR_UNKNOWN => Err(Self::StoreKeyErrorUnknown),
-
-            // `pallet_baby_liminal::verify` errors
+            // Proof verification errors
             VERIFY_DESERIALIZING_PROOF_FAIL => Err(Self::DeserializingProofFailed),
             VERIFY_DESERIALIZING_INPUT_FAIL => Err(Self::DeserializingPublicInputFailed),
             VERIFY_UNKNOWN_IDENTIFIER => Err(Self::UnknownVerificationKeyIdentifier),
@@ -71,20 +60,11 @@ impl ink::env::chain_extension::FromStatusCode for BabyLiminalError {
 pub trait BabyLiminalExtension {
     type ErrorCode = BabyLiminalError;
 
-    /// Directly call `pallet_baby_liminal::store_key`.
+    /// Verify a ZK proof `proof` given the public input `input` against the verification key
+    /// `identifier`.
     // IMPORTANT: this must match the extension ID in `extension_ids.rs`! However, because constants
     // are not inlined before macro processing, we can't use an identifier from another module here.
-    #[ink(extension = 41)]
-    fn store_key(
-        origin: AccountId,
-        identifier: VerificationKeyIdentifier,
-        key: Vec<u8>,
-    ) -> Result<(), BabyLiminalError>;
-
-    /// Directly call `pallet_baby_liminal::verify`.
-    // IMPORTANT: this must match the extension ID in `extension_ids.rs`! However, because constants
-    // are not inlined before macro processing, we can't use an identifier from another module here.
-    #[ink(extension = 42)]
+    #[ink(extension = 0)]
     fn verify(
         identifier: VerificationKeyIdentifier,
         proof: Vec<u8>,

--- a/baby-liminal-extension/src/lib.rs
+++ b/baby-liminal-extension/src/lib.rs
@@ -1,7 +1,6 @@
 //! # Baby Liminal Extension
 //!
-//! This crate provides a way for smart contracts to interact with the [`pallet_baby_liminal`]
-//! runtime module.
+//! This crate provides a way for smart contracts to work with ZK proofs (SNARKs).
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]

--- a/baby-liminal-extension/src/status_codes.rs
+++ b/baby-liminal-extension/src/status_codes.rs
@@ -1,17 +1,10 @@
 //! Status codes for the baby-liminal-extension pallet.
 //!
-//! Every extension function (like `store_key` or `verify`) comes with:
+//! Every extension function (like `verify`) comes with:
 //! * its own success code,
 //! * and a set of error codes (usually starting at the success code + 1).
 
 #![allow(missing_docs)] // Error constants are self-descriptive.
-
-// ---- `store_key` errors -------------------------------------------------------------------------
-const STORE_KEY_BASE: u32 = 10_000;
-pub const STORE_KEY_SUCCESS: u32 = STORE_KEY_BASE;
-pub const STORE_KEY_TOO_LONG_KEY: u32 = STORE_KEY_BASE + 1;
-pub const STORE_KEY_IDENTIFIER_IN_USE: u32 = STORE_KEY_BASE + 2;
-pub const STORE_KEY_ERROR_UNKNOWN: u32 = STORE_KEY_BASE + 3;
 
 // ---- `verify` errors ----------------------------------------------------------------------------
 const VERIFY_BASE: u32 = 11_000;

--- a/baby-liminal-extension/test_contract/lib.rs
+++ b/baby-liminal-extension/test_contract/lib.rs
@@ -14,14 +14,6 @@ mod test_contract {
         }
 
         #[ink(message)]
-        pub fn call_store_key(&self) {
-            self.env()
-                .extension()
-                .store_key(self.env().caller(), [0; 8], vec![0; 32])
-                .unwrap();
-        }
-
-        #[ink(message)]
         pub fn call_verify(&self) {
             self.env()
                 .extension()
@@ -36,17 +28,6 @@ mod test_contract {
 
         use super::*;
 
-        struct MockedStoreKeyExtension;
-        impl ink::env::test::ChainExtension for MockedStoreKeyExtension {
-            fn func_id(&self) -> u32 {
-                baby_liminal_extension::extension_ids::STORE_KEY_EXT_ID
-            }
-
-            fn call(&mut self, _: &[u8], _: &mut Vec<u8>) -> u32 {
-                baby_liminal_extension::status_codes::STORE_KEY_SUCCESS
-            }
-        }
-
         struct MockedVerifyExtension;
         impl ink::env::test::ChainExtension for MockedVerifyExtension {
             fn func_id(&self) -> u32 {
@@ -56,12 +37,6 @@ mod test_contract {
             fn call(&mut self, _: &[u8], _: &mut Vec<u8>) -> u32 {
                 baby_liminal_extension::status_codes::VERIFY_SUCCESS
             }
-        }
-
-        #[ink::test]
-        fn store_key_works() {
-            register_chain_extension(MockedStoreKeyExtension);
-            TestContract::new().call_store_key();
         }
 
         #[ink::test]


### PR DESCRIPTION
# Description

As a part of redefining liminal pallet, we remove all key-related operations from the chain extension.

Next steps:
 - bring verification to CE
 - purge pallet

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- I have made neccessary updates to the Infrastructure
- I have made corresponding changes to the existing documentation
