### PR TITLE
A0-3627: Reverted ink-dev to 1.0.0

### DIFF
--- a/contracts/adder/deploy.sh
+++ b/contracts/adder/deploy.sh
@@ -13,7 +13,7 @@ function run_ink_builder() {
     --name ink_builder \
     --platform linux/amd64 \
     --detach \
-    --rm public.ecr.aws/p6e8q1z1/ink-dev:2.0.0 sleep 1d 1>&2
+    --rm public.ecr.aws/p6e8q1z1/ink-dev:1.0.0 sleep 1d 1>&2
 }
 
 function ink_build() {


### PR DESCRIPTION
# Description

This PR reverts regression introduced in https://github.com/Cardinal-Cryptography/aleph-node/commit/03af3c3e20ea1618e4fc3b6b81216060cd991ae4#diff-3a41020016879ea871e02f455267f8a057fbdde94bdfb5e3ba8e4cad2a2f2943L16

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Testing:

* https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/7191635945
