### PR TITLE
A0-3737: Support for dynamic sudo in FE bootstrap

### DIFF
--- a/.github/workflows/featurenet-create.yml
+++ b/.github/workflows/featurenet-create.yml
@@ -101,7 +101,7 @@ jobs:
     # to prevent this job to be skipped when on of the parent jobs is skipped
     if: ${{ !cancelled() }}
     name: Create featurenet from branch
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create.yml@A0-3737
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create.yml@v6
     secrets: inherit
     with:
       featurenet-name: ${{ inputs.featurenet-name }}

--- a/.github/workflows/featurenet-create.yml
+++ b/.github/workflows/featurenet-create.yml
@@ -38,6 +38,11 @@ on:
         description: 'Use short session aleph-node binary'
         required: true
         type: boolean
+      sudo-account-id:
+        description: 'Sudo account ID'
+        type: string
+        required: true
+        default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 
 jobs:
   validate-inputs:
@@ -96,7 +101,7 @@ jobs:
     # to prevent this job to be skipped when on of the parent jobs is skipped
     if: ${{ !cancelled() }}
     name: Create featurenet from branch
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create.yml@v6
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create.yml@A0-3737
     secrets: inherit
     with:
       featurenet-name: ${{ inputs.featurenet-name }}
@@ -105,3 +110,4 @@ jobs:
       expiration: ${{ inputs.expiration }}
       internal: ${{ inputs.internal && true || false }}
       delete-first: true
+      sudo-account-id: ${{ inputs.sudo-account-id }}

--- a/.github/workflows/featurenet-update.yml
+++ b/.github/workflows/featurenet-update.yml
@@ -108,7 +108,7 @@ jobs:
     # to prevent this job to be skipped when on of the parent jobs is skipped
     if: ${{ !cancelled() }}
     name: Update featurenet
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create.yml@A0-3737
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create.yml@v6
     secrets: inherit
     with:
       featurenet-name: ${{ inputs.featurenet-name }}

--- a/.github/workflows/featurenet-update.yml
+++ b/.github/workflows/featurenet-update.yml
@@ -46,6 +46,11 @@ on:
         description: 'Use short session aleph-node binary'
         required: true
         type: boolean
+      sudo-account-id:
+        description: 'Sudo account ID'
+        type: string
+        required: true
+        default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 
 jobs:
   validate-inputs:
@@ -103,7 +108,7 @@ jobs:
     # to prevent this job to be skipped when on of the parent jobs is skipped
     if: ${{ !cancelled() }}
     name: Update featurenet
-    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create.yml@v6
+    uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create.yml@A0-3737
     secrets: inherit
     with:
       featurenet-name: ${{ inputs.featurenet-name }}
@@ -112,3 +117,4 @@ jobs:
       expiration: ${{ inputs.expiration }}
       internal: ${{ inputs.internal && true || false }}
       rolling-update-partition: ${{ inputs.rolling-update-partition }}
+      sudo-account-id: ${{ inputs.sudo-account-id }}

--- a/.github/workflows/featurenet-update.yml
+++ b/.github/workflows/featurenet-update.yml
@@ -46,11 +46,6 @@ on:
         description: 'Use short session aleph-node binary'
         required: true
         type: boolean
-      sudo-account-id:
-        description: 'Sudo account ID'
-        type: string
-        required: true
-        default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 
 jobs:
   validate-inputs:
@@ -117,4 +112,5 @@ jobs:
       expiration: ${{ inputs.expiration }}
       internal: ${{ inputs.internal && true || false }}
       rolling-update-partition: ${{ inputs.rolling-update-partition }}
-      sudo-account-id: ${{ inputs.sudo-account-id }}
+      # temporary solution before clean up of not required arguments in update
+      sudo-account-id: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'

--- a/.github/workflows/nightly-fe-e2e-tests.yml
+++ b/.github/workflows/nightly-fe-e2e-tests.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check-vars-and-secrets:

--- a/.github/workflows/nightly-update-net-tests.yml
+++ b/.github/workflows/nightly-update-net-tests.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check-vars-and-secrets:


### PR DESCRIPTION
# Description

This PR adds the possibility to spawn FE with a custom sudo account id. 

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing

1. [Run with default parameters, Alice is sudo](https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/7258857766) 

![image](https://github.com/Cardinal-Cryptography/aleph-node/assets/3909333/9e238696-cffd-4dac-9457-5a25f21151ef)

![image](https://github.com/Cardinal-Cryptography/aleph-node/assets/3909333/bad9695c-afa1-4f4e-ac71-f55faa5ba5d1)

![image](https://github.com/Cardinal-Cryptography/aleph-node/assets/3909333/4c49ab09-ee5f-466a-98ff-c8b4305d84c2)


2. [Run with custom sudo account id, `5EyDzpeMZqrLsCoUMn6fPVYvGiScMfuA3LPAodQecvSmnLmK` is sudo](https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/7258896842)

![image](https://github.com/Cardinal-Cryptography/aleph-node/assets/3909333/0089703c-00c2-4152-b134-736d9eca61f0)

![image](https://github.com/Cardinal-Cryptography/aleph-node/assets/3909333/a7936b0a-05e2-4f17-9778-be0a0880e6ac)

![image](https://github.com/Cardinal-Cryptography/aleph-node/assets/3909333/a12831df-e2c7-4ac9-baab-9173714aeeac)

## Related PRs

https://github.com/Cardinal-Cryptography/github-actions/pull/36
https://github.com/Cardinal-Cryptography/featurenet-template/pull/19

