### PR TITLE
A0-3782: Fix order of aleph authorities

### DIFF
--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -33,7 +33,7 @@ pub mod pallet {
     };
     use pallet_session::SessionManager;
     use primitives::SessionInfoProvider;
-    use sp_std::collections::btree_set::BTreeSet;
+    use sp_std::collections::btree_map::BTreeMap;
     #[cfg(feature = "std")]
     use sp_std::marker::PhantomData;
 
@@ -132,21 +132,15 @@ pub mod pallet {
         fn get_authorities_for_next_session(
             next_authorities: Vec<(&T::AccountId, T::AuthorityId)>,
         ) -> Vec<T::AuthorityId> {
-            let next_committee_ids: BTreeSet<_> =
-                NextFinalityCommittee::<T>::get().into_iter().collect();
-
-            let next_committee_authorities: Vec<_> = next_authorities
+            let mut account_to_authority: BTreeMap<_, _> = next_authorities.into_iter().collect();
+            let stored_accounts = NextFinalityCommittee::<T>::get();
+            let stored_accounts_len = stored_accounts.len();
+            let next_committee_authorities: Vec<_> = stored_accounts
                 .into_iter()
-                .filter_map(|(account_id, auth_id)| {
-                    if next_committee_ids.contains(account_id) {
-                        Some(auth_id)
-                    } else {
-                        None
-                    }
-                })
+                .filter_map(|account_id| account_to_authority.remove(&account_id))
                 .collect();
 
-            if next_committee_authorities.len() != next_committee_ids.len() {
+            if next_committee_authorities.len() != stored_accounts_len {
                 log::error!(
                     target: LOG_TARGET,
                     "Not all committee members were converted to keys."

--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -133,14 +133,14 @@ pub mod pallet {
             next_authorities: Vec<(&T::AccountId, T::AuthorityId)>,
         ) -> Vec<T::AuthorityId> {
             let mut account_to_authority: BTreeMap<_, _> = next_authorities.into_iter().collect();
-            let stored_accounts = NextFinalityCommittee::<T>::get();
-            let stored_accounts_len = stored_accounts.len();
-            let next_committee_authorities: Vec<_> = stored_accounts
+            let next_committee_accounts = NextFinalityCommittee::<T>::get();
+            let expected_len = next_committee_accounts.len();
+            let next_committee_authorities: Vec<_> = next_committee_accounts
                 .into_iter()
                 .filter_map(|account_id| account_to_authority.remove(&account_id))
                 .collect();
 
-            if next_committee_authorities.len() != stored_accounts_len {
+            if next_committee_authorities.len() != expected_len {
                 log::error!(
                     target: LOG_TARGET,
                     "Not all committee members were converted to keys."

--- a/pallets/aleph/src/tests.rs
+++ b/pallets/aleph/src/tests.rs
@@ -87,6 +87,21 @@ fn test_session_rotation() {
 }
 
 #[test]
+fn test_session_rotation_with_larger_permuted_authorities() {
+    new_test_ext(&[(1u64, 1u64), (2u64, 2u64)]).execute_with(|| {
+        initialize_session();
+        run_session(1);
+
+        NextFinalityCommittee::<Test>::put(vec![5, 6]);
+        let new_validators = new_session_validators(&[1, 2]);
+        let queued_validators = new_session_validators(&[6, 4, 5]);
+        Aleph::on_new_session(true, new_validators, queued_validators);
+        assert_eq!(Aleph::authorities(), to_authorities(&[1, 2]));
+        assert_eq!(Aleph::next_authorities(), to_authorities(&[5, 6]));
+    })
+}
+
+#[test]
 fn test_emergency_signer() {
     new_test_ext(&[(1u64, 1u64), (2u64, 2u64)]).execute_with(|| {
         initialize_session();


### PR DESCRIPTION
# Description

The order of aleph authorities returned from `get_authorities_for_next_session` was not matching the order kept in `NextFinalityCommittee`. Due to conversion of `NextFinalityCommittee` into `BTree` we were losing the order initially created by shuffling the validators list in `pallets::committee_management::impls::shuffle_order_for_session`. Instead, the `next_committee_authorities` inferred its ordering according to `next_authorities` argument passed to `get_authorities_for_next_session` which had a different ordering (most likely matching the order of the **producers** list given in `pallets::committee_management::impls::shuffle_order_for_session`).

For a fix, instead converting `NextFinalityCommittee` to `BTreeSet`, convert `next_authorities` to `BTreeMap` and obtain the authority ids from the map by going in order of `NextFinalityCommittee`.

Bug most likely introduced by the `BTree` optimization [here](https://github.com/Cardinal-Cryptography/aleph-node/pull/1092/files#r1155123930). Previously there was an iteration in order of `NextFinalityCommittee` and extracting the corresponding authority ids by a linear sweep over `next_authorities`.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have added tests **...**
- I have bumped `spec_version` and `transaction_version` **???**
- Checked in polkadot UI that `chain_state::aleph::nextAuthorities` is in the same order as `chain_state::aleph::nextFinalityCommittee`
