### PR TITLE
A0-3852: Add config parameter to `run_nodes.sh` for liminal build

### DIFF
--- a/baby-liminal-extension/Cargo.lock
+++ b/baby-liminal-extension/Cargo.lock
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.2.0"
-source = "git+https://github.com/Cardinal-Cryptography/pse-halo2?branch=substrate-compatible#90a1eeb58cb21bc5de100c46d8cfcdf32138f5af"
+source = "git+https://github.com/Cardinal-Cryptography/pse-halo2?branch=aleph#6747312150634f2fd8f7a563448306132e0fd89e"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/scripts/run_nodes.sh
+++ b/scripts/run_nodes.sh
@@ -84,6 +84,7 @@ DONT_BOOTSTRAP=${DONT_BOOTSTRAP:-""}
 DONT_BUILD_ALEPH_NODE=${DONT_BUILD_ALEPH_NODE:-""}
 DONT_DELETE_DB=${DONT_DELETE_DB:-""}
 DONT_REMOVE_ABFT_BACKUPS=${DONT_REMOVE_ABFT_BACKUPS:-""}
+LIMINAL_BUILD=${LIMINAL_BUILD:-""}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -117,6 +118,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dont-remove-abft-backups)
       DONT_REMOVE_ABFT_BACKUPS="true"
+      shift
+      ;;
+    --liminal)
+      LIMINAL_BUILD="liminal"
       shift
       ;;
     *)
@@ -228,7 +233,7 @@ fi
 
 if [[ -z "${DONT_BUILD_ALEPH_NODE}" ]]; then
   info "Building testing aleph-node binary (short session)."
-  cargo build --release -p aleph-node --features "short_session enable_treasury_proposals"
+  cargo build --release -p aleph-node --features "short_session enable_treasury_proposals ${LIMINAL_BUILD}"
 elif [[ ! -x "${ALEPH_NODE}" ]]; then
   error "${ALEPH_NODE} does not exist or it's not an executable file!"
 fi

--- a/scripts/run_nodes.sh
+++ b/scripts/run_nodes.sh
@@ -73,6 +73,8 @@ Usage:
       set to not delete AlephBFT backups; by default they are removed since
       this script is intended to bootstrap chain by default, in which case you do not want to have
       them in 99% of scenarios
+    [--liminal]
+      build nodes with liminal feature
 EOF
   exit 0
 }


### PR DESCRIPTION
# Description

Just a minor change to `./scripts/run_nodes.sh` allowing for launching local liminal chain (with `./scripts/run_nodes.sh --liminal`).

## Type of change

- New feature (non-breaking change which adds functionality)
