### PR TITLE
A0-1306: PRUNING_ENABLED flag for docker_entrypoint.sh

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -33,6 +33,7 @@ DB_CACHE=${DB_CACHE:-1024}
 RUNTIME_CACHE_SIZE=${RUNTIME_CACHE_SIZE:-2}
 MAX_RUNTIME_INSTANCES=${MAX_RUNTIME_INSTANCES:-8}
 BACKUP_PATH=${BACKUP_PATH:-${BASE_PATH}/backup-stash}
+PRUNING_ENABLED=${PRUNING_ENABLED:-false}
 
 if [[ "true" == "$PURGE_BEFORE_START" ]]; then
   echo "Purging chain (${CHAIN}) at path ${BASE_PATH}"
@@ -120,6 +121,10 @@ if [[ "false" == "${VALIDATOR}" ]]; then
   # We will never use this address, but because of the current shape of our code we need to have something here.
   # This address is one reserved for documentation, so attempting to connect to it should always fail.
   PUBLIC_VALIDATOR_ADDRESS=${PUBLIC_VALIDATOR_ADDRESS:-"192.0.2.1:${VALIDATOR_PORT}"}
+fi
+
+if [[ "true" == "${PRUNING_ENABLED}" ]]; then
+    ARGS+=(--enable-pruning)
 fi
 
 ARGS+=(--public-validator-addresses "${PUBLIC_VALIDATOR_ADDRESS}")

--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -33,6 +33,7 @@ DB_CACHE=${DB_CACHE:-1024}
 RUNTIME_CACHE_SIZE=${RUNTIME_CACHE_SIZE:-2}
 MAX_RUNTIME_INSTANCES=${MAX_RUNTIME_INSTANCES:-8}
 BACKUP_PATH=${BACKUP_PATH:-${BASE_PATH}/backup-stash}
+DATABASE_ENGINE=${DATABASE_ENGINE:-}
 PRUNING_ENABLED=${PRUNING_ENABLED:-false}
 
 if [[ "true" == "$PURGE_BEFORE_START" ]]; then
@@ -121,6 +122,10 @@ if [[ "false" == "${VALIDATOR}" ]]; then
   # We will never use this address, but because of the current shape of our code we need to have something here.
   # This address is one reserved for documentation, so attempting to connect to it should always fail.
   PUBLIC_VALIDATOR_ADDRESS=${PUBLIC_VALIDATOR_ADDRESS:-"192.0.2.1:${VALIDATOR_PORT}"}
+fi
+
+if [[ -n "${DATABASE_ENGINE}" ]]; then
+    ARGS+=(--database "${DATABASE_ENGINE}")
 fi
 
 if [[ "true" == "${PRUNING_ENABLED}" ]]; then


### PR DESCRIPTION
# Description

Added a PRUNING_ENABLED flag to docker_entrypoint.sh. It allows to enable database pruning mode of aleph-node. Note that setting it to true also switches the db backend to paritydb (aleph-node command line params validation switches it).

## Type of change

- New feature (non-breaking change which adds functionality)