### PR TITLE
A0-3861:  Increase MaxCodeLen for contracts.

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -729,7 +729,7 @@ impl pallet_contracts::Config for Runtime {
     type DefaultDepositLimit = ConstU128<{ u128::MAX }>;
     type DepositPerItem = DepositPerItem;
     type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
-    type MaxCodeLen = ConstU32<{ 128 * 1024 }>;
+    type MaxCodeLen = ConstU32<{ 256 * 1024 }>;
     type MaxStorageKeyLen = ConstU32<128>;
     type UnsafeUnstableInterface = ConstBool<false>;
     type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
@@ -1298,7 +1298,7 @@ mod tests {
         let max_code_len: u32 = <Runtime as pallet_contracts::Config>::MaxCodeLen::get();
 
         // The factor comes from allocator, contracts representation, and wasmi
-        let lhs = max_call_depth * (72 * max_code_len + max_heap_size + MAX_STACK_SIZE);
+        let lhs = max_call_depth * (36 * max_code_len + max_heap_size + MAX_STACK_SIZE);
         // We allocate only 75% of all runtime memory to contracts execution. Important: it's not
         // enforeced in wasmtime
         let rhs = MAX_RUNTIME_MEM * 3 / 4;


### PR DESCRIPTION
# Description

THIS IS A RUNTIME-ONLY CHANGE.

Increases the maximum code len for a contract from 128 KB to 256 KB. The reason this is safe is that the constant 72 that we have in our integrity test changed:
- first 72 -> 68 (which we didn't mirror in our repo, but it's here https://github.com/paritytech/polkadot-sdk/blob/06fa111f58b0172c9f4ba7c209c8b6945787faeb/substrate/frame/contracts/src/lib.rs#L439 ) this was a result of changing gas metering
- then 68 -> 32 -- this is a result of updating wasmi to v0.30 which reduces the amount of memory each instruction requires. In slack I include a message from a Pallet Contract Developer which clarifies this further.


# Release note:

- Increased maximum length of a contract from 128KB to 256 KB.