### PR TITLE
A0-3642: Generate release artifacts checksum

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -27,7 +27,6 @@ jobs:
 
       - name: Call action get-ref-properties
         id: get-ref-properties
-        # yamllint disable-line rule:line-length
         uses: Cardinal-Cryptography/github-actions/get-ref-properties@v6
 
       - name: Configure AWS credentials
@@ -59,10 +58,17 @@ jobs:
           aws s3 cp '${{ env.S3BUCKET_URL }}/${{ env.S3BUCKET_FILE }}' \
              'aleph-node-${{ steps.get-ref-properties.outputs.sha }}-linux-amd64.tar.gz'
 
+      - name: Generate release artifacts checksum (SHA256)
+        uses: jmgilman/actions-generate-checksum@v1
+        with:
+          patterns: |
+            *.tar.gz
+
       - name: Add runtime and binary to the release
         uses: softprops/action-gh-release@v1
         with:
           files: |
+            checksum.txt
             aleph-runtime-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
             aleph-node-${{ steps.get-ref-properties.outputs.sha }}-linux-amd64.tar.gz
 

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Generate release artifacts checksum (SHA256)
         uses: jmgilman/actions-generate-checksum@v1
         with:
+          output:
+            checksums-${{ steps.get-ref-properties.outputs.sha }}-linux-amd64.tar.gz.SHA256.txt
           patterns: |
             *.tar.gz
 
@@ -68,7 +70,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            checksum.txt
+            checksums-${{ steps.get-ref-properties.outputs.sha }}-linux-amd64.tar.gz.SHA256.txt
             aleph-runtime-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
             aleph-node-${{ steps.get-ref-properties.outputs.sha }}-linux-amd64.tar.gz
 


### PR DESCRIPTION
# Description

Add SHA256 checksum to all artifacts uploaded in a GH release.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Testing

Tested on my fork:
* [Workflow run](https://github.com/Marcin-Radecki/aleph-node/actions/runs/7567662908/job/20607272006) - with some parts of it commented out to make it work on fork
* published release: https://github.com/Marcin-Radecki/aleph-node/releases/tag/test-tag-40