### PR TITLE
A0-3751: Make our `SyncOracle` compatible with `SyncingService`

### DIFF
--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -245,7 +245,7 @@ fn setup(
             block_relay: None,
         })?;
 
-    let sync_oracle = SyncOracle::new();
+    let (sync_oracle, _) = SyncOracle::new();
 
     let validator_address_cache = match collect_extra_debugging_data {
         true => Some(ValidatorAddressCache::new()),

--- a/finality-aleph/src/party/mod.rs
+++ b/finality-aleph/src/party/mod.rs
@@ -498,7 +498,7 @@ mod tests {
         let readonly_session_authorities = shared_map.read_only();
 
         let chain_state = Arc::new(MockChainState::new());
-        let sync_oracle = SyncOracle::new();
+        let (sync_oracle, _) = SyncOracle::new();
         let session_manager = Arc::new(MockNodeSessionManager::new());
         let session_info = SessionBoundaryInfo::new(session_period);
 

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -924,7 +924,7 @@ mod tests {
         let handler = Handler::new(
             database_io,
             verifier,
-            SyncOracle::new(),
+            SyncOracle::new().0,
             SESSION_BOUNDARY_INFO,
         )
         .expect("mock backend works");
@@ -1839,7 +1839,7 @@ mod tests {
         let mut handler = Handler::new(
             database_io,
             verifier,
-            SyncOracle::new(),
+            SyncOracle::new().0,
             SessionBoundaryInfo::new(SessionPeriod(20)),
         )
         .expect("mock backend works");

--- a/finality-aleph/src/sync_oracle.rs
+++ b/finality-aleph/src/sync_oracle.rs
@@ -26,7 +26,7 @@ pub struct SyncOracle {
 
 impl SyncOracle {
     pub fn new() -> (Self, Arc<AtomicBool>) {
-        let is_major_syncing = Arc::new(AtomicBool::new(false));
+        let is_major_syncing = Arc::new(AtomicBool::new(true));
         let oracle = SyncOracle {
             last_update: Arc::new(Mutex::new(Instant::now() - OFFLINE_THRESHOLD)),
             last_far_behind: Arc::new(Mutex::new(Instant::now())),

--- a/finality-aleph/src/sync_oracle.rs
+++ b/finality-aleph/src/sync_oracle.rs
@@ -20,6 +20,7 @@ const MAJOR_SYNC_THRESHOLD: Duration = Duration::from_secs(10);
 pub struct SyncOracle {
     last_far_behind: Arc<Mutex<Instant>>,
     last_update: Arc<Mutex<Instant>>,
+    // TODO: remove when SyncingService is no longer needed
     is_major_syncing: Arc<AtomicBool>,
 }
 

--- a/finality-aleph/src/sync_oracle.rs
+++ b/finality-aleph/src/sync_oracle.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -17,14 +20,18 @@ const MAJOR_SYNC_THRESHOLD: Duration = Duration::from_secs(10);
 pub struct SyncOracle {
     last_far_behind: Arc<Mutex<Instant>>,
     last_update: Arc<Mutex<Instant>>,
+    is_major_syncing: Arc<AtomicBool>,
 }
 
 impl SyncOracle {
-    pub fn new() -> Self {
-        SyncOracle {
+    pub fn new() -> (Self, Arc<AtomicBool>) {
+        let is_major_syncing = Arc::new(AtomicBool::new(false));
+        let oracle = SyncOracle {
             last_update: Arc::new(Mutex::new(Instant::now() - OFFLINE_THRESHOLD)),
             last_far_behind: Arc::new(Mutex::new(Instant::now())),
-        }
+            is_major_syncing: is_major_syncing.clone(),
+        };
+        (oracle, is_major_syncing)
     }
 
     pub fn update_behind(&self, behind: u32) {
@@ -33,16 +40,20 @@ impl SyncOracle {
         if behind > FAR_BEHIND_THRESHOLD {
             *self.last_far_behind.lock() = now;
         }
+        self.major_sync();
     }
 
     pub fn major_sync(&self) -> bool {
-        self.last_far_behind.lock().elapsed() < MAJOR_SYNC_THRESHOLD
+        let is_major_syncing = self.last_far_behind.lock().elapsed() < MAJOR_SYNC_THRESHOLD;
+        self.is_major_syncing
+            .store(is_major_syncing, Ordering::Relaxed);
+        is_major_syncing
     }
 }
 
 impl Default for SyncOracle {
     fn default() -> Self {
-        SyncOracle::new()
+        SyncOracle::new().0
     }
 }
 


### PR DESCRIPTION
# Description

Our `SyncOracle` now returns an `AtomicBool` denoting if we're in major sync.

## Type of change

- New feature (non-breaking change which adds functionality)
