### PR TITLE
A0-3899: Our base protocol outline

### DIFF
--- a/finality-aleph/src/base_protocol/handler.rs
+++ b/finality-aleph/src/base_protocol/handler.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+
+use sc_network::{ExtendedPeerInfo, PeerId};
+use sc_network_common::role::Roles;
+use sp_runtime::traits::{Block, Header};
+
+use crate::{BlockHash, BlockNumber};
+
+struct PeerInfo {
+    role: Roles,
+}
+
+/// Handler for the base protocol.
+pub struct Handler {
+    peers: HashMap<PeerId, PeerInfo>,
+}
+
+impl Handler {
+    /// Create a new handler.
+    pub fn new() -> Self {
+        Handler {
+            peers: HashMap::new(),
+        }
+    }
+
+    /// Returns a list of connected peers with some additional information.
+    // TODO(A0-3886): This shouldn't need to return the substrate type after replacing RPCs.
+    // In particular, it shouldn't depend on `B`.
+    pub fn peers_info<B>(&self) -> Vec<(PeerId, ExtendedPeerInfo<B>)>
+    where
+        B: Block<Hash = BlockHash>,
+        B::Header: Header<Number = BlockNumber>,
+    {
+        self.peers
+            .iter()
+            .map(|(id, info)| {
+                (
+                    *id,
+                    ExtendedPeerInfo {
+                        roles: info.role,
+                        best_hash: Default::default(),
+                        best_number: 0,
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{aleph_primitives::Block, base_protocol::handler::Handler};
+
+    #[test]
+    fn initially_no_peers() {
+        let handler = Handler::new();
+        assert!(
+            handler.peers_info::<Block>().is_empty(),
+            "there should be no peers initially"
+        );
+    }
+}

--- a/finality-aleph/src/base_protocol/mod.rs
+++ b/finality-aleph/src/base_protocol/mod.rs
@@ -1,0 +1,8 @@
+//TODO(A0-3750): This code should be used.
+#![allow(dead_code)]
+mod handler;
+mod service;
+
+pub use service::Service;
+
+const LOG_TARGET: &str = "aleph-base-protocol";

--- a/finality-aleph/src/base_protocol/service.rs
+++ b/finality-aleph/src/base_protocol/service.rs
@@ -1,0 +1,115 @@
+use std::{
+    fmt::{Display, Formatter, Result as FmtResult},
+    sync::{
+        atomic::{AtomicBool, AtomicUsize},
+        Arc,
+    },
+};
+
+use futures::stream::StreamExt;
+use log::{debug, trace, warn};
+use sc_network_common::sync::SyncEvent;
+use sc_network_sync::{service::chain_sync::ToServiceCommand, SyncingService};
+use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
+use sp_runtime::traits::{Block, Header};
+
+use crate::{
+    base_protocol::{handler::Handler, LOG_TARGET},
+    BlockHash, BlockNumber,
+};
+
+#[derive(Debug)]
+pub enum Error {
+    NoIncomingCommands,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        use Error::*;
+        match self {
+            NoIncomingCommands => write!(f, "Channel with commands from user closed."),
+        }
+    }
+}
+
+/// A service that needs to be run to have the base protocol of the network work.
+pub struct Service<B>
+where
+    B: Block<Hash = BlockHash>,
+    B::Header: Header<Number = BlockNumber>,
+{
+    handler: Handler,
+    commands_from_user: TracingUnboundedReceiver<ToServiceCommand<B>>,
+    events_for_users: Vec<TracingUnboundedSender<SyncEvent>>,
+}
+
+impl<B> Service<B>
+where
+    B: Block<Hash = BlockHash>,
+    B::Header: Header<Number = BlockNumber>,
+{
+    /// Create a new service.
+    // TODO(A0-3886): This shouldn't need to return the substrate type after replacing RPCs.
+    // In particular, it shouldn't depend on `B`. This is also the only reason why
+    // the `major_sync` argument is needed.
+    pub fn new(major_sync: Arc<AtomicBool>) -> (Self, SyncingService<B>) {
+        let (commands_for_service, commands_from_user) =
+            tracing_unbounded("mpsc_base_protocol", 100_000);
+        (
+            Service {
+                handler: Handler::new(),
+                commands_from_user,
+                events_for_users: Vec::new(),
+            },
+            SyncingService::new(
+                commands_for_service,
+                // We don't care about this one, so a dummy value.
+                Arc::new(AtomicUsize::new(0)),
+                major_sync,
+            ),
+        )
+    }
+
+    fn handle_command(&mut self, command: ToServiceCommand<B>) {
+        use ToServiceCommand::*;
+        match command {
+            EventStream(events_for_user) => self.events_for_users.push(events_for_user),
+            PeersInfo(response) => {
+                if response.send(self.handler.peers_info()).is_err() {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Failed to send response to peers info request."
+                    );
+                }
+            }
+            BestSeenBlock(response) => {
+                if response.send(None).is_err() {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Failed to send response to best block request."
+                    );
+                }
+            }
+            Status(_) => {
+                // We are explicitly dropping the response channel to cause an `Err(())` to be returned in the interface, as this produces the desired results for us.
+                trace!(target: LOG_TARGET, "Got status request, ignoring.");
+            }
+            _ => {
+                warn!(target: LOG_TARGET, "Got unexpected service command.");
+            }
+        }
+    }
+
+    /// Run the service managing the base protocol.
+    pub async fn run(mut self) -> Result<(), Error> {
+        use Error::*;
+        loop {
+            let command = self
+                .commands_from_user
+                .next()
+                .await
+                .ok_or(NoIncomingCommands)?;
+            self.handle_command(command);
+        }
+    }
+}

--- a/finality-aleph/src/lib.rs
+++ b/finality-aleph/src/lib.rs
@@ -43,6 +43,7 @@ use crate::{
 
 mod abft;
 mod aggregation;
+mod base_protocol;
 mod block;
 mod compatibility;
 mod crypto;


### PR DESCRIPTION
# Description

Adds an outline of the new base protocol, replacement for `SyncingEngine`. Does not have the protocol, but does some of the other things we will need.

I think some of the imports will have to be changed during the next substrate updates, because the definitions are now in different crates, but oh well.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have added tests
- I have created new documentation