### PR TITLE
A0-3838: Updates to dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,36 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: weekly
-      day: sunday
+      interval: daily
+      # UTC time
+      time: "06:00"
     rebase-strategy: disabled
+    commit-message:
+      prefix: "A0-3951: "
+    groups:
+      all-rust-deps:
+        patterns:
+          - "*"
+    pull-request-branch-name:
+      separator: "-"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
       day: sunday
+      # UTC time
+      time: "06:15"
     rebase-strategy: disabled
+    commit-message:
+      prefix: "A0-3952: "
+    groups:
+      all-github-actions:
+        patterns:
+          - "*"
+    pull-request-branch-name:
+      separator: "-"
+    reviewers:
+      - "Marcin-Radecki"
+      - "Mikolaj Gasior"
+


### PR DESCRIPTION
# Description

Based on [https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups), we can enable the following:

* `commit-message.prefix` set to some branch created for general Jira item for dependabot updates. This will be helpful also for audit purposes, as Jira will link all such PRs automatically
* `groups` : make one PR for version updates and another PR for github actions update. We can then change the interval to Daily for version updates (leave Weekly for actions updates), as there will be only one PR raised so costs from CI will be similar to 5 PRs raised per week. Each day, the following will be done:

>    When a scheduled update runs, Dependabot will refresh pull requests for grouped updates using the following rules:

    * If all the same dependencies need to be updated to the same versions, Dependabot will rebase the branch.

    *  If all the same dependencies need to be updated, but a newer version has become available for one (or more) of the dependencies, Dependabot will close the pull request and create a new one.

    * If the dependencies to be updated have changed - for example, if another dependency in the group now has an update available - Dependabot will close the pull request and create a new one.

There’s a small issue now, since we disabled automatic dependabot PR rebases: dependabot PRs get outdated quickly, so what I need to do as the dev person assigned to those PRs is to run `@dependabot rebase`, which takes time to re-run pipelines. We can’t enable automatic rebases as there would be too much noise (e.g. dependabot rebases PRs every time merge to main happens), having Daily Refresh would help here.

* set `pull-request-branch-name.separator` to `-` (now it’s default `/`) - this is to unify approach as developers usually do
* set `schedule.time` 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


