### PR TITLE
A0-3900: Sync handshake logic

### DIFF
--- a/finality-aleph/src/base_protocol/handler.rs
+++ b/finality-aleph/src/base_protocol/handler.rs
@@ -33,6 +33,7 @@ where
 {
     reserved_nodes: HashSet<PeerId>,
     peers: HashMap<PeerId, PeerInfo>,
+    // the below counters and bounds ignore the nodes which belong to `reserved_nodes`
     num_full_in_peers: usize,
     num_full_out_peers: usize,
     num_light_peers: usize,

--- a/finality-aleph/src/base_protocol/handler.rs
+++ b/finality-aleph/src/base_protocol/handler.rs
@@ -82,7 +82,6 @@ where
 
     /// Returns a list of connected peers with some additional information.
     // TODO(A0-3886): This shouldn't need to return the substrate type after replacing RPCs.
-    // In particular, it shouldn't depend on `B`.
     pub fn peers_info(&self) -> Vec<(PeerId, ExtendedPeerInfo<B>)>
     where
         B: Block<Hash = BlockHash>,

--- a/finality-aleph/src/base_protocol/handler.rs
+++ b/finality-aleph/src/base_protocol/handler.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use parity_scale_codec::DecodeAll;
+use parity_scale_codec::{DecodeAll, Error as CodecError};
 use sc_network::{config::FullNetworkConfiguration, ExtendedPeerInfo, PeerId};
 use sc_network_common::{role::Roles, sync::message::BlockAnnouncesHandshake};
 use sp_runtime::traits::{Block, Header, Saturating};
@@ -8,7 +8,7 @@ use sp_runtime::traits::{Block, Header, Saturating};
 use crate::{BlockHash, BlockNumber};
 
 pub enum ConnectError {
-    BadlyEncodedHandshake,
+    BadlyEncodedHandshake(CodecError),
     BadHandshakeGenesis,
     PeerAlreadyConnected,
     TooManyFullInboundPeers,
@@ -110,7 +110,7 @@ where
         is_inbound: bool,
     ) -> Result<Roles, ConnectError> {
         let handshake = BlockAnnouncesHandshake::<B>::decode_all(&mut &handshake[..])
-            .map_err(|_| ConnectError::BadlyEncodedHandshake)?;
+            .map_err(|e| ConnectError::BadlyEncodedHandshake(e))?;
         if handshake.genesis_hash != self.genesis_hash {
             return Err(ConnectError::BadHandshakeGenesis);
         }

--- a/finality-aleph/src/base_protocol/handler.rs
+++ b/finality-aleph/src/base_protocol/handler.rs
@@ -109,7 +109,7 @@ where
         is_inbound: bool,
     ) -> Result<Roles, ConnectError> {
         let handshake = BlockAnnouncesHandshake::<B>::decode_all(&mut &handshake[..])
-            .map_err(|e| ConnectError::BadlyEncodedHandshake(e))?;
+            .map_err(ConnectError::BadlyEncodedHandshake)?;
         if handshake.genesis_hash != self.genesis_hash {
             return Err(ConnectError::BadHandshakeGenesis);
         }
@@ -163,8 +163,6 @@ where
             self.num_light_peers += 1;
         }
 
-        // TODO(A0-3901): disseminate appropriate `SyncEvent`
-
         Ok(())
     }
 
@@ -186,8 +184,6 @@ where
         } else if info.role.is_light() {
             self.num_light_peers.saturating_dec();
         }
-
-        // TODO(A0-3901): disseminate appropriate `SyncEvent`
 
         Ok(())
     }

--- a/finality-aleph/src/base_protocol/handler.rs
+++ b/finality-aleph/src/base_protocol/handler.rs
@@ -1,32 +1,89 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use sc_network::{ExtendedPeerInfo, PeerId};
-use sc_network_common::role::Roles;
-use sp_runtime::traits::{Block, Header};
+use parity_scale_codec::DecodeAll;
+use sc_network::{config::FullNetworkConfiguration, ExtendedPeerInfo, PeerId};
+use sc_network_common::{role::Roles, sync::message::BlockAnnouncesHandshake};
+use sp_runtime::traits::{Block, Header, Saturating};
 
 use crate::{BlockHash, BlockNumber};
 
+pub enum ConnectError {
+    BadlyEncodedHandshake,
+    BadHandshakeGenesis,
+    PeerAlreadyConnected,
+    TooManyFullInboundPeers,
+    TooManyFullOutboundPeers,
+    TooManyLightPeers,
+}
+
+pub enum DisconnectError {
+    PeerWasNotConnected,
+}
+
 struct PeerInfo {
     role: Roles,
+    is_inbound: bool,
 }
 
 /// Handler for the base protocol.
-pub struct Handler {
+pub struct Handler<B>
+where
+    B: Block<Hash = BlockHash>,
+    B::Header: Header<Number = BlockNumber>,
+{
+    reserved_nodes: HashSet<PeerId>,
     peers: HashMap<PeerId, PeerInfo>,
+    num_full_in_peers: usize,
+    num_full_out_peers: usize,
+    num_light_peers: usize,
+    max_full_in_peers: usize,
+    max_full_out_peers: usize,
+    max_light_peers: usize,
+    genesis_hash: B::Hash,
 }
 
-impl Handler {
+impl<B> Handler<B>
+where
+    B: Block<Hash = BlockHash>,
+    B::Header: Header<Number = BlockNumber>,
+{
     /// Create a new handler.
-    pub fn new() -> Self {
+    pub fn new(genesis_hash: B::Hash, net_config: &FullNetworkConfiguration) -> Self {
+        let reserved_nodes = net_config
+            .network_config
+            .default_peers_set
+            .reserved_nodes
+            .iter()
+            .map(|reserved| reserved.peer_id)
+            .collect();
+
+        // It is assumed that `default_peers_set.out_peers` only refers to full nodes, but
+        // `default_peers_set.in_peers` refers to both full and light nodes.
+        // Moreover, `default_peers_set_num_full` refers to the total of full nodes.
+        let max_full_out_peers =
+            net_config.network_config.default_peers_set.out_peers as usize;
+        let max_full_in_peers =
+            (net_config.network_config.default_peers_set_num_full as usize).saturating_sub(max_full_out_peers);
+        let max_light_peers =
+            (net_config.network_config.default_peers_set.in_peers as usize).saturating_sub(max_full_in_peers);
+
         Handler {
+            reserved_nodes,
             peers: HashMap::new(),
+            max_full_in_peers,
+            max_full_out_peers,
+            max_light_peers,
+            num_full_in_peers: 0,
+            num_full_out_peers: 0,
+            num_light_peers: 0,
+            genesis_hash,
         }
     }
 
     /// Returns a list of connected peers with some additional information.
     // TODO(A0-3886): This shouldn't need to return the substrate type after replacing RPCs.
     // In particular, it shouldn't depend on `B`.
-    pub fn peers_info<B>(&self) -> Vec<(PeerId, ExtendedPeerInfo<B>)>
+    pub fn peers_info(&self) -> Vec<(PeerId, ExtendedPeerInfo<B>)>
     where
         B: Block<Hash = BlockHash>,
         B::Header: Header<Number = BlockNumber>,
@@ -44,6 +101,88 @@ impl Handler {
                 )
             })
             .collect()
+    }
+
+    fn verify_connection(&self, peer_id: PeerId, handshake: Vec<u8>, is_inbound: bool) -> Result<Roles, ConnectError> {
+        let handshake = BlockAnnouncesHandshake::<B>::decode_all(&mut &handshake[..])
+            .map_err(|_| ConnectError::BadlyEncodedHandshake)?;
+        if handshake.genesis_hash != self.genesis_hash {
+            return Err(ConnectError::BadHandshakeGenesis);
+        }
+
+        if self.peers.contains_key(&peer_id) {
+            return Err(ConnectError::PeerAlreadyConnected);
+        }
+
+        if !self.reserved_nodes.contains(&peer_id) {
+            // check slot constraints for full non-reserved nodes
+            if is_inbound && handshake.roles.is_full() && self.num_full_in_peers >= self.max_full_in_peers {
+                return Err(ConnectError::TooManyFullInboundPeers);
+            }
+            if !is_inbound && handshake.roles.is_full() && self.num_full_out_peers >= self.max_full_out_peers {
+                return Err(ConnectError::TooManyFullOutboundPeers);
+            }
+            // check slot constraints for light nodes
+            if handshake.roles.is_light() && self.num_light_peers >= self.max_light_peers {
+                return Err(ConnectError::TooManyLightPeers);
+            }
+        }
+
+        Ok(handshake.roles)
+    }
+
+    pub fn on_peer_connect(
+        &mut self,
+        peer_id: PeerId,
+        handshake: Vec<u8>,
+        is_inbound: bool,
+    ) -> Result<(), ConnectError> {
+        let role = self.verify_connection(peer_id, handshake, is_inbound)?;
+
+        // update peer sets
+        self.peers.insert(
+            peer_id,
+            PeerInfo {
+                role,
+                is_inbound,
+            },
+        );
+
+        if !self.reserved_nodes.contains(&peer_id) {
+            // update slots for full nodes
+            if is_inbound && role.is_full() {
+                self.num_full_in_peers += 1;
+            }
+            if !is_inbound && role.is_full() {
+                self.num_full_out_peers += 1;
+            }
+            // update slots of light nodes
+            if role.is_light() {
+                self.num_light_peers += 1;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn on_peer_disconnect(&mut self, peer_id: PeerId) -> Result<(), DisconnectError> {
+        let info = self.peers.remove(&peer_id).ok_or(DisconnectError::PeerWasNotConnected)?;
+        
+        if !self.reserved_nodes.contains(&peer_id) {
+            // update slots for full nodes
+            if info.is_inbound && info.role.is_full() {
+                self.num_full_in_peers.saturating_dec();
+            }
+            if !info.is_inbound && info.role.is_full() {
+                self.num_full_out_peers.saturating_dec();
+            }
+            // update slots of light nodes
+            if info.role.is_light() {
+                self.num_light_peers.saturating_dec();
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/finality-aleph/src/base_protocol/handler.rs
+++ b/finality-aleph/src/base_protocol/handler.rs
@@ -162,6 +162,8 @@ where
             }
         }
 
+        // TODO(A0-3901): disseminate appropriate `SyncEvent`
+
         Ok(())
     }
 
@@ -182,20 +184,8 @@ where
             }
         }
 
+        // TODO(A0-3901): disseminate appropriate `SyncEvent`
+
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{aleph_primitives::Block, base_protocol::handler::Handler};
-
-    #[test]
-    fn initially_no_peers() {
-        let handler = Handler::new();
-        assert!(
-            handler.peers_info::<Block>().is_empty(),
-            "there should be no peers initially"
-        );
     }
 }

--- a/finality-aleph/src/base_protocol/handler.rs
+++ b/finality-aleph/src/base_protocol/handler.rs
@@ -128,12 +128,14 @@ where
             && self.num_full_in_peers >= self.max_full_in_peers
         {
             return Err(ConnectError::TooManyFullInboundPeers);
-        } else if !is_inbound
+        }
+        if !is_inbound
             && handshake.roles.is_full()
             && self.num_full_out_peers >= self.max_full_out_peers
         {
             return Err(ConnectError::TooManyFullOutboundPeers);
-        } else if handshake.roles.is_light() && self.num_light_peers >= self.max_light_peers {
+        }
+        if handshake.roles.is_light() && self.num_light_peers >= self.max_light_peers {
             return Err(ConnectError::TooManyLightPeers);
         }
 

--- a/finality-aleph/src/base_protocol/handler.rs
+++ b/finality-aleph/src/base_protocol/handler.rs
@@ -130,14 +130,14 @@ where
         {
             return Err(ConnectError::TooManyFullInboundPeers);
         }
-        if !is_inbound
+        else if !is_inbound
             && handshake.roles.is_full()
             && self.num_full_out_peers >= self.max_full_out_peers
         {
             return Err(ConnectError::TooManyFullOutboundPeers);
         }
         // check slot constraints for light nodes
-        if handshake.roles.is_light() && self.num_light_peers >= self.max_light_peers {
+        else if handshake.roles.is_light() && self.num_light_peers >= self.max_light_peers {
             return Err(ConnectError::TooManyLightPeers);
         }
 
@@ -163,11 +163,11 @@ where
         if is_inbound && role.is_full() {
             self.num_full_in_peers += 1;
         }
-        if !is_inbound && role.is_full() {
+        else if !is_inbound && role.is_full() {
             self.num_full_out_peers += 1;
         }
         // update slots of light nodes
-        if role.is_light() {
+        else if role.is_light() {
             self.num_light_peers += 1;
         }
 
@@ -190,11 +190,11 @@ where
         if info.is_inbound && info.role.is_full() {
             self.num_full_in_peers.saturating_dec();
         }
-        if !info.is_inbound && info.role.is_full() {
+        else if !info.is_inbound && info.role.is_full() {
             self.num_full_out_peers.saturating_dec();
         }
         // update slots of light nodes
-        if info.role.is_light() {
+        else if info.role.is_light() {
             self.num_light_peers.saturating_dec();
         }
 

--- a/finality-aleph/src/base_protocol/handler.rs
+++ b/finality-aleph/src/base_protocol/handler.rs
@@ -123,21 +123,18 @@ where
             return Ok(handshake.roles);
         }
 
-        // check slot constraints for full non-reserved nodes
+        // Check slot constraints depending on the node's role and the connection's direction.
         if is_inbound
             && handshake.roles.is_full()
             && self.num_full_in_peers >= self.max_full_in_peers
         {
             return Err(ConnectError::TooManyFullInboundPeers);
-        }
-        else if !is_inbound
+        } else if !is_inbound
             && handshake.roles.is_full()
             && self.num_full_out_peers >= self.max_full_out_peers
         {
             return Err(ConnectError::TooManyFullOutboundPeers);
-        }
-        // check slot constraints for light nodes
-        else if handshake.roles.is_light() && self.num_light_peers >= self.max_light_peers {
+        } else if handshake.roles.is_light() && self.num_light_peers >= self.max_light_peers {
             return Err(ConnectError::TooManyLightPeers);
         }
 
@@ -152,22 +149,18 @@ where
     ) -> Result<(), ConnectError> {
         let role = self.verify_connection(peer_id, handshake, is_inbound)?;
 
-        // update peer sets
         self.peers.insert(peer_id, PeerInfo { role, is_inbound });
 
         if self.reserved_nodes.contains(&peer_id) {
             return Ok(());
         }
 
-        // update slots for full nodes
+        // Assign a slot for the node depending on their role and the connection's direction.
         if is_inbound && role.is_full() {
             self.num_full_in_peers += 1;
-        }
-        else if !is_inbound && role.is_full() {
+        } else if !is_inbound && role.is_full() {
             self.num_full_out_peers += 1;
-        }
-        // update slots of light nodes
-        else if role.is_light() {
+        } else if role.is_light() {
             self.num_light_peers += 1;
         }
 
@@ -186,15 +179,12 @@ where
             return Ok(());
         }
 
-        // update slots for full nodes
+        // Free the slot of the node depending on their role and the connection's direction.
         if info.is_inbound && info.role.is_full() {
             self.num_full_in_peers.saturating_dec();
-        }
-        else if !info.is_inbound && info.role.is_full() {
+        } else if !info.is_inbound && info.role.is_full() {
             self.num_full_out_peers.saturating_dec();
-        }
-        // update slots of light nodes
-        else if info.role.is_light() {
+        } else if info.role.is_light() {
             self.num_light_peers.saturating_dec();
         }
 

--- a/finality-aleph/src/base_protocol/service.rs
+++ b/finality-aleph/src/base_protocol/service.rs
@@ -53,7 +53,11 @@ where
     // TODO(A0-3886): This shouldn't need to return the substrate type after replacing RPCs.
     // In particular, it shouldn't depend on `B`. This is also the only reason why
     // the `major_sync` argument is needed.
-    pub fn new(major_sync: Arc<AtomicBool>, genesis_hash: B::Hash, net_config: &FullNetworkConfiguration) -> (Self, SyncingService<B>) {
+    pub fn new(
+        major_sync: Arc<AtomicBool>,
+        genesis_hash: B::Hash,
+        net_config: &FullNetworkConfiguration,
+    ) -> (Self, SyncingService<B>) {
         let (commands_for_service, commands_from_user) =
             tracing_unbounded("mpsc_base_protocol", 100_000);
         (

--- a/finality-aleph/src/base_protocol/service.rs
+++ b/finality-aleph/src/base_protocol/service.rs
@@ -8,6 +8,7 @@ use std::{
 
 use futures::stream::StreamExt;
 use log::{debug, trace, warn};
+use sc_network::config::FullNetworkConfiguration;
 use sc_network_common::sync::SyncEvent;
 use sc_network_sync::{service::chain_sync::ToServiceCommand, SyncingService};
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
@@ -38,7 +39,7 @@ where
     B: Block<Hash = BlockHash>,
     B::Header: Header<Number = BlockNumber>,
 {
-    handler: Handler,
+    handler: Handler<B>,
     commands_from_user: TracingUnboundedReceiver<ToServiceCommand<B>>,
     events_for_users: Vec<TracingUnboundedSender<SyncEvent>>,
 }
@@ -52,12 +53,12 @@ where
     // TODO(A0-3886): This shouldn't need to return the substrate type after replacing RPCs.
     // In particular, it shouldn't depend on `B`. This is also the only reason why
     // the `major_sync` argument is needed.
-    pub fn new(major_sync: Arc<AtomicBool>) -> (Self, SyncingService<B>) {
+    pub fn new(major_sync: Arc<AtomicBool>, genesis_hash: B::Hash, net_config: &FullNetworkConfiguration) -> (Self, SyncingService<B>) {
         let (commands_for_service, commands_from_user) =
             tracing_unbounded("mpsc_base_protocol", 100_000);
         (
             Service {
-                handler: Handler::new(),
+                handler: Handler::new(genesis_hash, net_config),
                 commands_from_user,
                 events_for_users: Vec::new(),
             },


### PR DESCRIPTION
# Description

Add logic for handshake and peer slot constraints verification. The verification part checks the genesis hash contained in the handshake, and checks if we can connect the peer according to the specified constraints. Added logic for peer sets management and counting the peers of a particular role and direction (full inbound, full outbound, light).

The logic of accepting peers depending on their role and available spots has been rewritten to be more readable and should preserve the previous logic of `SyncingEngine`. The peer slot rules are:
* reserved nodes (those who have been specified during construction of `Handler` as `reserved_nodes`) can freely connect and disconnect with no constraints.
* there are separate bounds on the number of **inbound** and **outbound** full nodes.
* there is a bound on the **light** nodes.
* The above bounds **ignore** the reserved nodes.

Removed the `mod test` because we can't construct the `Handler` now without the `FullNetworkConfiguration`, and it's best to wait for the substrate update before using it.

## Type of change
- New feature (non-breaking change which adds functionality)

# Checklist:
- I have made corresponding changes to the existing documentation
