### PR TITLE
A0-4009: Bump node and runtime spec_version and tx version in release-13 branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-node"
-version = "0.13.0+dev"
+version = "0.13.0"
 dependencies = [
  "aleph-runtime",
  "finality-aleph",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-runtime"
-version = "0.13.0+dev"
+version = "0.13.0"
 dependencies = [
  "baby-liminal-extension",
  "frame-benchmarking",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-node"
-version = "0.13.0+dev"
+version = "0.13.0"
 description = "Aleph node binary"
 build = "build.rs"
 license = "GPL-3.0-or-later"

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-runtime"
-version = "0.13.0+dev"
+version = "0.13.0"
 license = "GPL-3.0-or-later"
 authors.workspace = true
 edition.workspace = true

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -97,10 +97,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 67,
+    spec_version: 69,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 17,
+    transaction_version: 18,
     state_version: 0,
 };
 


### PR DESCRIPTION
# Description

* bump `spec_version` and `transaction_version`
* bump runtime and node version

Current `spec_version` and `transaction_version`  on Testnet in Mainet is the same and as follows: `68` and `17`.
