### PR TITLE
A0-3219: Remove deprecated --execution flag from docker_entrypoint.sh

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -43,7 +43,6 @@ fi
 
 ARGS=(
   --validator
-  --execution Native
   --name "${NAME}"
   --base-path "${BASE_PATH}"
   --pool-limit "${POOL_LIMIT}"


### PR DESCRIPTION
# Description

As per https://github.com/paritytech/substrate/pull/14387, `--execution` flag is already deprecated (from AlephNode 12.X version). 

This PR clears out warning raised when `aleph-node` starts
```
CLI parameter `--execution` has no effect anymore and will be removed in the future!
```

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

