### PR TITLE
A0-4055: hide on-chain verifier also behind runtime checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,6 +844,7 @@ dependencies = [
  "halo2_proofs",
  "log",
  "pallet-contracts",
+ "pallet-feature-control",
  "pallet-vk-storage",
  "parity-scale-codec",
  "paste",

--- a/baby-liminal-extension/Cargo.lock
+++ b/baby-liminal-extension/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "ink",
  "log",
  "pallet-contracts",
+ "pallet-feature-control",
  "pallet-vk-storage",
  "parity-scale-codec",
  "paste",

--- a/baby-liminal-extension/Cargo.toml
+++ b/baby-liminal-extension/Cargo.toml
@@ -23,6 +23,8 @@ frame-system = { git = "https://github.com/Cardinal-Cryptography/polkadot-sdk.gi
 pallet-contracts = { git = "https://github.com/Cardinal-Cryptography/polkadot-sdk.git", branch = "aleph-v1.2.0", default-features = false, optional = true }
 sp-std = { git = "https://github.com/Cardinal-Cryptography/polkadot-sdk.git", branch = "aleph-v1.2.0", default-features = false, optional = true }
 
+pallet-feature-control = { path = "../pallets/feature-control", default-features = false, optional = true }
+
 ## Proof verification dependencies:
 
 aleph-runtime-interfaces = { path = "../runtime-interfaces", default-features = false, optional = true }
@@ -51,6 +53,7 @@ runtime = [
     "frame-system",
     "pallet-contracts",
     "sp-std",
+    "pallet-feature-control",
     "pallet-vk-storage",
     "aleph-runtime-interfaces/liminal",
 ]
@@ -62,6 +65,7 @@ runtime-std = [
     "frame-system/std",
     "pallet-contracts/std",
     "sp-std/std",
+    "pallet-feature-control/std",
     "pallet-vk-storage/std",
     "aleph-runtime-interfaces/liminal-std",
 ]

--- a/baby-liminal-extension/src/backend/executor.rs
+++ b/baby-liminal-extension/src/backend/executor.rs
@@ -1,5 +1,4 @@
 use aleph_runtime_interfaces::snark_verifier::{verify, VerifierError};
-use pallet_contracts::Config as ContractsConfig;
 use pallet_vk_storage::{Config as VkStorageConfig, VerificationKeys};
 
 use crate::args::VerifyArgs;
@@ -8,10 +7,6 @@ use crate::args::VerifyArgs;
 pub trait BackendExecutor {
     fn verify(args: VerifyArgs) -> Result<(), VerifierError>;
 }
-
-/// Minimal runtime configuration required by the standard chain extension executor.
-pub trait MinimalRuntime: VkStorageConfig + ContractsConfig {}
-impl<R: VkStorageConfig + ContractsConfig> MinimalRuntime for R {}
 
 /// Default implementation for the chain extension mechanics.
 impl<Runtime: VkStorageConfig> BackendExecutor for Runtime {

--- a/baby-liminal-extension/src/backend/tests.rs
+++ b/baby-liminal-extension/src/backend/tests.rs
@@ -6,7 +6,7 @@ mod weighting;
 use aleph_runtime::Runtime as AlephRuntime;
 use aleph_runtime_interfaces::snark_verifier::VerifierError::*;
 use frame_support::pallet_prelude::Weight;
-use pallet_contracts::chain_extension::{ChainExtension, RetVal};
+use pallet_contracts::chain_extension::RetVal;
 
 use crate::{
     backend::{
@@ -34,11 +34,6 @@ fn simulate_verify<Exc: BackendExecutor>(expected_ret_val: u32) {
     let expected_charged = <TestWeight as WeightInfo>::verify()
         + TestWeight::verify_read_args(verify_args().len() as u32);
     assert_eq!(charged, expected_charged);
-}
-
-#[test]
-fn extension_is_enabled() {
-    assert!(BabyLiminalChainExtension::<AlephRuntime>::enabled())
 }
 
 #[test]

--- a/baby-liminal-extension/src/backend/tests.rs
+++ b/baby-liminal-extension/src/backend/tests.rs
@@ -6,7 +6,7 @@ mod weighting;
 use aleph_runtime::Runtime as AlephRuntime;
 use aleph_runtime_interfaces::snark_verifier::VerifierError::*;
 use frame_support::pallet_prelude::Weight;
-use pallet_contracts::chain_extension::RetVal;
+use pallet_contracts::chain_extension::{ChainExtension, RetVal};
 
 use crate::{
     backend::{
@@ -58,6 +58,11 @@ fn verify__charges_before_reading_arguments() {
 #[allow(non_snake_case)]
 fn verify__positive_scenario() {
     simulate_verify::<VerifyOkayer>(VERIFY_SUCCESS)
+}
+
+#[test]
+fn extension_is_enabled() {
+    assert!(!BabyLiminalChainExtension::<AlephRuntime>::enabled())
 }
 
 #[test]

--- a/baby-liminal-extension/src/backend/tests.rs
+++ b/baby-liminal-extension/src/backend/tests.rs
@@ -61,11 +61,6 @@ fn verify__positive_scenario() {
 }
 
 #[test]
-fn extension_is_enabled() {
-    assert!(!BabyLiminalChainExtension::<AlephRuntime>::enabled())
-}
-
-#[test]
 #[allow(non_snake_case)]
 fn verify__pallet_says_input_deserialization_failed() {
     simulate_verify::<VerifyErrorer<{ DeserializingPublicInputFailed }>>(

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -34,6 +34,8 @@ use frame_system::{EnsureRoot, EnsureSignedBy};
 use frame_try_runtime::UpgradeCheckSelect;
 pub use pallet_balances::Call as BalancesCall;
 use pallet_committee_management::SessionAndEraManager;
+#[cfg(feature = "liminal")]
+use pallet_feature_control::Feature;
 use pallet_session::QueuedKeys;
 pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
@@ -56,7 +58,8 @@ pub use sp_runtime::BuildStorage;
 use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
     traits::{
-        AccountIdLookup, BlakeTwo256, Block as BlockT, Bounded, ConvertInto, One, OpaqueKeys,
+        AccountIdLookup, BlakeTwo256, Block as BlockT, Bounded, Convert, ConvertInto, One,
+        OpaqueKeys,
     },
     transaction_validity::{TransactionSource, TransactionValidity},
     ApplyExtrinsicResult, FixedU128, RuntimeDebug,
@@ -431,10 +434,6 @@ parameter_types! {
     pub const NominationPoolsPalletId: PalletId = PalletId(*b"py/nopls");
     pub const MaxPointsToBalance: u8 = 10;
 }
-
-#[cfg(feature = "liminal")]
-use pallet_feature_control::Feature;
-use sp_runtime::traits::Convert;
 
 pub struct BalanceToU256;
 

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -432,6 +432,7 @@ parameter_types! {
     pub const MaxPointsToBalance: u8 = 10;
 }
 
+#[cfg(feature = "liminal")]
 use pallet_feature_control::Feature;
 use sp_runtime::traits::Convert;
 

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -143,11 +143,26 @@ parameter_types! {
     pub const SS58Prefix: u8 = ADDRESSES_ENCODING;
 }
 
+pub enum CallFilter {}
+impl Contains<RuntimeCall> for CallFilter {
+    fn contains(call: &RuntimeCall) -> bool {
+        match call {
+            #[cfg(feature = "liminal")]
+            RuntimeCall::VkStorage(_) => {
+                pallet_feature_control::Pallet::<Runtime>::is_feature_enabled(
+                    Feature::OnChainVerifier,
+                )
+            }
+            _ => true,
+        }
+    }
+}
+
 // Configure FRAME pallets to include in runtime.
 
 impl frame_system::Config for Runtime {
     /// The basic call filter to use in dispatchable.
-    type BaseCallFilter = frame_support::traits::Everything;
+    type BaseCallFilter = CallFilter;
     /// Block & extrinsics weights: base values and limits.
     type BlockWeights = BlockWeights;
     /// The maximum length of a block (in bytes).
@@ -417,6 +432,7 @@ parameter_types! {
     pub const MaxPointsToBalance: u8 = 10;
 }
 
+use pallet_feature_control::Feature;
 use sp_runtime::traits::Convert;
 
 pub struct BalanceToU256;


### PR DESCRIPTION
# Description

We are using `feature-control` pallet to ensure that nobody can access on-chain verifier related code, unless this feature is enabled.

E2E tests will be added after this and #1614 are merged, so that we don't have to tackle with `liminal` compilation feature in e2e-test launching setup.

## Type of change

- New feature (non-breaking change which adds functionality)
