### PR TITLE
A0-4053: Remove without-storage-info macro where possible

### DIFF
--- a/pallets/feature-control/src/lib.rs
+++ b/pallets/feature-control/src/lib.rs
@@ -65,7 +65,6 @@ pub mod pallet {
 
     #[pallet::pallet]
     #[pallet::storage_version(STORAGE_VERSION)]
-    #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 
     #[pallet::call]

--- a/pallets/vk-storage/src/lib.rs
+++ b/pallets/vk-storage/src/lib.rs
@@ -73,7 +73,6 @@ pub mod pallet {
 
     #[pallet::pallet]
     #[pallet::storage_version(STORAGE_VERSION)]
-    #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 
     #[pallet::storage]


### PR DESCRIPTION
# Description

Complying with https://github.com/paritytech/polkadot-sdk/issues/323 in two pallets (out of five). The other (`aleph`, `committee_management` and `elections`) contain vectors, but they are sudo-controlled, so we should be kinda safe (although we might want to come up with some size bounds there at some point).

## Type of change

- Bug fix (non-breaking change which fixes an issue)
