### PR TITLE
A0-3728: script for fixing double providers counter

### DIFF
--- a/scripts/accounts-invariants/pallet-balances-maintenance.py
+++ b/scripts/accounts-invariants/pallet-balances-maintenance.py
@@ -407,7 +407,8 @@ def state_sanity_check(chain_connection,
     assert changed_state_for_sake_of_assert == set_storage_info_state, \
         f"Parent account info state is different from set storage state with more than providers counter! " \
         f"Parent state: {parent_account_info_state} " \
-        f"Set storage state: {set_storage_info_state}"
+        f"Set storage state: {set_storage_info_state}" \
+        f"Set storage block number {set_storage_block_number}"
 
 
 def get_system_account_metadata_scale_codec_type(chain_connection):
@@ -468,8 +469,11 @@ def fix_double_providers_count_for_account(chain_connection,
         }
     )
 
+    # add a small tip to make sure this will be the first transaction in the block
+    token_mili_unit = 1000000000
     extrinsic = chain_connection.create_signed_extrinsic(call=sudo_unchecked_weight_call,
-                                                         keypair=sudo_sender_keypair)
+                                                         keypair=sudo_sender_keypair,
+                                                         tip=token_mili_unit)
     block_hash = submit_extrinsic(chain_connection, extrinsic, 1, input_args.dry_run)
     if not input_args.dry_run:
         state_sanity_check(chain_connection,

--- a/scripts/accounts-invariants/pallet-balances-maintenance.py
+++ b/scripts/accounts-invariants/pallet-balances-maintenance.py
@@ -44,7 +44,9 @@ Accounts that do not satisfy those checks are written to accounts-with-failed-in
     parser.add_argument('--log-level',
                         default='info',
                         choices=['debug', 'info', 'warning', 'error'],
-                        help='Provide logging level. Default is info')
+                        help='Provide global logging level, for both file and console logger. If set to debug, '
+                             'file logger will log with debug anyway, but console with info. If set to info, '
+                             'both will log as info.')
     parser.add_argument('--dry-run',
                         action='store_true',
                         help='Specify this switch if script should just print what if would do. Default: False')
@@ -448,7 +450,8 @@ def set_provider_count_to_one(chain_connection,
 
     account_data['providers'] = 1
 
-    # encode_scale under the hood does
+    # encode_scale under the hood does a few RPC calls, which is unfortunate, as it slows down this function
+    # execution, which should as fast as possible to avoid data race conditions
     encoded_account_data = chain_connection.encode_scale(type_string=internal_system_account_scale_codec_type,
                                                          value=account_data,
                                                          block_hash=block_hash)

--- a/scripts/accounts-invariants/pallet-balances-maintenance.py
+++ b/scripts/accounts-invariants/pallet-balances-maintenance.py
@@ -1,5 +1,4 @@
 #!/bin/python3
-import copy
 import datetime
 import json
 import pathlib
@@ -358,9 +357,9 @@ def upgrade_accounts(chain_connection,
         submit_extrinsic(chain_connection, extrinsic, len(account_ids_chunk), args.dry_run)
 
 
-def check_if_account_double_providers(account, chain_major_version, ed):
+def check_if_account_has_double_providers(account, chain_major_version, ed):
     """
-    This predicate checks if an account's providers counter is different from 2
+    This predicate checks if an account's providers counter is equal to 2
     :param account: AccountInfo struct (element of System.Accounts StorageMap)
     :param chain_major_version: Must be >= 12
     :param ed: existential deposit, not used
@@ -377,7 +376,7 @@ def check_if_account_double_providers(account, chain_major_version, ed):
 
 def events_sanity_check(chain_connection, double_providers_accounts, original_state_block_hash):
     """
-    Makes sure that there were no unexpected events emitted meanwhile System.setStorage was issues.
+    Makes sure that there were no unexpected events emitted meanwhile System.setStorage was issued.
     It logs warning in case some unexpected events were emitted for original double_providers_accounts,
     such as Balances.transfer.
     :param chain_connection WS connection handler
@@ -424,7 +423,7 @@ def fix_double_providers_count(chain_connection,
     double_providers_accounts = filter_accounts(chain_connection=chain_connection,
                                                 ed=None,
                                                 chain_major_version=chain_major_version,
-                                                check_accounts_predicate=check_if_account_double_providers,
+                                                check_accounts_predicate=check_if_account_has_double_providers,
                                                 check_accounts_predicate_name="\'double provider count\'",
                                                 block_hash=chain_head)
     log.info(f"Found {len(double_providers_accounts)} accounts with double provider counter.")


### PR DESCRIPTION
# Description

Script attaches to given WS URL and 
* queries all `System.Account` keys which have `providers` counter set to 2 (from single block state),
* transforms above `AccountInfo` data in a way only `providers` counter is modifies and set to 1
* performs `System.setStorage` with list of key-value tuples (storage_key, storage_value)
* checks that from the original state there were no events emitted that concerns double providers accounts,
* at the end makes sure there are no double providers account anymore.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


