### PR TITLE
A0-3589: Direct storage read functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,6 +2427,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "env_logger",
+ "frame-support",
  "futures",
  "futures-timer",
  "hash-db",

--- a/finality-aleph/Cargo.toml
+++ b/finality-aleph/Cargo.toml
@@ -43,6 +43,8 @@ tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thre
 
 substrate-prometheus-endpoint = { workspace = true }
 
+frame-support = { workspace = true }
+
 sc-client-api = { workspace = true }
 sc-consensus = { workspace = true }
 sc-consensus-aura = { workspace = true }

--- a/finality-aleph/src/runtime_api.rs
+++ b/finality-aleph/src/runtime_api.rs
@@ -99,8 +99,8 @@ where
         at_block: BlockHash,
     ) -> Result<D, ApiError> {
         let mut storage_key = [twox_128(pallet.as_bytes()), twox_128(item.as_bytes())].concat();
-        let p = key.using_encoded(H::hash);
-        storage_key.extend(p.as_ref());
+        let hashed_encoded_key = key.using_encoded(H::hash);
+        storage_key.extend(hashed_encoded_key.as_ref());
         match self.access_storage::<D>(storage_key, at_block) {
             Err(ApiError::NoStorage) => {
                 Err(ApiError::NoStorageMapElement(pallet.into(), item.into()))

--- a/finality-aleph/src/runtime_api.rs
+++ b/finality-aleph/src/runtime_api.rs
@@ -337,7 +337,7 @@ mod test {
         );
         let result2 = runtime_api.read_storage_value::<u32>("Pallet", "StorageValue", Hash::zero());
 
-        assert!(matches!(result1, Err(ApiError::StorageAccessFailure)));
-        assert!(matches!(result2, Err(ApiError::StorageAccessFailure)));
+        assert_eq!(result1, Err(ApiError::StorageAccessFailure));
+        assert_eq!(result2, Err(ApiError::StorageAccessFailure));
     }
 }

--- a/finality-aleph/src/runtime_api.rs
+++ b/finality-aleph/src/runtime_api.rs
@@ -169,7 +169,7 @@ mod test {
         sync::Arc,
     };
 
-    use frame_support::{Twox128, Twox64Concat};
+    use frame_support::Twox64Concat;
     use parity_scale_codec::Encode;
     use primitives::Hash;
     use sp_runtime::Storage;

--- a/finality-aleph/src/runtime_api.rs
+++ b/finality-aleph/src/runtime_api.rs
@@ -110,7 +110,7 @@ where
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ApiError {
     StorageAccessFailure,
     NoStorage,
@@ -222,12 +222,8 @@ mod test {
         let storage_value =
             runtime_api.read_storage_value::<u32>("Pallet", "StorageValue", genesis_hash);
 
-        assert!(map_value1.is_ok());
-        assert!(map_value2.is_ok());
-        assert!(storage_value.is_ok());
-
-        assert_eq!(map_value1.unwrap(), 1);
-        assert_eq!(map_value2.unwrap(), 2);
-        assert_eq!(storage_value.unwrap(), 3);
+        assert_eq!(map_value1, Ok(1));
+        assert_eq!(map_value2, Ok(2));
+        assert_eq!(storage_value, Ok(3));
     }
 }


### PR DESCRIPTION
# Description

An implementation of direct storage access to support backwards-compatible runtime API.
* Added `read_storage_map` which reads the element of a runtime storage map directly
* Improved error handling
* Added test which checks that `read_storage_map` and `read_storage_value` work assuming appropriate storage key naming convention (map element is under appropriately digested version of `pallet + map_name + key`, storage value similarly at `pallet + storage_value_name`).

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist:
- I have added tests
