### PR TITLE
A0-4060: Fix spurious fails of data provider tests

### DIFF
--- a/finality-aleph/src/data_io/data_provider.rs
+++ b/finality-aleph/src/data_io/data_provider.rs
@@ -353,7 +353,7 @@ mod tests {
     use crate::{
         data_io::{
             data_provider::{ChainTracker, ChainTrackerConfig},
-            DataProvider, MAX_DATA_BRANCH_LEN,
+            AlephData, DataProvider, MAX_DATA_BRANCH_LEN,
         },
         metrics::AllBlockMetrics,
         party::manager::Runnable,
@@ -366,7 +366,7 @@ mod tests {
 
     const SESSION_LEN: u32 = 100;
     // The lower the interval the less time the tests take, however setting this too low might cause
-    // the tests to fail. Even though 1ms works with no issues, we set it to 5ms for safety.
+    // the tests to fail.
     const REFRESH_INTERVAL: Duration = Duration::from_millis(5);
 
     fn prepare_chain_tracker_test() -> (
@@ -407,8 +407,29 @@ mod tests {
     }
 
     // Sleep enough time so that the internal refreshing in ChainTracker has time to finish.
+    // Even though sleep time should be more enough, this may return None instead of Some very occasionally.
     async fn sleep_enough() {
         sleep(REFRESH_INTERVAL + REFRESH_INTERVAL + REFRESH_INTERVAL).await;
+    }
+
+    // Retries `sleep_enough` until data in provider is available.
+    // This theoretically might fail, but practically shouldn't.
+    async fn sleep_until_data_available(
+        data_provider: &mut DataProvider<THeader>,
+    ) -> AlephData<THeader> {
+        const RETRIES: u128 = 1000;
+        for _ in 0..RETRIES {
+            sleep_enough().await;
+            let maybe_data = data_provider.get_data().await;
+            if let Some(data) = maybe_data {
+                return data;
+            }
+        }
+        panic!(
+            "Data not available after {}ms (usually should be available after {}ms).",
+            RETRIES * REFRESH_INTERVAL.as_millis(),
+            REFRESH_INTERVAL.as_millis()
+        );
     }
 
     async fn run_test<F, S>(scenario: S)
@@ -442,9 +463,7 @@ mod tests {
                 .initialize_single_branch_and_import(2 * MAX_DATA_BRANCH_LEN)
                 .await;
 
-            sleep_enough().await;
-
-            let data = data_provider.get_data().await.unwrap();
+            let data = sleep_until_data_available(&mut data_provider).await;
             let expected_data = aleph_data_from_blocks(blocks[..MAX_DATA_BRANCH_LEN].to_vec());
             assert_eq!(data, expected_data);
         })
@@ -459,8 +478,7 @@ mod tests {
                 .await;
             for height in 1..(2 * MAX_DATA_BRANCH_LEN) {
                 chain_builder.finalize_block(&blocks[height - 1].header.hash());
-                sleep_enough().await;
-                let data = data_provider.get_data().await.unwrap();
+                let data = sleep_until_data_available(&mut data_provider).await;
                 let expected_data =
                     aleph_data_from_blocks(blocks[height..(MAX_DATA_BRANCH_LEN + height)].to_vec());
                 assert_eq!(data, expected_data);
@@ -484,8 +502,7 @@ mod tests {
                     (SESSION_LEN as usize) + 3 * MAX_DATA_BRANCH_LEN,
                 )
                 .await;
-            sleep_enough().await;
-            let data = data_provider.get_data().await.unwrap();
+            let data = sleep_until_data_available(&mut data_provider).await;
             let expected_data = aleph_data_from_blocks(blocks[0..MAX_DATA_BRANCH_LEN].to_vec());
             assert_eq!(data, expected_data);
 

--- a/finality-aleph/src/data_io/data_provider.rs
+++ b/finality-aleph/src/data_io/data_provider.rs
@@ -407,7 +407,7 @@ mod tests {
     }
 
     // Sleep enough time so that the internal refreshing in ChainTracker has time to finish.
-    // Even though sleep time should be more enough, this may return None instead of Some very occasionally.
+    // Even though the sleep time should be enough, this may return None instead of Some very occasionally.
     async fn sleep_enough() {
         sleep(REFRESH_INTERVAL + REFRESH_INTERVAL + REFRESH_INTERVAL).await;
     }

--- a/finality-aleph/src/data_io/legacy/data_provider.rs
+++ b/finality-aleph/src/data_io/legacy/data_provider.rs
@@ -362,6 +362,8 @@ mod tests {
     // The lower the interval the less time the tests take, however setting this too low might cause
     // the tests to fail.
     const REFRESH_INTERVAL: Duration = Duration::from_millis(5);
+    //  Sleep time that's usually enough for the internal refreshing in ChainTracker to finish.
+    const SLEEP_TIME: Duration = Duration::from_millis(15);
 
     fn prepare_chain_tracker_test() -> (
         impl Future<Output = ()>,
@@ -400,17 +402,12 @@ mod tests {
         )
     }
 
-    // Even though sleep time should be more enough, this may return None instead of Some very occasionally.
-    async fn sleep_enough() {
-        sleep(REFRESH_INTERVAL + REFRESH_INTERVAL + REFRESH_INTERVAL).await;
-    }
-
-    // Retries `sleep_enough` until data in provider is available.
+    // Retries sleeping and checking if data in provider is available.
     // This theoretically might fail, but practically shouldn't.
     async fn sleep_until_data_available(data_provider: &mut DataProvider) -> AlephData {
         const RETRIES: u128 = 1000;
         for _ in 0..RETRIES {
-            sleep_enough().await;
+            sleep(SLEEP_TIME).await;
             let maybe_data = data_provider.get_data().await;
             if let Some(data) = maybe_data {
                 return data;
@@ -442,7 +439,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn proposes_empty_and_nonempty_when_expected() {
         run_test(|mut chain_builder, mut data_provider| async move {
-            sleep_enough().await;
+            sleep(SLEEP_TIME).await;
 
             assert_eq!(
                 data_provider.get_data().await,
@@ -475,7 +472,7 @@ mod tests {
                 assert_eq!(data, expected_data);
             }
             chain_builder.finalize_block(&blocks.last().unwrap().header.hash());
-            sleep_enough().await;
+            sleep(SLEEP_TIME).await;
             assert_eq!(
                 data_provider.get_data().await,
                 None,
@@ -499,7 +496,7 @@ mod tests {
 
             // Finalize a block beyond the last block in the session.
             chain_builder.finalize_block(&blocks.last().unwrap().header.hash());
-            sleep_enough().await;
+            sleep(SLEEP_TIME).await;
             assert_eq!(
                 data_provider.get_data().await,
                 None,


### PR DESCRIPTION
# Description
Sleep with retires when expecting Some data (still theoretically not ideal, but practically it sleeps 15s in the worst case before failing, when practically 5ms should be sufficient) .

## Type of change

Change in tests pipeline

# Checklist:
