### PR TITLE
Remove unnecessary input in the featurenet-update workflow

### DIFF
--- a/.github/workflows/featurenet-update.yml
+++ b/.github/workflows/featurenet-update.yml
@@ -109,4 +109,3 @@ jobs:
       featurenet-name: ${{ inputs.featurenet-name }}
       aleph-node-image: ${{ needs.get-full-docker-image-path.outputs.fqdn-image }}
       rolling-update-partition: ${{ inputs.rolling-update-partition }}
-      update: true


### PR DESCRIPTION
# Description

Workflow for updating featurenets fails because of invalid input.  We have forgotten to remove it with some of the latest tiny refactors.
