### PR TITLE
A0-4096: FIX timeouts for run_e2e_test action

### DIFF
--- a/.github/actions/run-e2e-test/action.yml
+++ b/.github/actions/run-e2e-test/action.yml
@@ -39,7 +39,8 @@ inputs:
     description: 'aleph-e2e-client image'
     required: true
   timeout-minutes:
-    description: 'The maximum number of minutes to let a test run before it is canceled and considered failed'
+    description: 'The maximum number of minutes to let a test run before it is canceled and
+      considered failed'
     required: false
     default: 15
 
@@ -105,7 +106,8 @@ runs:
           popd
         fi
 
-        TIMEOUT_MINUTES="${{ inputs.timeout-minutes }}m" ./.github/scripts/run_e2e_test.sh "${ARGS[@]}"
+        export TIMEOUT_MINUTES="${{ inputs.timeout-minutes }}m"
+        ./.github/scripts/run_e2e_test.sh "${ARGS[@]}"
 
     - name: Get log tarball file name
       if: ${{ failure() }}

--- a/.github/actions/run-e2e-test/action.yml
+++ b/.github/actions/run-e2e-test/action.yml
@@ -38,6 +38,10 @@ inputs:
   aleph-e2e-client-image:
     description: 'aleph-e2e-client image'
     required: true
+  timeout-minutes:
+    description: 'The maximum number of minutes to let a test run before it is canceled and considered failed'
+    required: false
+    default: 15
 
 runs:
   using: 'composite'
@@ -101,7 +105,7 @@ runs:
           popd
         fi
 
-        ./.github/scripts/run_e2e_test.sh "${ARGS[@]}"
+        TIMEOUT_MINUTES="${{ inputs.timeout-minutes }}m" ./.github/scripts/run_e2e_test.sh "${ARGS[@]}"
 
     - name: Get log tarball file name
       if: ${{ failure() }}

--- a/.github/workflows/nightly-normal-session-e2e-tests.yml
+++ b/.github/workflows/nightly-normal-session-e2e-tests.yml
@@ -54,7 +54,7 @@ jobs:
           compose-file: docker/docker-compose.synthetic-network.yml
           # yamllint disable-line rule:line-length
           aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
-        timeout-minutes: 40
+          timeout-minutes: 40
 
   run-e2e-sync-test-one_node_catching_up_and_then_becoming_necessary_for_consensus:
     needs: [build-synthetic-node, build-aleph-e2e-client-image]
@@ -79,7 +79,7 @@ jobs:
           node-count: 7
           # yamllint disable-line rule:line-length
           aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
-        timeout-minutes: 35
+          timeout-minutes: 35
 
   run-e2e-sync-test-one_node_catching_up:
     needs: [build-synthetic-node, build-aleph-e2e-client-image]
@@ -103,7 +103,7 @@ jobs:
           node-count: 7
           # yamllint disable-line rule:line-length
           aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
-        timeout-minutes: 35
+          timeout-minutes: 35
 
   run-e2e-sync-test-into_two_groups_and_one_quorum_and_switch_quorum_between_them:
     needs: [build-synthetic-node, build-aleph-e2e-client-image]
@@ -128,7 +128,7 @@ jobs:
           node-count: 7
           # yamllint disable-line rule:line-length
           aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
-        timeout-minutes: 35
+          timeout-minutes: 35
 
   run-e2e-sync-test-into_multiple_groups_of_two:
     needs: [build-synthetic-node, build-aleph-e2e-client-image]
@@ -152,7 +152,7 @@ jobs:
           node-count: 7
           # yamllint disable-line rule:line-length
           aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
-        timeout-minutes: 35
+          timeout-minutes: 35
 
   run-e2e-sync-test-into_two_equal_size_groups_with_no_quorum:
     needs: [build-synthetic-node, build-aleph-e2e-client-image]
@@ -177,7 +177,7 @@ jobs:
           node-count: 7
           # yamllint disable-line rule:line-length
           aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
-        timeout-minutes: 35
+          timeout-minutes: 35
 
   run-e2e-sync-test-into_two_groups_one_with_quorum:
     needs: [build-synthetic-node, build-aleph-e2e-client-image]
@@ -202,7 +202,7 @@ jobs:
           node-count: 7
           # yamllint disable-line rule:line-length
           aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
-        timeout-minutes: 35
+          timeout-minutes: 35
 
   run-e2e-finalization-stall:
     needs: [build-synthetic-node, build-aleph-e2e-client-image]
@@ -226,7 +226,7 @@ jobs:
           compose-file: docker/docker-compose.finalization_stall_with_pruning.yml
           # yamllint disable-line rule:line-length
           aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
-        timeout-minutes: 60
+          timeout-minutes: 60
 
   run-major-sync-test:
     needs: [build-production-node-and-runtime]
@@ -288,7 +288,7 @@ jobs:
           compose-file: docker/docker-compose.synthetic-network.yml
           # yamllint disable-line rule:line-length
           aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
-        timeout-minutes: 35
+          timeout-minutes: 35
 
   check-nightly-pipeline-completion:
     needs: [run-e2e-high-out-latency,


### PR DESCRIPTION
# Description

It looks like all tests run by `run_e2e_test.sh` were using only the default value for its `TIMEOUT_MINUTES` variable.

It can be verified by investigating past runs of the nighly-pipeline: compare its logs (i.e. `2024-02-21T22:27:03.4202170Z Running test, logs will be shown when tests finishes or after 20m timeout.`) with values used in action's declaration.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
