### PR TITLE
A0-4099: New pallets API in aleph-client

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.9.1"
+version = "3.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "3.9.0"
+version = "3.9.1"
 edition = "2021"
 authors = ["Cardinal"]
 documentation = "https://docs.rs/aleph_client"

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "3.9.1"
+version = "3.10.0"
 edition = "2021"
 authors = ["Cardinal"]
 documentation = "https://docs.rs/aleph_client"

--- a/aleph-client/src/pallets/feature_control.rs
+++ b/aleph-client/src/pallets/feature_control.rs
@@ -22,7 +22,7 @@ pub trait FeatureControlSudoApi {
 #[async_trait::async_trait]
 impl<C: ConnectionApi> FeatureControlApi for C {
     async fn is_feature_active(&self, feature: Feature, at: Option<BlockHash>) -> bool {
-        let addrs = api::storage().feature_control().active_features(&feature);
+        let addrs = api::storage().feature_control().active_features(feature);
         self.get_storage_entry_maybe(&addrs, at).await.is_some()
     }
 }

--- a/aleph-client/src/pallets/feature_control.rs
+++ b/aleph-client/src/pallets/feature_control.rs
@@ -1,0 +1,41 @@
+use crate::{
+    api, pallet_feature_control::Feature, BlockHash, ConnectionApi, RootConnection,
+    SignedConnectionApi, TxInfo, TxStatus,
+};
+
+/// Read only pallet feature control API.
+#[async_trait::async_trait]
+pub trait FeatureControlApi {
+    /// Check if a feature is active.
+    async fn is_feature_active(&self, feature: Feature, at: Option<BlockHash>) -> bool;
+}
+
+/// Pallet feature control API that requires sudo.
+#[async_trait::async_trait]
+pub trait FeatureControlSudoApi {
+    /// Enable a feature.
+    async fn enable_feature(&self, feature: Feature, status: TxStatus) -> anyhow::Result<TxInfo>;
+    /// Disable a feature.
+    async fn disable_feature(&self, feature: Feature, status: TxStatus) -> anyhow::Result<TxInfo>;
+}
+
+#[async_trait::async_trait]
+impl<C: ConnectionApi> FeatureControlApi for C {
+    async fn is_feature_active(&self, feature: Feature, at: Option<BlockHash>) -> bool {
+        let addrs = api::storage().feature_control().active_features(&feature);
+        self.get_storage_entry_maybe(&addrs, at).await.is_some()
+    }
+}
+
+#[async_trait::async_trait]
+impl FeatureControlSudoApi for RootConnection {
+    async fn enable_feature(&self, feature: Feature, status: TxStatus) -> anyhow::Result<TxInfo> {
+        let tx = api::tx().feature_control().enable(feature);
+        self.send_tx(tx, status).await
+    }
+
+    async fn disable_feature(&self, feature: Feature, status: TxStatus) -> anyhow::Result<TxInfo> {
+        let tx = api::tx().feature_control().disable(feature);
+        self.send_tx(tx, status).await
+    }
+}

--- a/aleph-client/src/pallets/mod.rs
+++ b/aleph-client/src/pallets/mod.rs
@@ -10,6 +10,8 @@ pub mod committee_management;
 pub mod contract;
 /// Pallet elections API
 pub mod elections;
+/// Pallet feature control API
+pub mod feature_control;
 /// Pallet transaction payment API
 pub mod fee;
 /// Pallet multisig API

--- a/aleph-client/src/pallets/vk_storage.rs
+++ b/aleph-client/src/pallets/vk_storage.rs
@@ -22,7 +22,7 @@ pub trait VkStorageUserApi {
 #[async_trait::async_trait]
 impl<C: ConnectionApi> VkStorageApi for C {
     async fn get_verification_key(&self, key_hash: H256, at: Option<BlockHash>) -> Vec<u8> {
-        let addrs = api::storage().vk_storage().verification_keys(&key_hash);
+        let addrs = api::storage().vk_storage().verification_keys(key_hash);
         self.get_storage_entry(&addrs, at).await.0
     }
 }

--- a/aleph-client/src/pallets/vk_storage.rs
+++ b/aleph-client/src/pallets/vk_storage.rs
@@ -1,12 +1,30 @@
 use anyhow::Result;
 
-use crate::{api, SignedConnection, SignedConnectionApi, TxInfo, TxStatus};
+use crate::{
+    api, sp_core::H256, BlockHash, ConnectionApi, SignedConnection, SignedConnectionApi, TxInfo,
+    TxStatus,
+};
+
+/// Read only pallet vk storage API.
+#[async_trait::async_trait]
+pub trait VkStorageApi {
+    /// Get verification key from pallet's storage.
+    async fn get_verification_key(&self, key_hash: H256, at: Option<BlockHash>) -> Vec<u8>;
+}
 
 /// Pallet vk storage API.
 #[async_trait::async_trait]
 pub trait VkStorageUserApi {
-    /// Store verifying key in pallet's storage.
+    /// Store a verifying key in pallet's storage.
     async fn store_key(&self, key: Vec<u8>, status: TxStatus) -> Result<TxInfo>;
+}
+
+#[async_trait::async_trait]
+impl<C: ConnectionApi> VkStorageApi for C {
+    async fn get_verification_key(&self, key_hash: H256, at: Option<BlockHash>) -> Vec<u8> {
+        let addrs = api::storage().vk_storage().verification_keys(&key_hash);
+        self.get_storage_entry(&addrs, at).await.0
+    }
 }
 
 #[async_trait::async_trait]

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.9.1"
+version = "3.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/cliain/Cargo.lock
+++ b/bin/cliain/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.8.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.9.1"
+version = "3.10.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
# Description

Recently we added the feature control and vk storage pallet - in order to test them in e2e tests, we need its API covered by aleph-client.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have created new documentation
- I have bumped aleph-client version if relevant
