### PR TITLE
A0-4100: [HOTFIX] Equivocations have to happen in the same session

### DIFF
--- a/finality-aleph/src/block/substrate/verification/cache.rs
+++ b/finality-aleph/src/block/substrate/verification/cache.rs
@@ -121,6 +121,9 @@ fn download_data<AP: AuthorityProvider>(
     })
 }
 
+// Equivocations only happen per time slot _and_ session..
+type SessionSlot = (SessionId, Slot);
+
 /// Cache storing SessionVerifier structs and Aura authorities for multiple sessions.
 /// Keeps up to `cache_size` verifiers of top sessions.
 /// If the session is too new or ancient it will fail to return requested data.
@@ -134,7 +137,7 @@ where
     H: HeaderT,
 {
     cached_data: HashMap<SessionId, CachedData>,
-    equivocation_cache: HashMap<u64, (H, bool)>,
+    equivocation_cache: HashMap<SessionSlot, (H, bool)>,
     session_info: SessionBoundaryInfo,
     finalization_info: FI,
     authority_provider: AP,
@@ -194,9 +197,11 @@ where
         }
     }
 
-    fn get_data(&mut self, number: BlockNumber) -> Result<&CachedData, CacheError> {
-        let session_id = self.session_info.session_id_from_block_num(number);
+    fn session_id_from_block_num(&self, number: BlockNumber) -> SessionId {
+        self.session_info.session_id_from_block_num(number)
+    }
 
+    fn get_data(&mut self, session_id: SessionId) -> Result<&CachedData, CacheError> {
         if session_id < self.lower_bound {
             return Err(CacheError::SessionTooOld(session_id, self.lower_bound));
         }
@@ -228,7 +233,9 @@ where
     /// Returns session verifier for block number if available. Updates cache if necessary.
     /// Must be called using the number of the verified block.
     pub fn get(&mut self, number: BlockNumber) -> Result<&SessionVerifier, CacheError> {
-        Ok(&self.get_data(number)?.session_verifier)
+        Ok(&self
+            .get_data(self.session_id_from_block_num(number))?
+            .session_verifier)
     }
 }
 
@@ -237,22 +244,23 @@ where
     AP: AuthorityProvider,
     FS: FinalizationInfo,
 {
-    /// Returns the list of Aura authorities for a given block number. Updates cache if necessary.
-    /// Must be called using the number of the PARENT of the verified block.
+    /// Returns the list of Aura authorities for a given session. Updates cache if necessary.
     /// This method assumes that the queued Aura authorities will indeed become Aura authorities
     /// in the next session.
-    pub fn get_aura_authorities(
+    fn get_aura_authorities(
         &mut self,
-        number: BlockNumber,
+        session_id: SessionId,
     ) -> Result<&Vec<(Option<AccountId>, AuraId)>, CacheError> {
-        Ok(&self.get_data(number)?.aura_authorities)
+        Ok(&self.get_data(session_id)?.aura_authorities)
     }
 
     fn parse_aura_header(
         &mut self,
         header: &mut Header,
-    ) -> Result<(Slot, AuraSignature, H256, AuraId, Option<AccountId>), HeaderVerificationError>
-    {
+    ) -> Result<
+        (SessionSlot, AuraSignature, H256, AuraId, Option<AccountId>),
+        HeaderVerificationError,
+    > {
         use HeaderVerificationError::*;
         let slot =
             find_pre_digest::<Block, AuthoritySignature>(header).map_err(PreDigestLookupError)?;
@@ -267,8 +275,9 @@ where
 
         // Aura: authorities are stored in the parent block
         let parent_number = header.number() - 1;
+        let session_id = self.session_id_from_block_num(parent_number);
         let authorities = self
-            .get_aura_authorities(parent_number)
+            .get_aura_authorities(session_id)
             .map_err(|_| MissingAuthorityData)?;
         // Aura: round robin
         let idx = *slot % (authorities.len() as u64);
@@ -277,7 +286,7 @@ where
             .expect("idx < authorities.len()")
             .clone();
 
-        Ok((slot, sig, pre_hash, author, maybe_account_id))
+        Ok(((session_id, slot), sig, pre_hash, author, maybe_account_id))
     }
 
     // This function assumes that:
@@ -286,7 +295,7 @@ where
     // 3. Slot number is calculated using the current system time.
     fn verify_aura_header(
         &mut self,
-        slot: &Slot,
+        slot: &SessionSlot,
         sig: &AuraSignature,
         pre_hash: H256,
         author: &AuraId,
@@ -298,8 +307,8 @@ where
             sp_timestamp::Timestamp::current(),
             sp_consensus_slots::SlotDuration::from_millis(MILLISECS_PER_BLOCK),
         );
-        if *slot > slot_now + HEADER_VERIFICATION_SLOT_OFFSET {
-            return Err(VerificationError::HeaderVerification(HeaderTooNew(*slot)));
+        if slot.1 > slot_now + HEADER_VERIFICATION_SLOT_OFFSET {
+            return Err(VerificationError::HeaderVerification(HeaderTooNew(slot.1)));
         }
         if !AuthorityPair::verify(sig, pre_hash.as_ref(), author) {
             return Err(VerificationError::HeaderVerification(IncorrectAuthority));
@@ -313,12 +322,12 @@ where
     fn check_for_equivocation(
         &mut self,
         header: &Header,
-        slot: Slot,
+        slot: SessionSlot,
         author: AuraId,
         maybe_account_id: Option<AccountId>,
         just_created: bool,
     ) -> Result<Option<EquivocationProof>, VerificationError> {
-        match self.equivocation_cache.entry(slot.into()) {
+        match self.equivocation_cache.entry(slot) {
             Entry::Occupied(occupied) => {
                 let (cached_header, certainly_own) = occupied.into_mut();
                 if cached_header == header {


### PR DESCRIPTION
# Description

In rare situations a block created in the same slot but different session was falsely marked as an equivocation, this PR fixes the problem.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- I have made corresponding changes to the existing documentation
- I have created new documentation
