### PR TITLE
A0-4111: Added staking.nominationsQuota to runtime API that always returns 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "pallet-scheduler",
  "pallet-session",
  "pallet-staking",
+ "pallet-staking-runtime-api",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -6020,6 +6021,15 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-std",
+]
+
+[[package]]
+name = "pallet-staking-runtime-api"
+version = "4.0.0-dev"
+source = "git+https://github.com/Cardinal-Cryptography/polkadot-sdk.git?branch=aleph-v1.2.0#180a545dc6f9bed44274c5c9f0f572fd05798c92"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ pallet-insecure-randomness-collective-flip = { git = "https://github.com/Cardina
 pallet-scheduler = { git = "https://github.com/Cardinal-Cryptography/polkadot-sdk.git", branch = "aleph-v1.2.0", default-features = false }
 pallet-session = { git = "https://github.com/Cardinal-Cryptography/polkadot-sdk.git", branch = "aleph-v1.2.0", default-features = false }
 pallet-staking = { git = "https://github.com/Cardinal-Cryptography/polkadot-sdk.git", branch = "aleph-v1.2.0", default-features = false }
+pallet-staking-runtime-api = { git = "https://github.com/Cardinal-Cryptography/polkadot-sdk.git", branch = "aleph-v1.2.0", default-features = false }
 pallet-sudo = { git = "https://github.com/Cardinal-Cryptography/polkadot-sdk.git", branch = "aleph-v1.2.0", default-features = false }
 pallet-timestamp = { git = "https://github.com/Cardinal-Cryptography/polkadot-sdk.git", branch = "aleph-v1.2.0", default-features = false }
 pallet-transaction-payment = { git = "https://github.com/Cardinal-Cryptography/polkadot-sdk.git", branch = "aleph-v1.2.0", default-features = false }

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -33,6 +33,7 @@ pallet-insecure-randomness-collective-flip = { workspace = true }
 pallet-scheduler = { workspace = true }
 pallet-session = { workspace = true }
 pallet-staking = { workspace = true }
+pallet-staking-runtime-api = { workspace = true }
 pallet-sudo = { workspace = true }
 pallet-timestamp = { workspace = true }
 pallet-transaction-payment = { workspace = true }
@@ -91,6 +92,7 @@ std = [
     "pallet-insecure-randomness-collective-flip/std",
     "pallet-session/std",
     "pallet-staking/std",
+    "pallet-staking-runtime-api/std",
     "pallet-sudo/std",
     "pallet-timestamp/std",
     "pallet-transaction-payment/std",

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -1185,6 +1185,13 @@ impl_runtime_apis! {
         }
     }
 
+    impl pallet_staking_runtime_api::StakingApi<Block, Balance> for Runtime {
+		fn nominations_quota(balance: Balance) -> u32 {
+			MAX_NOMINATORS
+		}
+	}
+
+
     impl pallet_contracts::ContractsApi<Block, AccountId, Balance, AlephBlockNumber, Hash, EventRecord>
         for Runtime
     {


### PR DESCRIPTION
# Description

As per PR title. Similiar to what Polkadot & Kusama [runtime added](https://github.com/polkadot-fellows/runtimes/commit/fa473effb69dade0135cd757fff651a23e098b13), but due to how AlephNode staking works, here it always returns 1.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Testing

New call always returns `1`, regardless input balance argument:

![image](https://github.com/Cardinal-Cryptography/aleph-node/assets/3909333/f561792b-48d7-4023-9a71-24b928c71175)

