### PR TITLE
A0-4112: Increase MaxHolds to 50

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -218,8 +218,7 @@ impl pallet_authorship::Config for Runtime {
 parameter_types! {
     pub const ExistentialDeposit: u128 = 500 * PICO_AZERO;
     pub const MaxLocks: u32 = 50;
-    // We have only 2 reasons for holds - CodeUploadDeposit and StorageDeposit.
-    pub const MaxHolds: u32 = 2;
+    pub const MaxHolds: u32 = 50;
     pub const MaxFreezes: u32 = 0;
     pub const MaxReserves: u32 = 50;
 }


### PR DESCRIPTION
# Description

Polkadot has 50, and there are no practical implications to not increase it. In AlephNode 13 version, there are only two reasons for holds (`CodeUploadDeposit` and `StorageDeposit`), but in the future, there can be more, as more and more pallets are going to use holds and deprecate locks. Also, now we have `MaxLocks` == 50.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Testing

* make sure constant returned from wallet is 50

![image](https://github.com/Cardinal-Cryptography/aleph-node/assets/3909333/87bbe71f-6391-42d6-8f81-1d07bf1fd474)

* run adder e2e test: https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/8062988259

