### PR TITLE
A0-4020: fix for fix accounts consumers underflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-node"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "aleph-runtime",
  "finality-aleph",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-runtime"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "baby-liminal-extension",
  "frame-benchmarking",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-node"
-version = "0.13.1"
+version = "0.13.2"
 description = "Aleph node binary"
 build = "build.rs"
 license = "GPL-3.0-or-later"

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-runtime"
-version = "0.13.1"
+version = "0.13.2"
 license = "GPL-3.0-or-later"
 authors.workspace = true
 edition.workspace = true

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 70,
+    spec_version: 71,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 18,
@@ -381,6 +381,7 @@ impl pallet_operations::Config for Runtime {
     type AccountInfoProvider = System;
     type BalancesProvider = Balances;
     type NextKeysSessionProvider = Session;
+    type BondedStashProvider = Staking;
 }
 
 impl pallet_committee_management::Config for Runtime {

--- a/pallets/operations/Cargo.toml
+++ b/pallets/operations/Cargo.toml
@@ -15,12 +15,12 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-session = { workspace = true }
 pallet-balances = { workspace = true }
+pallet-staking = { workspace = true }
 sp-runtime = { workspace = true }
 sp-core = { workspace = true }
 
 [dev-dependencies]
 sp-io = { workspace = true }
-pallet-staking = { workspace = true }
 pallet-timestamp = { workspace = true }
 frame-election-provider-support = { workspace = true }
 

--- a/pallets/operations/src/impls.rs
+++ b/pallets/operations/src/impls.rs
@@ -51,8 +51,8 @@ impl<T: Config> Pallet<T> {
         let has_staking_lock = Self::has_lock(&locks, STAKING_ID);
         let nominator_has_consumers_underflow = consumers == 2 && has_staking_lock;
         let has_next_session_keys = T::NextKeysSessionProvider::has_next_session_keys(who);
-        let stash_different_than_controller = match T::BondedStashProvider::get_controller(who) {
-            Some(controller) => *who != controller,
+        let stash_equal_to_controller = match T::BondedStashProvider::get_controller(who) {
+            Some(controller) => *who == controller,
             None => {
                 log::warn!(
                     target: LOG_TARGET,
@@ -65,7 +65,7 @@ impl<T: Config> Pallet<T> {
         let validator_has_consumers_underflow = consumers == 3
             && has_staking_lock
             && has_next_session_keys
-            && stash_different_than_controller;
+            && stash_equal_to_controller;
         vester_has_consumers_underflow
             || nominator_has_consumers_underflow
             || validator_has_consumers_underflow

--- a/pallets/operations/src/impls.rs
+++ b/pallets/operations/src/impls.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::nonminimal_bool)]
 
-use frame_support::dispatch::DispatchResult;
-use frame_support::{traits::LockIdentifier, WeakBoundedVec};
+use frame_support::{dispatch::DispatchResult, traits::LockIdentifier, WeakBoundedVec};
 use pallet_balances::BalanceLock;
 use parity_scale_codec::Encode;
 use sp_core::hexdisplay::HexDisplay;

--- a/pallets/operations/src/impls.rs
+++ b/pallets/operations/src/impls.rs
@@ -1,9 +1,7 @@
 #![allow(clippy::nonminimal_bool)]
 
-use frame_support::{
-    dispatch::DispatchResultWithPostInfo, pallet_prelude::Get, traits::LockIdentifier,
-    WeakBoundedVec,
-};
+use frame_support::dispatch::DispatchResult;
+use frame_support::{traits::LockIdentifier, WeakBoundedVec};
 use pallet_balances::BalanceLock;
 use parity_scale_codec::Encode;
 use sp_core::hexdisplay::HexDisplay;
@@ -18,63 +16,71 @@ use crate::{
 impl<T: Config> Pallet<T> {
     /// Checks if account has an underflow of `consumers` counter. In such case, it increments
     /// it by one.
-    pub fn fix_underflow_consumer_counter(who: T::AccountId) -> DispatchResultWithPostInfo {
-        let mut weight = T::DbWeight::get().reads(1);
-        let consumers = T::AccountInfoProvider::get_consumers(&who);
+    pub fn fix_underflow_consumer_counter(who: T::AccountId) -> DispatchResult {
+        let current_consumers = T::AccountInfoProvider::get_consumers(&who);
+        let mut expected_consumers: u32 = 0;
 
-        weight += T::DbWeight::get().reads(1);
-        if Self::no_consumers_some_reserved(&who, consumers) {
-            Self::increment_consumers(who)?;
-            weight += T::DbWeight::get().writes(1);
-            return Ok(Some(weight).into());
+        if Self::reserved_or_frozen_non_zero(&who) {
+            expected_consumers += 1;
+        }
+        let has_vesting_lock = Self::has_vesting_lock(&who);
+        let has_staking_lock = Self::has_staking_lock(&who);
+        if has_staking_lock || has_vesting_lock {
+            expected_consumers += 1;
+            if has_staking_lock {
+                expected_consumers += 1;
+            }
+        }
+        if Self::has_next_session_keys_and_account_is_controller(&who) {
+            expected_consumers += 1;
         }
 
-        weight += T::DbWeight::get().reads(2);
-        if Self::staker_has_consumers_underflow(&who, consumers) {
+        if current_consumers < expected_consumers {
+            log::debug!(
+                target: LOG_TARGET,
+                "Account {:?} has current consumers {} less than expected consumers {:?}, incrementing ",
+                HexDisplay::from(&who.encode()), current_consumers, expected_consumers);
             Self::increment_consumers(who)?;
-            weight += T::DbWeight::get().writes(1);
-            return Ok(Some(weight).into());
+        } else {
+            log::debug!(
+                target: LOG_TARGET,
+                "Account {:?} does not have consumers underflow, not incrementing",
+                HexDisplay::from(&who.encode())
+            );
         }
 
-        log::debug!(
-            target: LOG_TARGET,
-            "Account {:?} has correct consumer counter, not incrementing",
-            HexDisplay::from(&who.encode())
-        );
-        Ok(Some(weight).into())
+        Ok(())
     }
 
-    fn staker_has_consumers_underflow(who: &T::AccountId, consumers: u32) -> bool {
+    fn reserved_or_frozen_non_zero(who: &T::AccountId) -> bool {
+        !T::BalancesProvider::is_reserved_zero(who) || !T::BalancesProvider::is_frozen_zero(who)
+    }
+
+    fn has_vesting_lock(who: &T::AccountId) -> bool {
         let locks = T::BalancesProvider::locks(who);
-        let has_vesting_lock = Self::has_lock(&locks, VESTING_ID);
-        let vester_has_consumers_underflow = consumers == 1 && has_vesting_lock;
-        let has_staking_lock = Self::has_lock(&locks, STAKING_ID);
-        let nominator_has_consumers_underflow = consumers == 2 && has_staking_lock;
+        Self::has_lock(&locks, VESTING_ID)
+    }
+
+    fn has_staking_lock(who: &T::AccountId) -> bool {
+        let locks = T::BalancesProvider::locks(who);
+        Self::has_lock(&locks, STAKING_ID)
+    }
+
+    fn has_next_session_keys_and_account_is_controller(who: &T::AccountId) -> bool {
         let has_next_session_keys = T::NextKeysSessionProvider::has_next_session_keys(who);
         let stash_equal_to_controller = match T::BondedStashProvider::get_controller(who) {
             Some(controller) => *who == controller,
-            None => {
-                log::warn!(
-                    target: LOG_TARGET,
-                    "Account {:?} has staking lock, but its Bonded is empty!",
-                    HexDisplay::from(&who.encode())
-                );
-                false
-            }
+            None => false,
         };
-        let validator_has_consumers_underflow = consumers == 3
-            && has_staking_lock
-            && has_next_session_keys
-            && stash_equal_to_controller;
-        vester_has_consumers_underflow
-            || nominator_has_consumers_underflow
-            || validator_has_consumers_underflow
-    }
-
-    fn no_consumers_some_reserved(who: &T::AccountId, consumers: u32) -> bool {
-        let is_reserved_not_zero = T::BalancesProvider::is_reserved_not_zero(who);
-
-        consumers == 0 && is_reserved_not_zero
+        if has_next_session_keys && stash_equal_to_controller {
+            return true;
+        }
+        match T::BondedStashProvider::get_stash(who) {
+            Some(stash) => {
+                *who != stash && T::NextKeysSessionProvider::has_next_session_keys(&stash)
+            }
+            None => false,
+        }
     }
 
     fn has_lock<U, V>(locks: &WeakBoundedVec<BalanceLock<U>, V>, id: LockIdentifier) -> bool {

--- a/pallets/operations/src/lib.rs
+++ b/pallets/operations/src/lib.rs
@@ -62,16 +62,13 @@ pub mod pallet {
         /// An account can have an underflow of a `consumers` counter.
         /// Account categories that are impacted by this issue depends on a chain runtime,
         /// but specifically for AlephNode runtime are as follows:
-        /// * `consumers`  == 0, `reserved`  > 0
-        /// * `consumers`  == 1, `balances.Locks` contain an entry with `id`  == `vesting`
-        /// * `consumers`  == 2, `balances.Locks` contain an entry with `id`  == `staking`
-        /// * `consumers` == 3,
-        ///   `balances.Locks` contain entries with `id`  == `staking`,
-        ///   `staking.bonded(accountId) == accountId`,
-        ///    accountId is in `session.nextKeys`
+        /// +1 consumers if reserved > 0 || frozen > 0
+        /// +1 consumers if there is at least one lock (staking or vesting)
+        /// +1 consumers if there's session.nextKeys set, for controller account
+        /// +1 consumers if account bonded
         ///
-        ///	`fix_accounts_consumers_underflow` checks if the account falls into one of above
-        /// categories, and increase its `consumers` counter.
+        ///	`fix_accounts_consumers_underflow` calculates expected consumers counter and comperes
+        /// it with current consumers counter, incrementing by one in case of an underflow
         ///
         /// - `origin`: Must be `Signed`.
         /// - `who`: An account to be fixed
@@ -83,10 +80,10 @@ pub mod pallet {
         pub fn fix_accounts_consumers_underflow(
             origin: OriginFor<T>,
             who: T::AccountId,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             ensure_signed(origin)?;
             Self::fix_underflow_consumer_counter(who)?;
-            Ok(().into())
+            Ok(())
         }
     }
 }

--- a/pallets/operations/src/lib.rs
+++ b/pallets/operations/src/lib.rs
@@ -26,7 +26,9 @@ pub mod pallet {
     use frame_system::{ensure_signed, pallet_prelude::OriginFor};
 
     use crate::{
-        traits::{AccountInfoProvider, BalancesProvider, NextKeysSessionProvider},
+        traits::{
+            AccountInfoProvider, BalancesProvider, BondedStashProvider, NextKeysSessionProvider,
+        },
         STORAGE_VERSION,
     };
 
@@ -35,8 +37,12 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
         /// Something that provides information about an account's consumers counter
         type AccountInfoProvider: AccountInfoProvider<AccountId = Self::AccountId, RefCount = u32>;
+        /// Something that provides information about account's balances
         type BalancesProvider: BalancesProvider<AccountId = Self::AccountId>;
+        /// Something that provides information about an account's next session keys
         type NextKeysSessionProvider: NextKeysSessionProvider<AccountId = Self::AccountId>;
+        /// Something that provides information about an account's controller
+        type BondedStashProvider: BondedStashProvider<AccountId = Self::AccountId>;
     }
 
     #[pallet::pallet]
@@ -59,8 +65,10 @@ pub mod pallet {
         /// * `consumers`  == 0, `reserved`  > 0
         /// * `consumers`  == 1, `balances.Locks` contain an entry with `id`  == `vesting`
         /// * `consumers`  == 2, `balances.Locks` contain an entry with `id`  == `staking`
-        /// * `consumers`  == 3, `balances.Locks` contain entries with `id`  == `staking`
-        ///    and account id is in `session.nextKeys`
+        /// * `consumers` == 3,
+        ///   `balances.Locks` contain entries with `id`  == `staking`,
+        ///   `staking.bonded(accountId) == accountId`,
+        ///    accountId is in `session.nextKeys`
         ///
         ///	`fix_accounts_consumers_underflow` checks if the account falls into one of above
         /// categories, and increase its `consumers` counter.

--- a/pallets/operations/src/tests/setup.rs
+++ b/pallets/operations/src/tests/setup.rs
@@ -187,6 +187,7 @@ impl pallet_operations::Config for TestRuntime {
     type AccountInfoProvider = System;
     type BalancesProvider = Balances;
     type NextKeysSessionProvider = Session;
+    type BondedStashProvider = Staking;
 }
 
 pub fn new_test_ext(accounts_and_balances: &[(u64, bool, u128)]) -> sp_io::TestExternalities {

--- a/pallets/operations/src/tests/suite.rs
+++ b/pallets/operations/src/tests/suite.rs
@@ -416,8 +416,7 @@ fn given_nominator_account_with_staking_lock_when_fixing_consumers_then_consumer
 }
 
 #[test]
-fn given_validator_with_stash_equal_to_consumer_when_fixing_consumers_then_consumers_increases(
-) {
+fn given_validator_with_stash_equal_to_consumer_when_fixing_consumers_then_consumers_increases() {
     let authority_id = 1_u64;
     let non_authority_id = 2_u64;
     let total_balance_authority = 1000_u128;
@@ -443,15 +442,18 @@ fn given_validator_with_stash_equal_to_consumer_when_fixing_consumers_then_consu
                 authority_id
             )
         );
-        assert_eq!(pallet_operations_events(), [crate::Event::ConsumersUnderflowFixed { who: authority_id }]);
+        assert_eq!(
+            pallet_operations_events(),
+            [crate::Event::ConsumersUnderflowFixed { who: authority_id }]
+        );
 
         assert_eq!(consumers(authority_id), 4);
     });
 }
 
 #[test]
-fn given_validator_with_stash_not_equal_to_consumer_when_fixing_consumers_then_consumers_does_not_increase()
-{
+fn given_validator_with_stash_not_equal_to_consumer_when_fixing_consumers_then_consumers_does_not_increase(
+) {
     let authority_id = 1_u64;
     let non_authority_id = 2_u64;
     let total_balance_authority = 1000_u128;
@@ -482,10 +484,7 @@ fn given_validator_with_stash_not_equal_to_consumer_when_fixing_consumers_then_c
                 authority_id
             )
         );
-        assert_eq!(
-            pallet_operations_events(),
-            []
-        );
+        assert_eq!(pallet_operations_events(), []);
 
         assert_eq!(consumers(authority_id), 3);
     });

--- a/pallets/operations/src/tests/suite.rs
+++ b/pallets/operations/src/tests/suite.rs
@@ -416,7 +416,7 @@ fn given_nominator_account_with_staking_lock_when_fixing_consumers_then_consumer
 }
 
 #[test]
-fn given_validator_with_stash_equal_to_consumer_when_fixing_consumers_then_consumers_does_not_increase(
+fn given_validator_with_stash_equal_to_consumer_when_fixing_consumers_then_consumers_increases(
 ) {
     let authority_id = 1_u64;
     let non_authority_id = 2_u64;
@@ -443,14 +443,14 @@ fn given_validator_with_stash_equal_to_consumer_when_fixing_consumers_then_consu
                 authority_id
             )
         );
-        assert_eq!(pallet_operations_events(), []);
+        assert_eq!(pallet_operations_events(), [crate::Event::ConsumersUnderflowFixed { who: authority_id }]);
 
-        assert_eq!(consumers(authority_id), 3);
+        assert_eq!(consumers(authority_id), 4);
     });
 }
 
 #[test]
-fn given_validator_with_stash_not_equal_to_consumer_when_fixing_consumers_then_consumers_increases()
+fn given_validator_with_stash_not_equal_to_consumer_when_fixing_consumers_then_consumers_does_not_increase()
 {
     let authority_id = 1_u64;
     let non_authority_id = 2_u64;
@@ -484,9 +484,9 @@ fn given_validator_with_stash_not_equal_to_consumer_when_fixing_consumers_then_c
         );
         assert_eq!(
             pallet_operations_events(),
-            [crate::Event::ConsumersUnderflowFixed { who: authority_id }]
+            []
         );
 
-        assert_eq!(consumers(authority_id), 4);
+        assert_eq!(consumers(authority_id), 3);
     });
 }


### PR DESCRIPTION
# Description

`operations.fix_accounts_consumers_underflow` does not take into account controller != stash scenario, in which case `consumers` should not be incremented on stash account, but on the controller account.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
