### PR TITLE
A0-4164: Increase node startup timeout for sync tests

### DIFF
--- a/.github/scripts/test_testnet_db_sync.sh
+++ b/.github/scripts/test_testnet_db_sync.sh
@@ -77,7 +77,7 @@ chmod +x aleph-node
     --no-mdns 1>/dev/null 2>/dev/null &
 
 echo "Waiting a moment for the node to start up..."
-sleep 1m
+sleep 5m
 
 get_current_block
 echo "Syncing to ${TARGET_BLOCK} starting at ${CURRENT_BLOCK}."


### PR DESCRIPTION
# Description

Increase the timeout before we attempt to connect to a node in sync from snapshot tests.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:
