### PR TITLE
A0-4172: Fix for FE e2e nightly

### DIFF
--- a/.github/workflows/nightly-fe-e2e-tests.yml
+++ b/.github/workflows/nightly-fe-e2e-tests.yml
@@ -57,7 +57,7 @@ jobs:
     needs:
       - get-full-docker-image-path
       - build-and-push-featurenet-node-image
-    # to prevent this job to be skipped when on of the parent jobs is skipped
+    # to prevent this job to be skipped when one of the parent jobs is skipped
     if: ${{ !cancelled() }}
     name: Create featurenet from ${{ github.ref }}
     uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create.yml@v6
@@ -75,6 +75,8 @@ jobs:
       - create-featurenet
       - build-aleph-e2e-client-image
     name: Runs finalization e2e on FE
+    # to prevent this job to be skipped when one of the parent jobs is skipped
+    if: ${{ !cancelled() }}
     env:
       # yamllint disable-line rule:line-length
       ALEPH_E2E_CLIENT_IMAGE: '${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}'

--- a/.github/workflows/nightly-fe-e2e-tests.yml
+++ b/.github/workflows/nightly-fe-e2e-tests.yml
@@ -57,7 +57,6 @@ jobs:
     needs:
       - get-full-docker-image-path
       - build-and-push-featurenet-node-image
-    # to prevent this job to be skipped when one of the parent jobs is skipped
     if: ${{ !cancelled() }}
     name: Create featurenet from ${{ github.ref }}
     uses: Cardinal-Cryptography/github-actions/.github/workflows/_featurenet-create.yml@v6
@@ -75,7 +74,6 @@ jobs:
       - create-featurenet
       - build-aleph-e2e-client-image
     name: Runs finalization e2e on FE
-    # to prevent this job to be skipped when one of the parent jobs is skipped
     if: ${{ !cancelled() }}
     env:
       # yamllint disable-line rule:line-length


### PR DESCRIPTION
# Description

When an ECR image exists, this workflow is a no-op and silently skips e2e test run. This is because GHA skips a job when any parent job is skipped.

Unfortunately, there is no way to test this as the scenario in which bug occurs is when there's already an image on ECR, ie when e.g. running this workflow from `main`. So I've just run workflow from this PR https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/8292896136, and if its okay then we can merge this PR and re-run from main to see if it helped.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

