### PR TITLE
A0-4173: Workspace resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "aggregator",


### PR DESCRIPTION
# Description

When working with the `aleph-node` repo (e.g. `./scripts/run_nodes.sh`) one gets:
 
```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```

Fixed it by specifying resolver version in the main `Cargo.toml`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
