### PR TITLE
A0-4174: Ignore aleph-bft-rmc and aleph-bft-types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
           - "*"
     pull-request-branch-name:
       separator: "-"
+    ignore:
+      - dependency-name: "aleph-bft"
+      - dependency-name: "aleph-bft-rmc"
+      - dependency-name: "aleph-bft-types"
 
   - package-ecosystem: github-actions
     directory: /
@@ -36,7 +40,4 @@ updates:
     reviewers:
       - "Marcin-Radecki"
       - "Mikolaj Gasior"
-ignore:
-  - dependency-name: "aleph-bft"
-  - dependency-name: "aleph-bft-rmc"
-  - dependency-name: "aleph-bft-types"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,5 +37,6 @@ updates:
       - "Marcin-Radecki"
       - "Mikolaj Gasior"
 ignore:
+  - dependency-name: "aleph-bft"
   - dependency-name: "aleph-bft-rmc"
   - dependency-name: "aleph-bft-types"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,4 +36,6 @@ updates:
     reviewers:
       - "Marcin-Radecki"
       - "Mikolaj Gasior"
-
+ignore:
+  - dependency-name: "aleph-bft-rmc"
+  - dependency-name: "aleph-bft-types"


### PR DESCRIPTION
Ignore aleph-bft-rmc and aleph-bft-types in dependabot. This is equivalent to running those commands on a PR:

```
https://github.com/dependabot ignore aleph-bft-types
https://github.com/dependabot ignore aleph-bft-rmc
```
