### PR TITLE
A0-4216: Does not depend on actual runtime API in aleph-node: const and types refactor

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -41,7 +41,15 @@ use pallet_session::QueuedKeys;
 pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use primitives::{staking::MAX_NOMINATORS_REWARDED_PER_VALIDATOR, wrap_methods, AlephNodeSessionKeys as SessionKeys, ApiError as AlephApiError, AuraId, AuthorityId as AlephId, Block as AlephBlock, BlockId as AlephBlockId, BlockNumber as AlephBlockNumber, Header as AlephHeader, SessionAuthorityData, SessionCommittee, SessionIndex, SessionInfoProvider, SessionValidatorError, Version as FinalityVersion, ADDRESSES_ENCODING, DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS, DEFAULT_SESSIONS_PER_ERA, DEFAULT_SESSION_PERIOD, MAX_BLOCK_SIZE, MILLISECS_PER_BLOCK, TOKEN, Address};
+use primitives::{
+    staking::MAX_NOMINATORS_REWARDED_PER_VALIDATOR, wrap_methods, Address,
+    AlephNodeSessionKeys as SessionKeys, ApiError as AlephApiError, AuraId, AuthorityId as AlephId,
+    Block as AlephBlock, BlockId as AlephBlockId, BlockNumber as AlephBlockNumber,
+    Header as AlephHeader, SessionAuthorityData, SessionCommittee, SessionIndex,
+    SessionInfoProvider, SessionValidatorError, Version as FinalityVersion, ADDRESSES_ENCODING,
+    DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS, DEFAULT_SESSIONS_PER_ERA,
+    DEFAULT_SESSION_PERIOD, MAX_BLOCK_SIZE, MILLISECS_PER_BLOCK, TOKEN,
+};
 pub use primitives::{AccountId, AccountIndex, Balance, Hash, Nonce, Signature};
 use sp_api::impl_runtime_apis;
 use sp_application_crypto::key_types::AURA;
@@ -957,7 +965,7 @@ pub type SignedExtra = (
 
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =
-generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+    generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
 
 /// Block type as expected by this runtime.
 pub type Block = generic::Block<AlephHeader, UncheckedExtrinsic>;

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -41,15 +41,7 @@ use pallet_session::QueuedKeys;
 pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use primitives::{
-    staking::MAX_NOMINATORS_REWARDED_PER_VALIDATOR, wrap_methods,
-    AlephNodeSessionKeys as SessionKeys, ApiError as AlephApiError, AuraId, AuthorityId as AlephId,
-    Block as AlephBlock, BlockId as AlephBlockId, BlockNumber as AlephBlockNumber,
-    Header as AlephHeader, SessionAuthorityData, SessionCommittee, SessionIndex,
-    SessionInfoProvider, SessionValidatorError, Version as FinalityVersion, ADDRESSES_ENCODING,
-    DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS, DEFAULT_SESSIONS_PER_ERA,
-    DEFAULT_SESSION_PERIOD, MAX_BLOCK_SIZE, MILLISECS_PER_BLOCK, TOKEN,
-};
+use primitives::{staking::MAX_NOMINATORS_REWARDED_PER_VALIDATOR, wrap_methods, AlephNodeSessionKeys as SessionKeys, ApiError as AlephApiError, AuraId, AuthorityId as AlephId, Block as AlephBlock, BlockId as AlephBlockId, BlockNumber as AlephBlockNumber, Header as AlephHeader, SessionAuthorityData, SessionCommittee, SessionIndex, SessionInfoProvider, SessionValidatorError, Version as FinalityVersion, ADDRESSES_ENCODING, DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS, DEFAULT_SESSIONS_PER_ERA, DEFAULT_SESSION_PERIOD, MAX_BLOCK_SIZE, MILLISECS_PER_BLOCK, TOKEN, Address};
 pub use primitives::{AccountId, AccountIndex, Balance, Hash, Nonce, Signature};
 use sp_api::impl_runtime_apis;
 use sp_application_crypto::key_types::AURA;
@@ -951,16 +943,6 @@ construct_runtime!(
     }
 );
 
-/// The address format for describing accounts.
-pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
-/// Block header type as expected by this runtime.
-pub type Header = AlephHeader;
-/// Block type as expected by this runtime.
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-/// A Block signed with a Justification
-pub type SignedBlock = generic::SignedBlock<Block>;
-/// BlockId type as expected by this runtime.
-pub type BlockId = generic::BlockId<Block>;
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
     frame_system::CheckNonZeroSender<Runtime>,
@@ -975,9 +957,15 @@ pub type SignedExtra = (
 
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =
-    generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
-/// Extrinsic type that has already been checked.
-pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
+generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+
+/// Block type as expected by this runtime.
+pub type Block = generic::Block<AlephHeader, UncheckedExtrinsic>;
+/// A Block signed with a Justification
+pub type SignedBlock = generic::SignedBlock<Block>;
+/// BlockId type as expected by this runtime.
+pub type BlockId = generic::BlockId<Block>;
+
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
     Runtime,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -43,75 +43,118 @@ impl_opaque_keys! {
     }
 }
 
-pub type Balance = u128;
-pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type BlockId = generic::BlockId<Block>;
-pub type BlockHash = <Header as HeaderT>::Hash;
+/// The block number type used by AlephNode.
+/// 32-bits will allow for 136 years of blocks assuming 1 block per second.
 pub type BlockNumber = u32;
-pub type SessionCount = u32;
-pub type BlockCount = u32;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
+/// This allows one of several kinds of underlying crypto to be used, so isn't a fixed size when encoded.
 pub type Signature = MultiSignature;
+
+/// Alias to the public key used for this chain, actually a `MultiSigner`. Like the signature, this
+/// also isn't a fixed size when encoded, as different cryptos have different size public keys.
+pub type AccountPublic = <Signature as Verify>::Signer;
 
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
-pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+/// Alias to the opaque account ID type for this chain, actually a `AccountId32`. This is always
+/// 32 bytes.
+pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
 
 /// The type for looking up accounts. We don't expect more than 4 billion of them, but you
 /// never know...
 pub type AccountIndex = u32;
 
-/// Index of a transaction in the chain.
-pub type Nonce = u32;
-
 /// A hash of some data used by the chain.
 pub type Hash = sp_core::H256;
 
-// Default number of heap pages that gives limit of 256MB for a runtime instance since each page is 64KB
+/// Index of a transaction in the chain.
+pub type Nonce = u32;
+
+/// The balance of an account.
+pub type Balance = u128;
+
+/// Header type.
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+
+/// Block type.
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+
+/// Block ID.
+pub type BlockId = generic::BlockId<Block>;
+
+/// Block Hash type
+pub type BlockHash = <Header as HeaderT>::Hash;
+
+/// The address format for describing accounts.
+pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
+
+/// Session Count type
+pub type SessionCount = u32;
+
+/// Block Count type
+pub type BlockCount = u32;
+
+/// Default number of heap pages that gives limit of 256MB for a runtime instance since each page is 64KB
 pub const HEAP_PAGES: u64 = 4096;
 
+/// How much execution time fits in a single block
 pub const MILLISECS_PER_BLOCK: u64 = 1000;
-// We agreed to 5MB as the block size limit.
+
+/// Block size limit.
 pub const MAX_BLOCK_SIZE: u32 = 5 * 1024 * 1024;
 
-// Quick sessions for testing purposes
+// --------------- Test build  ---------------------
+/// How many blocks is in single session
 #[cfg(feature = "short_session")]
 pub const DEFAULT_SESSION_PERIOD: u32 = 30;
+
+/// How many sessions is in single era
 #[cfg(feature = "short_session")]
 pub const DEFAULT_SESSIONS_PER_ERA: SessionIndex = 3;
+// --------------- Test build end  ---------------------
 
-// Default values outside testing
+// --------------- Production build ---------------------
+/// How many blocks is in single session
 #[cfg(not(feature = "short_session"))]
 pub const DEFAULT_SESSION_PERIOD: u32 = 900;
+
+/// How many sessions is in single era
 #[cfg(not(feature = "short_session"))]
 pub const DEFAULT_SESSIONS_PER_ERA: SessionIndex = 96;
+// --------------- Production build end ---------------------
 
+/// How many decimals AZERO coin has
 pub const TOKEN_DECIMALS: u32 = 12;
+
+/// Representation of 1 AZERO coin
 pub const TOKEN: u128 = 10u128.pow(TOKEN_DECIMALS);
 
+/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
 pub const ADDRESSES_ENCODING: u8 = 42;
+
+/// ABFT unit creation delay (in ms)
 pub const DEFAULT_UNIT_CREATION_DELAY: u64 = 300;
 
+/// Committe Size for new chains
 pub const DEFAULT_COMMITTEE_SIZE: u32 = 4;
-
-pub const DEFAULT_BAN_MINIMAL_EXPECTED_PERFORMANCE: Perbill = Perbill::from_percent(0);
-pub const DEFAULT_BAN_SESSION_COUNT_THRESHOLD: SessionCount = 3;
-pub const DEFAULT_BAN_REASON_LENGTH: u32 = 300;
-pub const DEFAULT_MAX_WINNERS: u32 = u32::MAX;
 
 pub const DEFAULT_CLEAN_SESSION_COUNTER_DELAY: SessionCount = 960;
 pub const DEFAULT_BAN_PERIOD: EraIndex = 10;
 
 /// Version returned when no version has been set.
 pub const DEFAULT_FINALITY_VERSION: Version = 0;
+
 /// Current version of abft.
 pub const CURRENT_FINALITY_VERSION: u16 = LEGACY_FINALITY_VERSION + 1;
+
 /// Legacy version of abft.
 pub const LEGACY_FINALITY_VERSION: u16 = 2;
+
+/// Percentage of validator performance that is treated as 100% performance
 pub const LENIENT_THRESHOLD: Perquintill = Perquintill::from_percent(90);
 
+/// Amount of non-finalized blocks that halts block production
 pub const DEFAULT_MAX_NON_FINALIZED_BLOCKS: u32 = 20;
 
 /// Hold set of validators that produce blocks and set of validators that participate in finality
@@ -175,6 +218,11 @@ pub struct BanConfig {
     /// how many eras a validator is banned for
     pub ban_period: EraIndex,
 }
+
+pub const DEFAULT_BAN_MINIMAL_EXPECTED_PERFORMANCE: Perbill = Perbill::from_percent(0);
+pub const DEFAULT_BAN_SESSION_COUNT_THRESHOLD: SessionCount = 3;
+pub const DEFAULT_BAN_REASON_LENGTH: u32 = 300;
+pub const DEFAULT_MAX_WINNERS: u32 = u32::MAX;
 
 impl Default for BanConfig {
     fn default() -> Self {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -154,7 +154,7 @@ pub const LEGACY_FINALITY_VERSION: u16 = 2;
 /// Percentage of validator performance that is treated as 100% performance
 pub const LENIENT_THRESHOLD: Perquintill = Perquintill::from_percent(90);
 
-/// Amount of non-finalized blocks that halts block production
+/// Number of non-finalized blocks that halts block production
 pub const DEFAULT_MAX_NON_FINALIZED_BLOCKS: u32 = 20;
 
 /// Hold set of validators that produce blocks and set of validators that participate in finality

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -95,7 +95,7 @@ pub type SessionCount = u32;
 /// Block Count type
 pub type BlockCount = u32;
 
-/// Default number of heap pages that gives limit of 256MB for a runtime instance since each page is 64KB
+/// Default number of heap pages. That gives a limit of 256MB for a runtime instance, since each page is 64KB
 pub const HEAP_PAGES: u64 = 4096;
 
 /// How much execution time fits in a single block

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -136,7 +136,7 @@ pub const ADDRESSES_ENCODING: u8 = 42;
 /// ABFT unit creation delay (in ms)
 pub const DEFAULT_UNIT_CREATION_DELAY: u64 = 300;
 
-/// Committe Size for new chains
+/// Committee Size for new chains
 pub const DEFAULT_COMMITTEE_SIZE: u32 = 4;
 
 pub const DEFAULT_CLEAN_SESSION_COUNTER_DELAY: SessionCount = 960;


### PR DESCRIPTION
# Description

This PR moves some types from `aleph-runtime` to `primitives`. Also, it cleans up and documents most of the types and consts in `primitives`. I used https://github.com/Cardinal-Cryptography/polkadot-sdk/blob/aleph-v1.4.0/polkadot/node/service/src/lib.rs as a baseline for types, their order in the file and comments.

What can't be extracted though is `Block` type and its dependees. This is because, in `primitives` it uses `OpaqueExtrinsic`, and in runtime non-opaque one, so there are different types.

This is PR 1/2 of incorporating [`fake_runtime_api.rs`](https://github.com/Cardinal-Cryptography/polkadot-sdk/blob/aleph-v1.4.0/polkadot/node/service/src/fake_runtime_api.rs) into `aleph-node`.

