### PR TITLE
A0-4216: Does not depend on actual runtime API in aleph-node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,6 @@ dependencies = [
  "parity-scale-codec",
  "primitives",
  "sc-basic-authorship",
- "sc-block-builder",
  "sc-chain-spec",
  "sc-cli",
  "sc-client-api",
@@ -315,7 +314,6 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-aura",
  "sp-core",
- "sp-inherents",
  "sp-io",
  "sp-keystore",
  "sp-runtime",
@@ -2486,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "finality-aleph"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aggregator 0.4.0",
  "aggregator 0.6.0",
@@ -2495,7 +2493,6 @@ dependencies = [
  "aleph-bft-crypto 0.8.0",
  "aleph-bft-rmc 0.11.1",
  "aleph-bft-rmc 0.6.1",
- "aleph-runtime",
  "async-trait",
  "bytes",
  "derive_more",
@@ -6457,18 +6454,28 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "0.8.1"
+version = "0.14.0+dev"
 dependencies = [
+ "frame-support",
+ "frame-system-rpc-runtime-api",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-api",
  "sp-application-crypto",
+ "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
+ "sp-inherents",
+ "sp-offchain",
  "sp-runtime",
+ "sp-session",
  "sp-staking",
  "sp-std",
+ "sp-transaction-pool",
+ "sp-version",
 ]
 
 [[package]]

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -28,7 +28,6 @@ static_assertions = { workspace = true }
 thiserror = { workspace = true }
 
 sc-basic-authorship = { workspace = true }
-sc-block-builder = { workspace = true }
 sc-chain-spec = { workspace = true }
 sc-cli = { workspace = true }
 sc-client-api = { workspace = true }
@@ -43,13 +42,12 @@ sc-service = { workspace = true }
 sc-telemetry = { workspace = true }
 sc-transaction-pool = { workspace = true }
 sc-transaction-pool-api = { workspace = true }
-
 sp-application-crypto = { workspace = true }
 sp-arithmetic = { workspace = true }
+sp-block-builder = { workspace = true }
 sp-consensus = { workspace = true }
 sp-consensus-aura = { workspace = true }
 sp-core = { workspace = true }
-sp-inherents = { workspace = true }
 sp-io = { workspace = true }
 sp-keystore = { workspace = true }
 sp-runtime = { workspace = true }
@@ -62,7 +60,9 @@ try-runtime-cli = { workspace = true, optional = true }
 frame-benchmarking-cli = { workspace = true, optional = true }
 frame-benchmarking = { workspace = true, optional = true }
 
+# this is only neeeded for chainspec generation
 aleph-runtime = { workspace = true }
+
 aleph-runtime-interfaces = { workspace = true }
 finality-aleph = { workspace = true }
 primitives = { workspace = true }
@@ -73,7 +73,7 @@ sc-rpc = { workspace = true }
 sc-rpc-api = { workspace = true }
 sp-api = { workspace = true }
 sp-blockchain = { workspace = true }
-sp-block-builder = { workspace = true }
+
 substrate-frame-rpc-system = { workspace = true }
 pallet-transaction-payment-rpc = { workspace = true }
 
@@ -84,7 +84,7 @@ substrate-build-script-utils = { workspace = true }
 default = []
 short_session = [
     "aleph-runtime/short_session",
-    "primitives/short_session"
+    "primitives/short_session",
 ]
 try-runtime = [
     "aleph-runtime/try-runtime",

--- a/bin/node/src/aleph_cli.rs
+++ b/bin/node/src/aleph_cli.rs
@@ -2,9 +2,8 @@ use std::path::PathBuf;
 
 use finality_aleph::UnitCreationDelay;
 use log::warn;
+use primitives::{DEFAULT_MAX_NON_FINALIZED_BLOCKS, DEFAULT_UNIT_CREATION_DELAY};
 use sc_cli::clap::{self, ArgGroup, Parser};
-
-use crate::aleph_primitives::{DEFAULT_MAX_NON_FINALIZED_BLOCKS, DEFAULT_UNIT_CREATION_DELAY};
 
 #[derive(Debug, Parser, Clone)]
 #[clap(group(ArgGroup::new("backup")))]

--- a/bin/node/src/chain_spec.rs
+++ b/bin/node/src/chain_spec.rs
@@ -1,12 +1,18 @@
 use std::{collections::HashSet, str::FromStr, string::ToString};
 
 use aleph_runtime::{
-    AccountId, AlephConfig, AuraConfig, BalancesConfig, CommitteeManagementConfig, ElectionsConfig,
-    Feature, FeatureControlConfig, Perbill, RuntimeGenesisConfig, SessionConfig, StakingConfig,
-    SudoConfig, SystemConfig, VestingConfig, WASM_BINARY,
+    AlephConfig, AuraConfig, BalancesConfig, CommitteeManagementConfig, ElectionsConfig, Feature,
+    FeatureControlConfig, Perbill, RuntimeGenesisConfig, SessionConfig, StakingConfig, SudoConfig,
+    SystemConfig, VestingConfig, WASM_BINARY,
 };
 use libp2p::PeerId;
 use pallet_staking::{Forcing, StakerStatus};
+use primitives::{
+    staking::{MIN_NOMINATOR_BOND, MIN_VALIDATOR_BOND},
+    AccountId, AlephNodeSessionKeys as SessionKeys, AuraId, AuthorityId as AlephId,
+    SessionValidators, Version as FinalityVersion, ADDRESSES_ENCODING, LEGACY_FINALITY_VERSION,
+    TOKEN_DECIMALS,
+};
 use sc_cli::{
     clap::{self, Args},
     Error as CliError,
@@ -16,12 +22,6 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Number, Value};
 use sp_application_crypto::Ss58Codec;
 use sp_core::{sr25519, Pair};
-
-use crate::aleph_primitives::{
-    staking::{MIN_NOMINATOR_BOND, MIN_VALIDATOR_BOND},
-    AlephNodeSessionKeys as SessionKeys, AuraId, AuthorityId as AlephId, SessionValidators,
-    Version as FinalityVersion, ADDRESSES_ENCODING, LEGACY_FINALITY_VERSION, TOKEN_DECIMALS,
-};
 
 pub const CHAINTYPE_DEV: &str = "dev";
 pub const CHAINTYPE_LOCAL: &str = "local";

--- a/bin/node/src/commands.rs
+++ b/bin/node/src/commands.rs
@@ -4,8 +4,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use aleph_runtime::AccountId;
 use libp2p::identity::{ed25519 as libp2p_ed25519, PublicKey};
+use primitives::{AccountId, AuraId, AuthorityId as AlephId};
 use sc_cli::{
     clap::{self, Args, Parser},
     Error, KeystoreParams,
@@ -15,12 +15,9 @@ use sc_service::config::{BasePath, KeystoreConfig};
 use sp_application_crypto::{key_types, Ss58Codec};
 use sp_keystore::Keystore;
 
-use crate::{
-    aleph_primitives::{AuraId, AuthorityId as AlephId},
-    chain_spec::{
-        self, account_id_from_string, AuthorityKeys, ChainParams, ChainSpec, SerializablePeerId,
-        DEFAULT_BACKUP_FOLDER,
-    },
+use crate::chain_spec::{
+    self, account_id_from_string, AuthorityKeys, ChainParams, ChainSpec, SerializablePeerId,
+    DEFAULT_BACKUP_FOLDER,
 };
 
 #[derive(Debug, Args)]
@@ -67,10 +64,10 @@ fn aura_key(keystore: &impl Keystore) -> AuraId {
 
 /// returns Aleph key, if absent a new key is generated
 fn aleph_key(keystore: &impl Keystore) -> AlephId {
-    Keystore::ed25519_public_keys(keystore, crate::aleph_primitives::KEY_TYPE)
+    Keystore::ed25519_public_keys(keystore, primitives::KEY_TYPE)
         .pop()
         .unwrap_or_else(|| {
-            Keystore::ed25519_generate_new(keystore, crate::aleph_primitives::KEY_TYPE, None)
+            Keystore::ed25519_generate_new(keystore, primitives::KEY_TYPE, None)
                 .expect("Could not create Aleph key")
         })
         .into()

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -10,5 +10,4 @@ mod service;
 
 pub use cli::{Cli, Subcommand};
 pub use executor::ExecutorDispatch;
-use primitives as aleph_primitives;
 pub use service::{new_authority, new_partial};

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -87,8 +87,7 @@ fn main() -> sc_cli::Result<()> {
         #[cfg(feature = "try-runtime")]
         Some(Subcommand::TryRuntime(cmd)) => {
             use aleph_node::ExecutorDispatch;
-            use primitives::Block;
-            use primitives::MILLISECS_PER_BLOCK;
+            use primitives::{Block, MILLISECS_PER_BLOCK};
             use sc_executor::{sp_wasm_interface::ExtendedHostFunctions, NativeExecutionDispatch};
             use try_runtime_cli::block_building_info::timestamp_with_aura_info;
 

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -7,8 +7,6 @@ use pruning_config::PruningConfigValidator;
 use sc_cli::{clap::Parser, SubstrateCli};
 use sc_network::config::Role;
 use sc_service::{Configuration, PartialComponents};
-#[cfg(any(feature = "try-runtime", feature = "runtime-benchmarks"))]
-use {aleph_node::ExecutorDispatch, aleph_runtime::Block, sc_executor::NativeExecutionDispatch};
 
 fn enforce_heap_pages(config: &mut Configuration) {
     config.default_heap_pages = Some(HEAP_PAGES);
@@ -88,9 +86,12 @@ fn main() -> sc_cli::Result<()> {
         }
         #[cfg(feature = "try-runtime")]
         Some(Subcommand::TryRuntime(cmd)) => {
+            use aleph_node::ExecutorDispatch;
+            use primitives::Block;
             use primitives::MILLISECS_PER_BLOCK;
             use sc_executor::{sp_wasm_interface::ExtendedHostFunctions, NativeExecutionDispatch};
             use try_runtime_cli::block_building_info::timestamp_with_aura_info;
+
             let runner = cli.create_runner(cmd)?;
             runner.async_run(|config| {
                 let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
@@ -99,6 +100,12 @@ fn main() -> sc_cli::Result<()> {
                         .map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
 
                 Ok((
+                    // TODO
+                    // warning: use of deprecated method `try_runtime_cli::TryRuntimeCmd::run`:
+                    // Substrate's `try-runtime` subcommand has been migrated to a standalone CLI
+                    // (https://github.com/paritytech/try-runtime-cli). It is no longer being
+                    // maintained here and will be removed entirely some time after January 2024.
+                    // Please remove this subcommand from your runtime and use the standalone CLI.
                     cmd.run::<Block, ExtendedHostFunctions<
                         sp_io::SubstrateHostFunctions,
                         <ExecutorDispatch as NativeExecutionDispatch>::ExtendHostFunctions,
@@ -115,6 +122,10 @@ fn main() -> sc_cli::Result<()> {
             .into()),
         #[cfg(feature = "runtime-benchmarks")]
         Some(Subcommand::Benchmark(cmd)) => {
+            use aleph_node::ExecutorDispatch;
+            use primitives::Block;
+            use sc_executor::NativeExecutionDispatch;
+
             let runner = cli.create_runner(cmd)?;
             runner.sync_run(|config| {
                 if let frame_benchmarking_cli::BenchmarkCmd::Pallet(cmd) = cmd {

--- a/bin/node/src/rpc.rs
+++ b/bin/node/src/rpc.rs
@@ -7,10 +7,10 @@
 
 use std::sync::Arc;
 
-use aleph_runtime::{opaque::Block, AccountId, Balance, Nonce};
 use finality_aleph::{Justification, JustificationTranslator, ValidatorAddressCache};
 use futures::channel::mpsc;
 use jsonrpsee::RpcModule;
+use primitives::{AccountId, Balance, Block, Nonce};
 use sc_client_api::StorageProvider;
 pub use sc_rpc_api::DenyUnsafe;
 use sc_transaction_pool_api::TransactionPool;

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -5,7 +5,6 @@ use std::{
     sync::Arc,
 };
 
-use aleph_runtime::{self, opaque::Block, RuntimeApi};
 use finality_aleph::{
     run_validator_node, AlephBlockImport, AlephConfig, AllBlockMetrics, BlockImporter,
     ChannelProvider, Justification, JustificationTranslator, MillisecsPerBlock, Protocol,
@@ -13,6 +12,7 @@ use finality_aleph::{
     SubstrateNetwork, SyncOracle, TracingBlockImport, ValidatorAddressCache,
 };
 use log::warn;
+use primitives::{fake_runtime_api::RuntimeApi, AlephSessionApi, Block, MAX_BLOCK_SIZE};
 use sc_basic_authorship::ProposerFactory;
 use sc_client_api::{BlockBackend, HeaderBackend};
 use sc_consensus::ImportQueue;
@@ -28,7 +28,6 @@ use sp_consensus_aura::{sr25519::AuthorityPair as AuraPair, Slot};
 
 use crate::{
     aleph_cli::AlephCli,
-    aleph_primitives::{AlephSessionApi, MAX_BLOCK_SIZE},
     chain_spec::DEFAULT_BACKUP_FOLDER,
     executor::AlephExecutor,
     rpc::{create_full as create_full_rpc, FullDeps as RpcFullDeps},

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -12,7 +12,9 @@ use finality_aleph::{
     SubstrateNetwork, SyncOracle, TracingBlockImport, ValidatorAddressCache,
 };
 use log::warn;
-use primitives::{fake_runtime_api::RuntimeApi, AlephSessionApi, Block, MAX_BLOCK_SIZE};
+use primitives::{
+    fake_runtime_api::fake_runtime::RuntimeApi, AlephSessionApi, Block, MAX_BLOCK_SIZE,
+};
 use sc_basic_authorship::ProposerFactory;
 use sc_client_api::{BlockBackend, HeaderBackend};
 use sc_consensus::ImportQueue;

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -1070,10 +1070,6 @@ impl_runtime_apis! {
         ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
             TransactionPayment::query_info(uxt, len)
         }
-        // TODO check if it's needed, it exists in polkadot-sdk 1.4.0 fake_runtime.rs
-        // fn query_info(_: <Block as BlockT>::Extrinsic, _: u32) -> RuntimeDispatchInfo<Balance> {
-        //     unimplemented!()
-        // }
         fn query_fee_details(
             uxt: <Block as BlockT>::Extrinsic,
             len: u32,

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -44,10 +44,9 @@ use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use primitives::{
     staking::MAX_NOMINATORS_REWARDED_PER_VALIDATOR, wrap_methods, Address,
     AlephNodeSessionKeys as SessionKeys, ApiError as AlephApiError, AuraId, AuthorityId as AlephId,
-    Block as AlephBlock, BlockId as AlephBlockId, BlockNumber as AlephBlockNumber,
-    Header as AlephHeader, SessionAuthorityData, SessionCommittee, SessionIndex,
-    SessionInfoProvider, SessionValidatorError, Version as FinalityVersion, ADDRESSES_ENCODING,
-    DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS, DEFAULT_SESSIONS_PER_ERA,
+    BlockNumber as AlephBlockNumber, Header as AlephHeader, SessionAuthorityData, SessionCommittee,
+    SessionIndex, SessionInfoProvider, SessionValidatorError, Version as FinalityVersion,
+    ADDRESSES_ENCODING, DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS, DEFAULT_SESSIONS_PER_ERA,
     DEFAULT_SESSION_PERIOD, MAX_BLOCK_SIZE, MILLISECS_PER_BLOCK, TOKEN,
 };
 pub use primitives::{AccountId, AccountIndex, Balance, Hash, Nonce, Signature};
@@ -58,7 +57,7 @@ use sp_core::{crypto::KeyTypeId, ConstU128, OpaqueMetadata};
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 use sp_runtime::{
-    create_runtime_str, generic, impl_opaque_keys,
+    create_runtime_str, generic,
     traits::{
         AccountIdLookup, BlakeTwo256, Block as BlockT, Bounded, Convert, ConvertInto,
         IdentityLookup, One, OpaqueKeys,
@@ -72,30 +71,6 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-
-/// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
-/// the specifics of the runtime. They can then be made to be agnostic over specific formats
-/// of data like extrinsics, allowing for them to continue syncing the network through upgrades
-/// to even the core data structures.
-pub mod opaque {
-    pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
-
-    use super::*;
-
-    /// Opaque block header type.
-    pub type Header = AlephHeader;
-    /// Opaque block type.
-    pub type Block = AlephBlock;
-    /// Opaque block identifier type.
-    pub type BlockId = AlephBlockId;
-
-    impl_opaque_keys! {
-        pub struct SessionKeys {
-            pub aura: Aura,
-            pub aleph: Aleph,
-        }
-    }
-}
 
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
@@ -1072,13 +1047,13 @@ impl_runtime_apis! {
 
     impl sp_session::SessionKeys<Block> for Runtime {
         fn generate_session_keys(seed: Option<Vec<u8>>) -> Vec<u8> {
-            opaque::SessionKeys::generate(seed)
+            SessionKeys::generate(seed)
         }
 
         fn decode_session_keys(
             encoded: Vec<u8>,
         ) -> Option<Vec<(Vec<u8>, KeyTypeId)>> {
-            opaque::SessionKeys::decode_into_raw_public_keys(&encoded)
+            SessionKeys::decode_into_raw_public_keys(&encoded)
         }
     }
 
@@ -1095,6 +1070,10 @@ impl_runtime_apis! {
         ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
             TransactionPayment::query_info(uxt, len)
         }
+        // TODO check if it's needed, it exists in polkadot-sdk 1.4.0 fake_runtime.rs
+        // fn query_info(_: <Block as BlockT>::Extrinsic, _: u32) -> RuntimeDispatchInfo<Balance> {
+        //     unimplemented!()
+        // }
         fn query_fee_details(
             uxt: <Block as BlockT>::Extrinsic,
             len: u32,

--- a/finality-aleph/Cargo.toml
+++ b/finality-aleph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finality-aleph"
-version = "0.10.0"
+version = "0.11.0"
 license = "Apache 2.0"
 authors.workspace = true
 edition.workspace = true
@@ -79,7 +79,6 @@ substrate-test-runtime = { workspace = true }
 substrate-test-client = { workspace = true }
 sc-block-builder = { workspace = true }
 sc-basic-authorship = { workspace = true }
-aleph-runtime = { workspace = true }
 
 [features]
 only_legacy = []

--- a/finality-aleph/src/testing/mocks/client.rs
+++ b/finality-aleph/src/testing/mocks/client.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use primitives::{BlockHash, BlockNumber};
+use primitives::{fake_runtime_api, BlockHash, BlockNumber};
 use sp_blockchain::HeaderBackend;
 use substrate_test_client::{client, sc_client_db, sc_executor};
 use substrate_test_runtime_client::{GenesisParameters, LocalExecutorDispatch};
@@ -26,7 +26,7 @@ pub type TestClient = client::Client<
     Backend,
     client::LocalCallExecutor<TBlock, Backend, ExecutorDispatch>,
     TBlock,
-    aleph_runtime::RuntimeApi,
+    fake_runtime_api::RuntimeApi,
 >;
 
 /// A `test-runtime` extensions to `TestClientBuilder`.

--- a/finality-aleph/src/testing/mocks/client.rs
+++ b/finality-aleph/src/testing/mocks/client.rs
@@ -26,7 +26,7 @@ pub type TestClient = client::Client<
     Backend,
     client::LocalCallExecutor<TBlock, Backend, ExecutorDispatch>,
     TBlock,
-    fake_runtime_api::RuntimeApi,
+    fake_runtime_api::fake_runtime::RuntimeApi,
 >;
 
 /// A `test-runtime` extensions to `TestClientBuilder`.

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitives"
-version = "0.8.1"
+version = "0.14.0+dev"
 license = "Apache 2.0"
 authors.workspace = true
 edition.workspace = true
@@ -20,6 +20,19 @@ sp-std = { workspace = true }
 sp-staking = { workspace = true }
 sp-consensus-aura = { workspace = true }
 
+frame-support = { workspace = true, optional = true }
+frame-system-rpc-runtime-api = { workspace = true, optional = true }
+
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+
+sp-version = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-offchain = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-session = { workspace = true }
+sp-inherents = { workspace = true }
+
 [features]
 default = ["std"]
 std = [
@@ -32,6 +45,9 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "sp-staking/std",
-    "sp-consensus-aura/std"
+    "sp-consensus-aura/std",
+
+    "frame-support/std",
+    "frame-system-rpc-runtime-api/std",
 ]
 short_session = []

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -46,8 +46,18 @@ std = [
     "sp-std/std",
     "sp-staking/std",
     "sp-consensus-aura/std",
+    "sp-version/std",
+    "sp-block-builder/std",
+    "sp-offchain/std",
+    "sp-transaction-pool/std",
+    "sp-session/std",
+    "sp-inherents/std",
 
     "frame-support/std",
     "frame-system-rpc-runtime-api/std",
+
+    "pallet-transaction-payment-rpc-runtime-api/std",
+    "pallet-transaction-payment/std",
+
 ]
 short_session = []

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -20,8 +20,8 @@ sp-std = { workspace = true }
 sp-staking = { workspace = true }
 sp-consensus-aura = { workspace = true }
 
-frame-support = { workspace = true, optional = true }
-frame-system-rpc-runtime-api = { workspace = true, optional = true }
+frame-support = { workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
 
 pallet-transaction-payment = { workspace = true }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true }

--- a/primitives/src/fake_runtime_api.rs
+++ b/primitives/src/fake_runtime_api.rs
@@ -1,0 +1,243 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Provides "fake" runtime API implementations
+//!
+//! These are used to provide a type that implements these runtime APIs without requiring to import
+//! the native runtimes.
+
+use frame_support::weights::Weight;
+use pallet_transaction_payment::FeeDetails;
+use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
+use sp_consensus_aura::SlotDuration;
+use sp_core::OpaqueMetadata;
+use sp_runtime::{
+    traits::Block as BlockT,
+    transaction_validity::{TransactionSource, TransactionValidity},
+    ApplyExtrinsicResult,
+};
+use sp_version::RuntimeVersion;
+
+use crate::{
+    AccountId, ApiError as AlephApiError, AuraId, AuthorityId as AlephId, Balance, Block, Nonce,
+    SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError,
+    Version as FinalityVersion,
+};
+
+pub struct Runtime;
+
+sp_api::impl_runtime_apis! {
+    impl sp_api::Core<Block> for Runtime {
+        fn version() -> RuntimeVersion {
+            unimplemented!()
+        }
+
+        fn execute_block(_: Block) {
+            unimplemented!()
+        }
+
+        fn initialize_block(_: &<Block as BlockT>::Header) {
+            unimplemented!()
+        }
+    }
+
+    impl sp_api::Metadata<Block> for Runtime {
+        fn metadata() -> OpaqueMetadata {
+            unimplemented!()
+        }
+
+        fn metadata_at_version(_: u32) -> Option<OpaqueMetadata> {
+            unimplemented!()
+        }
+
+        fn metadata_versions() -> Vec<u32> {
+            unimplemented!()
+        }
+    }
+
+    impl sp_block_builder::BlockBuilder<Block> for Runtime {
+        fn apply_extrinsic(_: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+            unimplemented!()
+        }
+
+        fn finalize_block() -> <Block as BlockT>::Header {
+            unimplemented!()
+        }
+
+        fn inherent_extrinsics(_: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+            unimplemented!()
+        }
+
+        fn check_inherents(
+            _: Block,
+            _: sp_inherents::InherentData,
+        ) -> sp_inherents::CheckInherentsResult {
+            unimplemented!()
+        }
+    }
+
+    impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
+        fn validate_transaction(
+            _: TransactionSource,
+            _: <Block as BlockT>::Extrinsic,
+            _: <Block as BlockT>::Hash,
+        ) -> TransactionValidity {
+            unimplemented!()
+        }
+    }
+
+    impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
+        fn slot_duration() -> SlotDuration {
+            unimplemented!()
+        }
+
+        fn authorities() -> Vec<AuraId> {
+            unimplemented!()
+        }
+    }
+
+    impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
+        fn offchain_worker(_: &<Block as BlockT>::Header) {
+            unimplemented!()
+        }
+    }
+
+    impl sp_session::SessionKeys<Block> for Runtime {
+        fn generate_session_keys(_: Option<Vec<u8>>) -> Vec<u8> {
+            unimplemented!()
+        }
+
+        fn decode_session_keys(
+            _: Vec<u8>,
+        ) -> Option<Vec<(Vec<u8>, sp_core::crypto::KeyTypeId)>> {
+            unimplemented!()
+        }
+    }
+
+    impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Nonce> for Runtime {
+        fn account_nonce(_: AccountId) -> Nonce {
+            unimplemented!()
+        }
+    }
+
+    impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<
+        Block,
+        Balance,
+    > for Runtime {
+        fn query_info(_: <Block as BlockT>::Extrinsic, _: u32) -> RuntimeDispatchInfo<Balance> {
+            unimplemented!()
+        }
+        fn query_fee_details(_: <Block as BlockT>::Extrinsic, _: u32) -> FeeDetails<Balance> {
+            unimplemented!()
+        }
+        fn query_weight_to_fee(_: Weight) -> Balance {
+            unimplemented!()
+        }
+        fn query_length_to_fee(_: u32) -> Balance {
+            unimplemented!()
+        }
+    }
+
+     impl crate::AlephSessionApi<Block> for Runtime {
+        fn millisecs_per_block() -> u64 {
+            unimplemented!()
+        }
+
+        fn session_period() -> u32 {
+            unimplemented!()
+        }
+
+        fn authorities() -> Vec<AlephId> {
+            unimplemented!()
+        }
+
+        fn next_session_authorities() -> Result<Vec<AlephId>, AlephApiError> {
+            unimplemented!()
+        }
+
+        fn authority_data() -> SessionAuthorityData {
+            unimplemented!()
+        }
+
+        fn next_session_authority_data() -> Result<SessionAuthorityData, AlephApiError> {
+            unimplemented!()
+        }
+
+        fn finality_version() -> FinalityVersion {
+            unimplemented!()
+        }
+
+        fn next_session_finality_version() -> FinalityVersion {
+            unimplemented!()
+        }
+
+        fn predict_session_committee(
+            _session: SessionIndex,
+        ) -> Result<SessionCommittee<AccountId>, SessionValidatorError> {
+            unimplemented!()
+        }
+
+        fn next_session_aura_authorities() -> Vec<(AccountId, AuraId)> {
+            unimplemented!()
+        }
+
+        fn key_owner(_key: AlephId) -> Option<AccountId> {
+            unimplemented!()
+        }
+    }
+
+    /// There’s an important remark on how this fake runtime must be implemented - it does not need to
+    /// have all the same entries like `impl_runtime_apis!` has - in particular, it does not need an
+    /// implementation for
+    ///  * `pallet_nomination_pools_runtime_api::NominationPoolsApi`
+    ///  * `pallet_staking_runtime_api::StakingApi`
+    ///  * `pallet_contracts::ContractsApi`
+    /// ie, code compiles without them, even though real runtime has those.
+    /// Why? Because this fake runtime API is only used only for sake of compilation, so as long
+    /// as `fake_runtime_api` implements no less than real runtime API, we’re good.
+
+    #[cfg(feature = "try-runtime")]
+    impl frame_try_runtime::TryRuntime<Block> for Runtime {
+        fn on_runtime_upgrade(checks: frame_try_runtime::UpgradeCheckSelect) -> (Weight, Weight) {
+             unimplemented!()
+        }
+
+        fn execute_block(
+            block: Block,
+            state_root_check: bool,
+            checks: bool,
+            select: frame_try_runtime::TryStateSelect,
+        ) -> Weight {
+             unimplemented!()
+        }
+     }
+
+    #[cfg(feature = "runtime-benchmarks")]
+    impl frame_benchmarking::Benchmark<Block> for Runtime {
+        fn benchmark_metadata(extra: bool) -> (
+            Vec<frame_benchmarking::BenchmarkList>,
+            Vec<frame_support::traits::StorageInfo>,
+        ) {
+             unimplemented!()
+        }
+
+        fn dispatch_benchmark(
+            config: frame_benchmarking::BenchmarkConfig
+        ) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
+             unimplemented!()
+        }
+     }
+}

--- a/primitives/src/fake_runtime_api.rs
+++ b/primitives/src/fake_runtime_api.rs
@@ -1,19 +1,3 @@
-// Copyright (C) Parity Technologies (UK) Ltd.
-// This file is part of Polkadot.
-
-// Polkadot is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// Polkadot is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
-
 //! Provides "fake" runtime API implementations
 //!
 //! These are used to provide a type that implements these runtime APIs without requiring to import

--- a/primitives/src/fake_runtime_api.rs
+++ b/primitives/src/fake_runtime_api.rs
@@ -38,7 +38,9 @@ use crate::{
     Version as FinalityVersion,
 };
 
+#[cfg(feature = "std")]
 pub mod fake_runtime {
+
     pub struct Runtime;
 
     use super::*;

--- a/primitives/src/fake_runtime_api.rs
+++ b/primitives/src/fake_runtime_api.rs
@@ -38,207 +38,211 @@ use crate::{
     Version as FinalityVersion,
 };
 
-pub struct Runtime;
+pub mod fake_runtime {
+    pub struct Runtime;
 
-sp_api::impl_runtime_apis! {
-    impl sp_api::Core<Block> for Runtime {
-        fn version() -> RuntimeVersion {
-            unimplemented!()
+    use super::*;
+
+    sp_api::impl_runtime_apis! {
+        impl sp_api::Core<Block> for Runtime {
+            fn version() -> RuntimeVersion {
+                unimplemented!()
+            }
+
+            fn execute_block(_: Block) {
+                unimplemented!()
+            }
+
+            fn initialize_block(_: &<Block as BlockT>::Header) {
+                unimplemented!()
+            }
         }
 
-        fn execute_block(_: Block) {
-            unimplemented!()
+        impl sp_api::Metadata<Block> for Runtime {
+            fn metadata() -> OpaqueMetadata {
+                unimplemented!()
+            }
+
+            fn metadata_at_version(_: u32) -> Option<OpaqueMetadata> {
+                unimplemented!()
+            }
+
+            fn metadata_versions() -> Vec<u32> {
+                unimplemented!()
+            }
         }
 
-        fn initialize_block(_: &<Block as BlockT>::Header) {
-            unimplemented!()
+        impl sp_block_builder::BlockBuilder<Block> for Runtime {
+            fn apply_extrinsic(_: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+                unimplemented!()
+            }
+
+            fn finalize_block() -> <Block as BlockT>::Header {
+                unimplemented!()
+            }
+
+            fn inherent_extrinsics(_: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+                unimplemented!()
+            }
+
+            fn check_inherents(
+                _: Block,
+                _: sp_inherents::InherentData,
+            ) -> sp_inherents::CheckInherentsResult {
+                unimplemented!()
+            }
         }
+
+        impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
+            fn validate_transaction(
+                _: TransactionSource,
+                _: <Block as BlockT>::Extrinsic,
+                _: <Block as BlockT>::Hash,
+            ) -> TransactionValidity {
+                unimplemented!()
+            }
+        }
+
+        impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
+            fn slot_duration() -> SlotDuration {
+                unimplemented!()
+            }
+
+            fn authorities() -> Vec<AuraId> {
+                unimplemented!()
+            }
+        }
+
+        impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
+            fn offchain_worker(_: &<Block as BlockT>::Header) {
+                unimplemented!()
+            }
+        }
+
+        impl sp_session::SessionKeys<Block> for Runtime {
+            fn generate_session_keys(_: Option<Vec<u8>>) -> Vec<u8> {
+                unimplemented!()
+            }
+
+            fn decode_session_keys(
+                _: Vec<u8>,
+            ) -> Option<Vec<(Vec<u8>, sp_core::crypto::KeyTypeId)>> {
+                unimplemented!()
+            }
+        }
+
+        impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Nonce> for Runtime {
+            fn account_nonce(_: AccountId) -> Nonce {
+                unimplemented!()
+            }
+        }
+
+        impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<
+            Block,
+            Balance,
+        > for Runtime {
+            fn query_info(_: <Block as BlockT>::Extrinsic, _: u32) -> RuntimeDispatchInfo<Balance> {
+                unimplemented!()
+            }
+            fn query_fee_details(_: <Block as BlockT>::Extrinsic, _: u32) -> FeeDetails<Balance> {
+                unimplemented!()
+            }
+            fn query_weight_to_fee(_: Weight) -> Balance {
+                unimplemented!()
+            }
+            fn query_length_to_fee(_: u32) -> Balance {
+                unimplemented!()
+            }
+        }
+
+         impl crate::AlephSessionApi<Block> for Runtime {
+            fn millisecs_per_block() -> u64 {
+                unimplemented!()
+            }
+
+            fn session_period() -> u32 {
+                unimplemented!()
+            }
+
+            fn authorities() -> Vec<AlephId> {
+                unimplemented!()
+            }
+
+            fn next_session_authorities() -> Result<Vec<AlephId>, AlephApiError> {
+                unimplemented!()
+            }
+
+            fn authority_data() -> SessionAuthorityData {
+                unimplemented!()
+            }
+
+            fn next_session_authority_data() -> Result<SessionAuthorityData, AlephApiError> {
+                unimplemented!()
+            }
+
+            fn finality_version() -> FinalityVersion {
+                unimplemented!()
+            }
+
+            fn next_session_finality_version() -> FinalityVersion {
+                unimplemented!()
+            }
+
+            fn predict_session_committee(
+                _session: SessionIndex,
+            ) -> Result<SessionCommittee<AccountId>, SessionValidatorError> {
+                unimplemented!()
+            }
+
+            fn next_session_aura_authorities() -> Vec<(AccountId, AuraId)> {
+                unimplemented!()
+            }
+
+            fn key_owner(_key: AlephId) -> Option<AccountId> {
+                unimplemented!()
+            }
+        }
+
+        /// There’s an important remark on how this fake runtime must be implemented - it does not need to
+        /// have all the same entries like `impl_runtime_apis!` has - in particular, it does not need an
+        /// implementation for
+        ///  * `pallet_nomination_pools_runtime_api::NominationPoolsApi`
+        ///  * `pallet_staking_runtime_api::StakingApi`
+        ///  * `pallet_contracts::ContractsApi`
+        /// ie, code compiles without them, even though real runtime has those.
+        /// Why? Because this fake runtime API is only used only for sake of compilation, so as long
+        /// as `fake_runtime_api` implements no less than real runtime API, we’re good.
+
+        #[cfg(feature = "try-runtime")]
+        impl frame_try_runtime::TryRuntime<Block> for Runtime {
+            fn on_runtime_upgrade(checks: frame_try_runtime::UpgradeCheckSelect) -> (Weight, Weight) {
+                 unimplemented!()
+            }
+
+            fn execute_block(
+                block: Block,
+                state_root_check: bool,
+                checks: bool,
+                select: frame_try_runtime::TryStateSelect,
+            ) -> Weight {
+                 unimplemented!()
+            }
+         }
+
+        #[cfg(feature = "runtime-benchmarks")]
+        impl frame_benchmarking::Benchmark<Block> for Runtime {
+            fn benchmark_metadata(extra: bool) -> (
+                Vec<frame_benchmarking::BenchmarkList>,
+                Vec<frame_support::traits::StorageInfo>,
+            ) {
+                 unimplemented!()
+            }
+
+            fn dispatch_benchmark(
+                config: frame_benchmarking::BenchmarkConfig
+            ) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
+                 unimplemented!()
+            }
+         }
     }
-
-    impl sp_api::Metadata<Block> for Runtime {
-        fn metadata() -> OpaqueMetadata {
-            unimplemented!()
-        }
-
-        fn metadata_at_version(_: u32) -> Option<OpaqueMetadata> {
-            unimplemented!()
-        }
-
-        fn metadata_versions() -> Vec<u32> {
-            unimplemented!()
-        }
-    }
-
-    impl sp_block_builder::BlockBuilder<Block> for Runtime {
-        fn apply_extrinsic(_: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
-            unimplemented!()
-        }
-
-        fn finalize_block() -> <Block as BlockT>::Header {
-            unimplemented!()
-        }
-
-        fn inherent_extrinsics(_: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
-            unimplemented!()
-        }
-
-        fn check_inherents(
-            _: Block,
-            _: sp_inherents::InherentData,
-        ) -> sp_inherents::CheckInherentsResult {
-            unimplemented!()
-        }
-    }
-
-    impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
-        fn validate_transaction(
-            _: TransactionSource,
-            _: <Block as BlockT>::Extrinsic,
-            _: <Block as BlockT>::Hash,
-        ) -> TransactionValidity {
-            unimplemented!()
-        }
-    }
-
-    impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
-        fn slot_duration() -> SlotDuration {
-            unimplemented!()
-        }
-
-        fn authorities() -> Vec<AuraId> {
-            unimplemented!()
-        }
-    }
-
-    impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-        fn offchain_worker(_: &<Block as BlockT>::Header) {
-            unimplemented!()
-        }
-    }
-
-    impl sp_session::SessionKeys<Block> for Runtime {
-        fn generate_session_keys(_: Option<Vec<u8>>) -> Vec<u8> {
-            unimplemented!()
-        }
-
-        fn decode_session_keys(
-            _: Vec<u8>,
-        ) -> Option<Vec<(Vec<u8>, sp_core::crypto::KeyTypeId)>> {
-            unimplemented!()
-        }
-    }
-
-    impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Nonce> for Runtime {
-        fn account_nonce(_: AccountId) -> Nonce {
-            unimplemented!()
-        }
-    }
-
-    impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<
-        Block,
-        Balance,
-    > for Runtime {
-        fn query_info(_: <Block as BlockT>::Extrinsic, _: u32) -> RuntimeDispatchInfo<Balance> {
-            unimplemented!()
-        }
-        fn query_fee_details(_: <Block as BlockT>::Extrinsic, _: u32) -> FeeDetails<Balance> {
-            unimplemented!()
-        }
-        fn query_weight_to_fee(_: Weight) -> Balance {
-            unimplemented!()
-        }
-        fn query_length_to_fee(_: u32) -> Balance {
-            unimplemented!()
-        }
-    }
-
-     impl crate::AlephSessionApi<Block> for Runtime {
-        fn millisecs_per_block() -> u64 {
-            unimplemented!()
-        }
-
-        fn session_period() -> u32 {
-            unimplemented!()
-        }
-
-        fn authorities() -> Vec<AlephId> {
-            unimplemented!()
-        }
-
-        fn next_session_authorities() -> Result<Vec<AlephId>, AlephApiError> {
-            unimplemented!()
-        }
-
-        fn authority_data() -> SessionAuthorityData {
-            unimplemented!()
-        }
-
-        fn next_session_authority_data() -> Result<SessionAuthorityData, AlephApiError> {
-            unimplemented!()
-        }
-
-        fn finality_version() -> FinalityVersion {
-            unimplemented!()
-        }
-
-        fn next_session_finality_version() -> FinalityVersion {
-            unimplemented!()
-        }
-
-        fn predict_session_committee(
-            _session: SessionIndex,
-        ) -> Result<SessionCommittee<AccountId>, SessionValidatorError> {
-            unimplemented!()
-        }
-
-        fn next_session_aura_authorities() -> Vec<(AccountId, AuraId)> {
-            unimplemented!()
-        }
-
-        fn key_owner(_key: AlephId) -> Option<AccountId> {
-            unimplemented!()
-        }
-    }
-
-    /// There’s an important remark on how this fake runtime must be implemented - it does not need to
-    /// have all the same entries like `impl_runtime_apis!` has - in particular, it does not need an
-    /// implementation for
-    ///  * `pallet_nomination_pools_runtime_api::NominationPoolsApi`
-    ///  * `pallet_staking_runtime_api::StakingApi`
-    ///  * `pallet_contracts::ContractsApi`
-    /// ie, code compiles without them, even though real runtime has those.
-    /// Why? Because this fake runtime API is only used only for sake of compilation, so as long
-    /// as `fake_runtime_api` implements no less than real runtime API, we’re good.
-
-    #[cfg(feature = "try-runtime")]
-    impl frame_try_runtime::TryRuntime<Block> for Runtime {
-        fn on_runtime_upgrade(checks: frame_try_runtime::UpgradeCheckSelect) -> (Weight, Weight) {
-             unimplemented!()
-        }
-
-        fn execute_block(
-            block: Block,
-            state_root_check: bool,
-            checks: bool,
-            select: frame_try_runtime::TryStateSelect,
-        ) -> Weight {
-             unimplemented!()
-        }
-     }
-
-    #[cfg(feature = "runtime-benchmarks")]
-    impl frame_benchmarking::Benchmark<Block> for Runtime {
-        fn benchmark_metadata(extra: bool) -> (
-            Vec<frame_benchmarking::BenchmarkList>,
-            Vec<frame_support::traits::StorageInfo>,
-        ) {
-             unimplemented!()
-        }
-
-        fn dispatch_benchmark(
-            config: frame_benchmarking::BenchmarkConfig
-        ) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
-             unimplemented!()
-        }
-     }
 }

--- a/primitives/src/fake_runtime_api.rs
+++ b/primitives/src/fake_runtime_api.rs
@@ -29,6 +29,7 @@ use sp_runtime::{
     transaction_validity::{TransactionSource, TransactionValidity},
     ApplyExtrinsicResult,
 };
+use sp_std::vec::Vec;
 use sp_version::RuntimeVersion;
 
 use crate::{

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -321,7 +321,6 @@ pub struct VersionChange {
     pub session: SessionIndex,
 }
 
-// TODO this should be moved to separate crate pallet-aleph-session-api
 sp_api::decl_runtime_apis! {
     pub trait AlephSessionApi {
         fn next_session_authorities() -> Result<Vec<AuthorityId>, ApiError>;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -18,6 +18,8 @@ use sp_runtime::{
 pub use sp_staking::{EraIndex, SessionIndex};
 use sp_std::vec::Vec;
 
+pub mod fake_runtime_api;
+
 pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"alp0");
 
 // Same as GRANDPA_ENGINE_ID because as of right now substrate sends only
@@ -319,6 +321,7 @@ pub struct VersionChange {
     pub session: SessionIndex,
 }
 
+// TODO this should be moved to separate crate pallet-aleph-session-api
 sp_api::decl_runtime_apis! {
     pub trait AlephSessionApi {
         fn next_session_authorities() -> Result<Vec<AuthorityId>, ApiError>;


### PR DESCRIPTION
tl;dr 
Goal of this PR is to have only chainspec generation as only `aleph-runtime` dependency in `aleph-node`.

In aleph-node, we depend on aleph-runtimes RuntimeAPI type. This is not required, as per https://github.com/Cardinal-Cryptography/polkadot-sdk/commit/e53d15aa20e77eb35ccb590bb7ef940d3eca7dbb :

> These runtime api implementations are only used to make the compiler
think that we have implemented all required runtime apis. They will notbe called as we switch the executor to WasmExecutor. In the nearfuture we will not require these fake implementations anymore afterSubstrate has shifted away from this compile time requirement.This brings us the advantage that the polkadot-service doesn't need todepend on the runtimes for getting the RuntimeApi   also removes around 1min of build time on my machine ;)

1. To achieve so we need to implement similar idea like https://github.com/Cardinal-Cryptography/polkadot-sdk/blob/aleph-v1.4.0/polkadot/node/service/src/fake_runtime_api.rs into our `aleph-node` binary
2. There’s an important remark on how this fake runtime must be implemented - it does not need to have all the same entries like [`impl_runtime_apis!`](https://github.com/Cardinal-Cryptography/aleph-node/blob/main/bin/runtime/src/lib.rs#L1001-L1259) has - in particular, it does not need an implementation for 
* `pallet_nomination_pools_runtime_api::NominationPoolsApi`
* `pallet_staking_runtime_api::StakingApi`
* `pallet_contracts::ContractsApi`

ie, code compiles without them, even though real runtime has those. Why? Because this fake runtime API is only used only for sake of compilation:
* for explicit calls in aleph-node to runtime API, e.g. [this requires primitives::AlephSessionApi to be implemented for fake_runtime_api](https://github.com/Cardinal-Cryptography/aleph-node/blob/main/bin/node/src/service.rs#L200) 
* [because of trait bounds when creating RPC client in node](https://github.com/Cardinal-Cryptography/aleph-node/blob/main/bin/node/src/rpc.rs#L49-L51)
* [because of RPC modules to include in node](https://github.com/Cardinal-Cryptography/aleph-node/blob/main/bin/node/src/rpc.rs#L69-L83)

3. We use runtime’s SessionKeys, not opaque::SessionKeys when impl sp_session::SessionKeys<Block> for Runtime  - this is because Polkadot and other parachains do the same, and code compiles after the change.
4. Unifications of imports of primitives in aleph-node. 
5. Use fake_runtime in `finality-aleph`'s tests - no more aleph-runtime dependency!
6. Bumped `version` of `primitives` to be 0.14.0+dev - primitives needs to be versioned the same as runtime
