### PR TITLE
A0-4233: Nightly workflow for feature-gated builds

### DIFF
--- a/.github/workflows/nightly-check-node-features-build.yml
+++ b/.github/workflows/nightly-check-node-features-build.yml
@@ -1,0 +1,33 @@
+---
+# This workflow checks node build with various features
+name: Feature-gated builds
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 20 * * *'
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    name: Feature-gated builds
+    runs-on: [self-hosted, Linux, X64, large]
+    env:
+      RUST_BACKTRACE: full
+      RUSTC_WRAPPER: sccache
+    steps:
+      - name: Checkout aleph-node source code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v6
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: aleph-runtime with try-runtime
+        run: cargo check --profile production -p aleph-runtime --features try-runtime --locked
+
+      - name: aleph-node with runtime-benchmarks
+        run: cargo check --profile production -p aleph-node --features runtime-benchmarks --locked

--- a/.github/workflows/nightly-check-node-features-build.yml
+++ b/.github/workflows/nightly-check-node-features-build.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  main:
+  feature-gated-builds:
     name: Feature-gated builds
     runs-on: [self-hosted, Linux, X64, large]
     env:
@@ -31,3 +31,18 @@ jobs:
 
       - name: aleph-node with runtime-benchmarks
         run: cargo check --profile production -p aleph-node --features runtime-benchmarks --locked
+
+  slack-notification:
+    name: Slack notification
+    runs-on: ubuntu-20.04
+    needs: [feature-gated-builds]
+    if: >
+      !cancelled() &&
+      github.event_name != 'workflow_dispatch'
+    steps:
+      - name: Send Slack message
+        uses: Cardinal-Cryptography/github-actions/slack-notification@v6
+        with:
+          notify-on: "failure"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ONDUTY }}


### PR DESCRIPTION
# Description

This PR adds a simple `cargo check` command for `try-runtime` and `runtime-benchmarks` builds. Although it takes < 10 minutes, it is enough to build it in nightly or on demand only. 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/8599951172/job/23563916878