### PR TITLE
A0-3921: Fix runtime-benchmarks build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5762,6 +5762,7 @@ dependencies = [
  "pallet-contracts-proc-macro",
  "parity-scale-codec",
  "rand 0.8.5",
+ "rand_pcg",
  "scale-info",
  "serde",
  "smallvec",
@@ -5966,6 +5967,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/Cardinal-Cryptography/polkadot-sdk.git?branch=aleph-v1.4.0#8704aab0e8c88578adb4bfab53d06735c7df5437"
 dependencies = [
  "docify",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
@@ -6012,6 +6014,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
+ "rand_chacha 0.2.2",
  "scale-info",
  "serde",
  "sp-application-crypto",

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -164,9 +164,23 @@ try-runtime = [
 ]
 enable_treasury_proposals = []
 runtime-benchmarks = [
-    "frame-system/runtime-benchmarks",
-    "frame-benchmarking/runtime-benchmarks",
     "baby-liminal-extension/runtime-benchmarks",
+    "frame-benchmarking/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-balances/runtime-benchmarks",
+    "pallet-contracts/runtime-benchmarks",
     "pallet-feature-control/runtime-benchmarks",
+    "pallet-identity/runtime-benchmarks",
+    "pallet-multisig/runtime-benchmarks",
+    "pallet-nomination-pools/runtime-benchmarks",
+    "pallet-proxy/runtime-benchmarks",
+    "pallet-scheduler/runtime-benchmarks",
+    "pallet-staking/runtime-benchmarks",
+    "pallet-sudo/runtime-benchmarks",
+    "pallet-timestamp/runtime-benchmarks",
+    "pallet-treasury/runtime-benchmarks",
+    "pallet-utility/runtime-benchmarks",
+    "pallet-vesting/runtime-benchmarks",
     "pallet-vk-storage/runtime-benchmarks",
 ]

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -695,6 +695,8 @@ impl pallet_treasury::Config for Runtime {
     type Paymaster = PayFromAccount<Balances, TreasuryAccount>;
     type BalanceConverter = UnityAssetBalanceConversion;
     type PayoutPeriod = ConstU32<0>;
+    #[cfg(feature = "runtime-benchmarks")]
+    type BenchmarkHelper = ();
 }
 
 impl pallet_utility::Config for Runtime {


### PR DESCRIPTION
# Description

In `polkadot-sdk` 1.4.0, `pallet-contracts` depends on `xcm-builder` package. [It failed to build with `runtime-benchmarks` feature](https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/8605918122/job/23583222670). Fix is to enable `runtime-benchmarks` for `pallet-contracts` in our runtime. Also, this PR enables other `runtime-benchmark` features for various pallets our runtime uses.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing

https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/8611531265


