### PR TITLE
A0-4208: Hide NativeExecutionDispatch behind feature flags

### DIFF
--- a/.github/workflows/nightly-check-node-features-build.yml
+++ b/.github/workflows/nightly-check-node-features-build.yml
@@ -1,6 +1,6 @@
 ---
 # This workflow checks node build with various features
-name: Feature-gated builds
+name: Nightly feature-gated builds
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/nightly-check-node-features-build.yml
+++ b/.github/workflows/nightly-check-node-features-build.yml
@@ -32,6 +32,9 @@ jobs:
       - name: aleph-node with runtime-benchmarks
         run: cargo check --profile production -p aleph-node --features runtime-benchmarks --locked
 
+      - name: aleph-node with local-debugging
+        run: cargo check --profile dev -p aleph-node --features local-debugging --locked
+
   slack-notification:
     name: Slack notification
     runs-on: ubuntu-20.04

--- a/BUILD.md
+++ b/BUILD.md
@@ -104,6 +104,12 @@ If `cargo build --release` does not succeed but throws an error mentioning `Rust
 
 After a successful build the binary can be found in `target/release/aleph-node`.
 
+### Local debugging
+
+If you'd like to use Rust debugger with aleph-node binary, built it with `local-debugging` feature:
+```
+cargo check --profile dev -p aleph-node --features local-debugging --locked
+```
 
 [nix]: https://nixos.org/download.html
 [rustup]: https://rustup.rs/

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -101,3 +101,4 @@ runtime-benchmarks = [
 only_legacy = [
     "finality-aleph/only_legacy"
 ]
+local-debugging = []

--- a/bin/node/src/executor.rs
+++ b/bin/node/src/executor.rs
@@ -9,7 +9,7 @@ use sc_service::Configuration;
     feature = "local-debugging",
     feature = "try-runtime"
 )))]
-pub mod executor {
+pub mod aleph_executor {
     use super::Configuration;
     use sc_executor::WasmExecutor;
 
@@ -29,7 +29,7 @@ pub mod executor {
     feature = "local-debugging",
     feature = "try-runtime"
 ))]
-pub mod executor {
+pub mod aleph_executor {
     use super::Configuration;
     use sc_executor::NativeElseWasmExecutor;
 

--- a/bin/node/src/executor.rs
+++ b/bin/node/src/executor.rs
@@ -10,8 +10,9 @@ use sc_service::Configuration;
     feature = "try-runtime"
 )))]
 pub mod aleph_executor {
-    use super::Configuration;
     use sc_executor::WasmExecutor;
+
+    use super::Configuration;
 
     type ExtendHostFunctions = (
         sp_io::SubstrateHostFunctions,
@@ -30,8 +31,9 @@ pub mod aleph_executor {
     feature = "try-runtime"
 ))]
 pub mod aleph_executor {
-    use super::Configuration;
     use sc_executor::NativeElseWasmExecutor;
+
+    use super::Configuration;
 
     pub struct ExecutorDispatch;
 

--- a/bin/node/src/executor.rs
+++ b/bin/node/src/executor.rs
@@ -1,27 +1,62 @@
-//! `CodeExecutor` specialization which uses natively compiled runtime when the WASM to be
-//! executed is equivalent to the natively compiled code.
+//! This module declares an `AlephExecutor` which is either a
+//! * `WasmExecutor`, for production and test build (when no local debugging is required)
+//! * `NativeElseWasmExecutor` for `try-runtime`, `runtime-benchmarks` and local debugging builds
 
-use sc_executor::NativeElseWasmExecutor;
+use sc_service::Configuration;
 
-// Declare an instance of the native executor named `ExecutorDispatch`. Include the wasm binary as the equivalent wasm code.
-pub struct ExecutorDispatch;
+#[cfg(not(any(
+    feature = "runtime-benchmarks",
+    feature = "local-debugging",
+    feature = "try-runtime"
+)))]
+pub mod executor {
+    use super::Configuration;
+    use sc_executor::WasmExecutor;
 
-impl sc_executor::NativeExecutionDispatch for ExecutorDispatch {
-    #[cfg(feature = "runtime-benchmarks")]
     type ExtendHostFunctions = (
+        sp_io::SubstrateHostFunctions,
         aleph_runtime_interfaces::snark_verifier::HostFunctions,
-        frame_benchmarking::benchmarking::HostFunctions,
     );
-    #[cfg(not(feature = "runtime-benchmarks"))]
-    type ExtendHostFunctions = (aleph_runtime_interfaces::snark_verifier::HostFunctions,);
+    pub type Executor = WasmExecutor<ExtendHostFunctions>;
 
-    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
-        aleph_runtime::api::dispatch(method, data)
-    }
-
-    fn native_version() -> sc_executor::NativeVersion {
-        aleph_runtime::native_version()
+    pub fn get_executor(config: &Configuration) -> Executor {
+        sc_service::new_wasm_executor(config)
     }
 }
 
-pub type AlephExecutor = NativeElseWasmExecutor<ExecutorDispatch>;
+#[cfg(any(
+    feature = "runtime-benchmarks",
+    feature = "local-debugging",
+    feature = "try-runtime"
+))]
+pub mod executor {
+    use super::Configuration;
+    use sc_executor::NativeElseWasmExecutor;
+
+    pub struct ExecutorDispatch;
+
+    impl sc_executor::NativeExecutionDispatch for ExecutorDispatch {
+        #[cfg(feature = "runtime-benchmarks")]
+        type ExtendHostFunctions = (
+            aleph_runtime_interfaces::snark_verifier::HostFunctions,
+            frame_benchmarking::benchmarking::HostFunctions,
+        );
+
+        #[cfg(not(feature = "runtime-benchmarks"))]
+        type ExtendHostFunctions = (aleph_runtime_interfaces::snark_verifier::HostFunctions,);
+
+        fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+            aleph_runtime::api::dispatch(method, data)
+        }
+
+        fn native_version() -> sc_executor::NativeVersion {
+            aleph_runtime::native_version()
+        }
+    }
+
+    pub type Executor = NativeElseWasmExecutor<ExecutorDispatch>;
+
+    pub fn get_executor(config: &Configuration) -> Executor {
+        sc_service::new_native_or_wasm_executor(config)
+    }
+}

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -8,12 +8,11 @@ mod resources;
 mod rpc;
 mod service;
 
+pub use cli::{Cli, Subcommand};
 #[cfg(any(
     feature = "runtime-benchmarks",
     feature = "local-debugging",
     feature = "try-runtime"
 ))]
 pub use executor::aleph_executor::ExecutorDispatch;
-
-pub use cli::{Cli, Subcommand};
 pub use service::{new_authority, new_partial};

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -13,7 +13,7 @@ mod service;
     feature = "local-debugging",
     feature = "try-runtime"
 ))]
-pub use executor::executor::ExecutorDispatch;
+pub use executor::aleph_executor::ExecutorDispatch;
 
 pub use cli::{Cli, Subcommand};
 pub use service::{new_authority, new_partial};

--- a/bin/node/src/lib.rs
+++ b/bin/node/src/lib.rs
@@ -8,6 +8,12 @@ mod resources;
 mod rpc;
 mod service;
 
+#[cfg(any(
+    feature = "runtime-benchmarks",
+    feature = "local-debugging",
+    feature = "try-runtime"
+))]
+pub use executor::executor::ExecutorDispatch;
+
 pub use cli::{Cli, Subcommand};
-pub use executor::ExecutorDispatch;
 pub use service::{new_authority, new_partial};

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -31,10 +31,11 @@ use sp_consensus_aura::{sr25519::AuthorityPair as AuraPair, Slot};
 use crate::{
     aleph_cli::AlephCli,
     chain_spec::DEFAULT_BACKUP_FOLDER,
-    executor::AlephExecutor,
+    executor as aleph_executor,
     rpc::{create_full as create_full_rpc, FullDeps as RpcFullDeps},
 };
 
+type AlephExecutor = aleph_executor::executor::Executor;
 type FullClient = sc_service::TFullClient<Block, RuntimeApi, AlephExecutor>;
 type FullBackend = sc_service::TFullBackend<Block>;
 type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
@@ -103,7 +104,7 @@ pub fn new_partial(config: &Configuration) -> Result<ServiceComponents, ServiceE
         })
         .transpose()?;
 
-    let executor = sc_service::new_native_or_wasm_executor(config);
+    let executor = aleph_executor::executor::get_executor(config);
 
     let (client, backend, keystore_container, task_manager) =
         sc_service::new_full_parts::<Block, RuntimeApi, AlephExecutor>(

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -35,7 +35,7 @@ use crate::{
     rpc::{create_full as create_full_rpc, FullDeps as RpcFullDeps},
 };
 
-type AlephExecutor = aleph_executor::executor::Executor;
+type AlephExecutor = aleph_executor::aleph_executor::Executor;
 type FullClient = sc_service::TFullClient<Block, RuntimeApi, AlephExecutor>;
 type FullBackend = sc_service::TFullBackend<Block>;
 type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
@@ -104,7 +104,7 @@ pub fn new_partial(config: &Configuration) -> Result<ServiceComponents, ServiceE
         })
         .transpose()?;
 
-    let executor = aleph_executor::executor::get_executor(config);
+    let executor = aleph_executor::aleph_executor::get_executor(config);
 
     let (client, backend, keystore_container, task_manager) =
         sc_service::new_full_parts::<Block, RuntimeApi, AlephExecutor>(

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -31,11 +31,11 @@ use sp_consensus_aura::{sr25519::AuthorityPair as AuraPair, Slot};
 use crate::{
     aleph_cli::AlephCli,
     chain_spec::DEFAULT_BACKUP_FOLDER,
-    executor as aleph_executor,
+    executor::aleph_executor,
     rpc::{create_full as create_full_rpc, FullDeps as RpcFullDeps},
 };
 
-type AlephExecutor = aleph_executor::aleph_executor::Executor;
+type AlephExecutor = aleph_executor::Executor;
 type FullClient = sc_service::TFullClient<Block, RuntimeApi, AlephExecutor>;
 type FullBackend = sc_service::TFullBackend<Block>;
 type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
@@ -104,7 +104,7 @@ pub fn new_partial(config: &Configuration) -> Result<ServiceComponents, ServiceE
         })
         .transpose()?;
 
-    let executor = aleph_executor::aleph_executor::get_executor(config);
+    let executor = aleph_executor::get_executor(config);
 
     let (client, backend, keystore_container, task_manager) =
         sc_service::new_full_parts::<Block, RuntimeApi, AlephExecutor>(


### PR DESCRIPTION
# Description

Hide implementation of `NativeExecutionDispatch` for the `ExecutorDispatch` behind `local-debugging`. `NativeExecutionDispatch` is needed for debugging locally, as well as for `runtime-benchmarks`. Pehaps it's not needed for `try-runtime`, but it's subject to the next PRs.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/8628234269
https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/8615033603
