### PR TITLE
A0-3848: Update weekly nightly start FE tests to more recent aleph-node

### DIFF
--- a/.github/workflows/weekly-featurenets-short-session-full-sha.yml
+++ b/.github/workflows/weekly-featurenets-short-session-full-sha.yml
@@ -24,7 +24,7 @@ jobs:
     secrets: inherit
     with:
       featurenet-name: 'ops-test-full-hash'
-      ref: '787c39186884aaf86ed48f46f575a8cd8cfd13e8'
+      ref: '87ebe7c4856b4f3365ddba55b55089713a96631a'
       expiration: '2h'
       validators: '5'
       internal: true

--- a/.github/workflows/weekly-featurenets-short-session-tag.yml
+++ b/.github/workflows/weekly-featurenets-short-session-tag.yml
@@ -24,9 +24,9 @@ jobs:
     secrets: inherit
     with:
       featurenet-name: 'ops-test-tag'
-      ref: 'r-12.2'
+      ref: 'r-13.3'
       expiration: '5h'
-      validators: '8'
+      validators: '7'
       internal: true
       short-session: true
 


### PR DESCRIPTION
We should be using more recent `aleph-node` images on our CI.