### PR TITLE
A0-3575: Update block sync message versions

### DIFF
--- a/finality-aleph/src/sync/handler/request_handler.rs
+++ b/finality-aleph/src/sync/handler/request_handler.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     session::{SessionBoundaryInfo, SessionId},
     sync::{
-        data::{BranchKnowledge, MaybeHeader, ResponseItem, ResponseItems},
+        data::{BranchKnowledge, ResponseItem, ResponseItems},
         handler::Request,
     },
     BlockId,
@@ -199,7 +199,7 @@ where
     J: Justification,
     B: Block<UnverifiedHeader = UnverifiedHeaderFor<J>>,
 {
-    RequestBlock(MaybeHeader<UnverifiedHeaderFor<J>>),
+    RequestBlock(UnverifiedHeaderFor<J>),
     Response(ResponseItems<B, J>),
     Noop,
 }
@@ -209,7 +209,7 @@ where
     J: Justification,
     B: Block<UnverifiedHeader = UnverifiedHeaderFor<J>>,
 {
-    fn request_block(maybe_header: MaybeHeader<UnverifiedHeaderFor<J>>) -> Self {
+    fn request_block(maybe_header: UnverifiedHeaderFor<J>) -> Self {
         Action::RequestBlock(maybe_header)
     }
 

--- a/finality-aleph/src/sync/tasks.rs
+++ b/finality-aleph/src/sync/tasks.rs
@@ -82,9 +82,8 @@ impl RequestTask {
                     MaybeHeader::Header(header) => {
                         PreRequest::new(header, branch_knowledge, know_most)
                     }
-                    MaybeHeader::Id(id) => {
-                        PreRequest::new_headerless(id, branch_knowledge, know_most)
-                    }
+                    // TODO(A0-3494): This should no longer be happening.
+                    MaybeHeader::Id(_) => return Action::Ignore,
                 };
                 Action::Request(
                     pre_request,


### PR DESCRIPTION
# Description

We no longer need the id-only requests, nor support for v2 messages. Complete removal of id-only request logic will happen in a follow-up PR.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- I have made corresponding changes to the existing documentation
- I have created new documentation
