### PR TITLE
A0-4224: Extracted pallet alleph runtime API to a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ version = "0.14.0+dev"
 dependencies = [
  "aleph-runtime",
  "aleph-runtime-interfaces",
+ "fake-runtime-api",
  "finality-aleph",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -284,6 +285,7 @@ dependencies = [
  "jsonrpsee",
  "libp2p",
  "log",
+ "pallet-aleph-runtime-api",
  "pallet-staking",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
@@ -339,6 +341,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "pallet-aleph",
+ "pallet-aleph-runtime-api",
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
@@ -2329,6 +2332,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake-runtime-api"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system-rpc-runtime-api",
+ "pallet-aleph-runtime-api",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "primitives",
+ "sp-api",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-inherents",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-version",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2436,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "env_logger",
+ "fake-runtime-api",
  "frame-support",
  "futures",
  "futures-timer",
@@ -2419,6 +2446,7 @@ dependencies = [
  "log",
  "lru",
  "network-clique",
+ "pallet-aleph-runtime-api",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "primitives",
@@ -5388,6 +5416,16 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-aleph-runtime-api"
+version = "0.1.0"
+dependencies = [
+ "primitives",
+ "sp-api",
+ "sp-consensus-aura",
  "sp-std",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,11 @@ members = [
     "baby-liminal-extension",
     "bin/node",
     "bin/runtime",
+    "bin/fake-runtime-api",
     "clique",
     "finality-aleph",
     "pallets/aleph",
+    "pallets/aleph-runtime-api",
     "pallets/elections",
     "pallets/feature-control",
     "pallets/committee-management",
@@ -172,6 +174,7 @@ halo2_proofs = { git = "https://github.com/Cardinal-Cryptography/pse-halo2", bra
 
 # Local crates
 
+fake-runtime-api = { path = "bin/fake-runtime-api", default-features = false }
 aleph-runtime = { path = "bin/runtime" }
 aleph-runtime-interfaces = { path = "runtime-interfaces", default-features = false }
 baby-liminal-extension = { path = "baby-liminal-extension", default-features = false }
@@ -179,6 +182,7 @@ finality-aleph = { path = "finality-aleph" }
 network-clique = { path = "clique" }
 rate-limiter = { path = "rate-limiter" }
 pallet-aleph = { path = "pallets/aleph", default-features = false }
+pallet-aleph-runtime-api = { path = "pallets/aleph-runtime-api", default-features = false }
 pallet-committee-management = { path = "pallets/committee-management", default-features = false }
 pallet-elections = { path = "pallets/elections", default-features = false }
 pallet-feature-control = { path = "pallets/feature-control", default-features = false }

--- a/bin/fake-runtime-api/Cargo.toml
+++ b/bin/fake-runtime-api/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "fake-runtime-api"
+version = "0.1.0"
+license = "Apache 2.0"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+sp-api = { workspace = true }
+sp-core = { workspace = true }
+sp-std = { workspace = true }
+sp-runtime = { workspace = true }
+sp-consensus-aura = { workspace = true }
+
+frame-support = { workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+
+sp-version = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-offchain = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-session = { workspace = true }
+sp-inherents = { workspace = true }
+
+primitives = { workspace = true }
+pallet-aleph-runtime-api = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "primitives/std",
+    "pallet-aleph-runtime-api/std",
+]
+short_session = []

--- a/bin/fake-runtime-api/src/lib.rs
+++ b/bin/fake-runtime-api/src/lib.rs
@@ -4,8 +4,14 @@
 //! the native runtimes.
 
 use frame_support::weights::Weight;
+use pallet_aleph_runtime_api::*;
 use pallet_transaction_payment::FeeDetails;
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
+use primitives::{
+    AccountId, ApiError as AlephApiError, AuraId, AuthorityId as AlephId, Balance, Block, Nonce,
+    SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError,
+    Version as FinalityVersion,
+};
 use sp_consensus_aura::SlotDuration;
 use sp_core::OpaqueMetadata;
 use sp_runtime::{
@@ -15,13 +21,6 @@ use sp_runtime::{
 };
 use sp_std::vec::Vec;
 use sp_version::RuntimeVersion;
-
-use primitives::{
-    AccountId, ApiError as AlephApiError, AuraId, AuthorityId as AlephId, Balance, Block, Nonce,
-    SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError,
-    Version as FinalityVersion,
-};
-use pallet_aleph_runtime_api::*;
 
 #[cfg(feature = "std")]
 pub mod fake_runtime {

--- a/bin/fake-runtime-api/src/lib.rs
+++ b/bin/fake-runtime-api/src/lib.rs
@@ -16,11 +16,12 @@ use sp_runtime::{
 use sp_std::vec::Vec;
 use sp_version::RuntimeVersion;
 
-use crate::{
+use primitives::{
     AccountId, ApiError as AlephApiError, AuraId, AuthorityId as AlephId, Balance, Block, Nonce,
     SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError,
     Version as FinalityVersion,
 };
+use pallet_aleph_runtime_api::*;
 
 #[cfg(feature = "std")]
 pub mod fake_runtime {

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -66,6 +66,8 @@ aleph-runtime = { workspace = true }
 aleph-runtime-interfaces = { workspace = true }
 finality-aleph = { workspace = true }
 primitives = { workspace = true }
+fake-runtime-api = { workspace = true, features = ["std"] }
+pallet-aleph-runtime-api = { workspace = true, features = ["std"] }
 
 # These dependencies are used for the node's RPCs
 jsonrpsee = { workspace = true, features = ["server"] }

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -14,8 +14,10 @@ use finality_aleph::{
 };
 use log::warn;
 use primitives::{
-    fake_runtime_api::fake_runtime::RuntimeApi, AlephSessionApi, Block, MAX_BLOCK_SIZE,
+    Block, MAX_BLOCK_SIZE,
 };
+use pallet_aleph_runtime_api::AlephSessionApi;
+use fake_runtime_api::fake_runtime::RuntimeApi;
 use sc_basic_authorship::ProposerFactory;
 use sc_client_api::{BlockBackend, HeaderBackend};
 use sc_consensus::ImportQueue;

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -5,6 +5,7 @@ use std::{
     sync::Arc,
 };
 
+use fake_runtime_api::fake_runtime::RuntimeApi;
 use finality_aleph::{
     run_validator_node, AlephBlockImport, AlephConfig, AllBlockMetrics, BlockImporter,
     ChannelProvider, Justification, JustificationTranslator, MillisecsPerBlock,
@@ -13,11 +14,8 @@ use finality_aleph::{
     TracingBlockImport, ValidatorAddressCache,
 };
 use log::warn;
-use primitives::{
-    Block, MAX_BLOCK_SIZE,
-};
 use pallet_aleph_runtime_api::AlephSessionApi;
-use fake_runtime_api::fake_runtime::RuntimeApi;
+use primitives::{Block, MAX_BLOCK_SIZE};
 use sc_basic_authorship::ProposerFactory;
 use sc_client_api::{BlockBackend, HeaderBackend};
 use sc_consensus::ImportQueue;

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -61,6 +61,7 @@ sp-genesis-builder = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 
 pallet-aleph = { workspace = true }
+pallet-aleph-runtime-api = { workspace = true }
 pallet-committee-management = { workspace = true }
 pallet-elections = { workspace = true }
 pallet-feature-control = { workspace = true }

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -1085,7 +1085,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl primitives::AlephSessionApi<Block> for Runtime {
+    impl pallet_aleph_runtime_api::AlephSessionApi<Block> for Runtime {
         fn millisecs_per_block() -> u64 {
             MILLISECS_PER_BLOCK
         }

--- a/finality-aleph/Cargo.toml
+++ b/finality-aleph/Cargo.toml
@@ -21,6 +21,8 @@ primitives = { workspace = true }
 legacy-aleph-aggregator = { package = "aggregator", git = "https://github.com/Cardinal-Cryptography/aleph-node.git", tag = "r-13.3" }
 current-aleph-aggregator = { path = "../aggregator", package = "aggregator" }
 rate-limiter = { package = "rate-limiter", path = "../rate-limiter" }
+fake-runtime-api = { workspace = true, features = ["std"] }
+pallet-aleph-runtime-api = { workspace = true, features = ["std"] }
 
 async-trait = { workspace = true }
 bytes = { workspace = true }

--- a/finality-aleph/src/idx_to_account.rs
+++ b/finality-aleph/src/idx_to_account.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use primitives::{AccountId, AlephSessionApi, AuraId, BlockHash, BlockNumber};
+use primitives::{AccountId, AuraId, BlockHash, BlockNumber};
 use sc_client_api::Backend;
 use sp_consensus_aura::AuraApi;
 use sp_runtime::traits::{Block, Header};
@@ -12,6 +12,8 @@ use crate::{
     session_map::{AuthorityProvider, AuthorityProviderImpl},
     ClientForAleph,
 };
+use pallet_aleph_runtime_api::AlephSessionApi;
+
 
 pub trait ValidatorIndexToAccountIdConverter {
     fn account(&self, session: SessionId, validator_index: NodeIndex) -> Option<AccountId>;
@@ -20,7 +22,7 @@ pub trait ValidatorIndexToAccountIdConverter {
 pub struct ValidatorIndexToAccountIdConverterImpl<C, B, BE, RA>
 where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
-    C::Api: crate::aleph_primitives::AlephSessionApi<B> + AuraApi<B, AuraId>,
+    C::Api: AlephSessionApi<B> + AuraApi<B, AuraId>,
     B: Block<Hash = BlockHash>,
     BE: Backend<B> + 'static,
     RA: RuntimeApi,
@@ -33,7 +35,7 @@ where
 impl<C, B, BE, RA> ValidatorIndexToAccountIdConverterImpl<C, B, BE, RA>
 where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
-    C::Api: crate::aleph_primitives::AlephSessionApi<B> + AuraApi<B, AuraId>,
+    C::Api: AlephSessionApi<B> + AuraApi<B, AuraId>,
     B: Block<Hash = BlockHash>,
     B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,
@@ -52,7 +54,7 @@ impl<C, B, BE, RA> ValidatorIndexToAccountIdConverter
     for ValidatorIndexToAccountIdConverterImpl<C, B, BE, RA>
 where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
-    C::Api: crate::aleph_primitives::AlephSessionApi<B> + AuraApi<B, AuraId>,
+    C::Api: AlephSessionApi<B> + AuraApi<B, AuraId>,
     B: Block<Hash = BlockHash>,
     B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,

--- a/finality-aleph/src/idx_to_account.rs
+++ b/finality-aleph/src/idx_to_account.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use pallet_aleph_runtime_api::AlephSessionApi;
 use primitives::{AccountId, AuraId, BlockHash, BlockNumber};
 use sc_client_api::Backend;
 use sp_consensus_aura::AuraApi;
@@ -12,8 +13,6 @@ use crate::{
     session_map::{AuthorityProvider, AuthorityProviderImpl},
     ClientForAleph,
 };
-use pallet_aleph_runtime_api::AlephSessionApi;
-
 
 pub trait ValidatorIndexToAccountIdConverter {
     fn account(&self, session: SessionId, validator_index: NodeIndex) -> Option<AccountId>;

--- a/finality-aleph/src/nodes.rs
+++ b/finality-aleph/src/nodes.rs
@@ -10,9 +10,11 @@ use sc_keystore::{Keystore, LocalKeystore};
 use sc_transaction_pool_api::TransactionPool;
 use sp_consensus::SelectChain;
 use sp_consensus_aura::AuraApi;
+use pallet_aleph_runtime_api::AlephSessionApi;
+
 
 use crate::{
-    aleph_primitives::{AlephSessionApi, AuraId, Block},
+    aleph_primitives::{AuraId, Block},
     block::{
         substrate::{JustificationTranslator, SubstrateFinalizationInfo, VerifierCache},
         BlockchainEvents, ChainStatus, FinalizationStatus, Justification,

--- a/finality-aleph/src/nodes.rs
+++ b/finality-aleph/src/nodes.rs
@@ -4,14 +4,13 @@ use bip39::{Language, Mnemonic, MnemonicType};
 use futures::channel::oneshot;
 use log::{debug, error};
 use network_clique::{RateLimitingDialer, RateLimitingListener, Service, SpawnHandleT};
+use pallet_aleph_runtime_api::AlephSessionApi;
 use rate_limiter::SleepingRateLimiter;
 use sc_client_api::Backend;
 use sc_keystore::{Keystore, LocalKeystore};
 use sc_transaction_pool_api::TransactionPool;
 use sp_consensus::SelectChain;
 use sp_consensus_aura::AuraApi;
-use pallet_aleph_runtime_api::AlephSessionApi;
-
 
 use crate::{
     aleph_primitives::{AuraId, Block},

--- a/finality-aleph/src/party/manager/mod.rs
+++ b/finality-aleph/src/party/manager/mod.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 use futures::channel::oneshot;
 use log::{debug, info, trace, warn};
 use network_clique::SpawnHandleT;
+use pallet_aleph_runtime_api::AlephSessionApi;
 use sc_keystore::{Keystore, LocalKeystore};
 use sp_application_crypto::RuntimeAppPublic;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
-use pallet_aleph_runtime_api::AlephSessionApi;
 
 use crate::{
     abft::{

--- a/finality-aleph/src/party/manager/mod.rs
+++ b/finality-aleph/src/party/manager/mod.rs
@@ -7,13 +7,14 @@ use network_clique::SpawnHandleT;
 use sc_keystore::{Keystore, LocalKeystore};
 use sp_application_crypto::RuntimeAppPublic;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use pallet_aleph_runtime_api::AlephSessionApi;
 
 use crate::{
     abft::{
         current_create_aleph_config, legacy_create_aleph_config, run_current_member,
         run_legacy_member, SpawnHandle,
     },
-    aleph_primitives::{AlephSessionApi, BlockHash, BlockNumber, KEY_TYPE},
+    aleph_primitives::{BlockHash, BlockNumber, KEY_TYPE},
     block::{
         substrate::{Justification, JustificationTranslator},
         BestBlockSelector, Block, Header, HeaderVerifier, UnverifiedHeader,

--- a/finality-aleph/src/runtime_api.rs
+++ b/finality-aleph/src/runtime_api.rs
@@ -5,12 +5,12 @@ use std::{
 };
 
 use frame_support::StorageHasher;
+use pallet_aleph_runtime_api::AlephSessionApi;
 use parity_scale_codec::{Decode, DecodeAll, Encode, Error as DecodeError};
 use sc_client_api::Backend;
 use sp_application_crypto::key_types::AURA;
 use sp_core::twox_128;
 use sp_runtime::traits::{Block, OpaqueKeys};
-use pallet_aleph_runtime_api::AlephSessionApi;
 
 use crate::{
     aleph_primitives::{AccountId, AuraId},

--- a/finality-aleph/src/runtime_api.rs
+++ b/finality-aleph/src/runtime_api.rs
@@ -10,9 +10,10 @@ use sc_client_api::Backend;
 use sp_application_crypto::key_types::AURA;
 use sp_core::twox_128;
 use sp_runtime::traits::{Block, OpaqueKeys};
+use pallet_aleph_runtime_api::AlephSessionApi;
 
 use crate::{
-    aleph_primitives::{AccountId, AlephSessionApi, AuraId},
+    aleph_primitives::{AccountId, AuraId},
     BlockHash, ClientForAleph,
 };
 

--- a/finality-aleph/src/session_map.rs
+++ b/finality-aleph/src/session_map.rs
@@ -10,10 +10,11 @@ use tokio::sync::{
     oneshot::{Receiver as OneShotReceiver, Sender as OneShotSender},
     RwLock,
 };
+use pallet_aleph_runtime_api::AlephSessionApi;
 
 use crate::{
     aleph_primitives::{
-        AccountId, AlephSessionApi, AuraId, BlockHash, BlockNumber, SessionAuthorityData,
+        AccountId, AuraId, BlockHash, BlockNumber, SessionAuthorityData,
     },
     runtime_api::RuntimeApi,
     session::SessionBoundaryInfo,
@@ -41,7 +42,7 @@ pub trait AuthorityProvider: Clone + Send + Sync + 'static {
 pub struct AuthorityProviderImpl<C, B, BE, RA>
 where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
-    C::Api: crate::aleph_primitives::AlephSessionApi<B> + AuraApi<B, AuraId>,
+    C::Api: AlephSessionApi<B> + AuraApi<B, AuraId>,
     B: Block<Hash = BlockHash>,
     BE: Backend<B> + 'static,
     RA: RuntimeApi,
@@ -54,7 +55,7 @@ where
 impl<C, B, BE, RA> Clone for AuthorityProviderImpl<C, B, BE, RA>
 where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
-    C::Api: crate::aleph_primitives::AlephSessionApi<B> + AuraApi<B, AuraId>,
+    C::Api: AlephSessionApi<B> + AuraApi<B, AuraId>,
     B: Block<Hash = BlockHash>,
     B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,
@@ -68,7 +69,7 @@ where
 impl<C, B, BE, RA> AuthorityProviderImpl<C, B, BE, RA>
 where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
-    C::Api: crate::aleph_primitives::AlephSessionApi<B> + AuraApi<B, AuraId>,
+    C::Api: AlephSessionApi<B> + AuraApi<B, AuraId>,
     B: Block<Hash = BlockHash>,
     B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,
@@ -162,7 +163,7 @@ pub trait FinalityNotifier {
 pub struct FinalityNotifierImpl<C, B, BE>
 where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
-    C::Api: crate::aleph_primitives::AlephSessionApi<B>,
+    C::Api: AlephSessionApi<B>,
     B: Block,
     B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,
@@ -175,7 +176,7 @@ where
 impl<C, B, BE> FinalityNotifierImpl<C, B, BE>
 where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
-    C::Api: crate::aleph_primitives::AlephSessionApi<B>,
+    C::Api: AlephSessionApi<B>,
     B: Block,
     B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,
@@ -193,7 +194,7 @@ where
 impl<C, B, BE> FinalityNotifier for FinalityNotifierImpl<C, B, BE>
 where
     C: ClientForAleph<B, BE> + Send + Sync + 'static,
-    C::Api: crate::aleph_primitives::AlephSessionApi<B>,
+    C::Api: AlephSessionApi<B>,
     B: Block,
     B::Header: Header<Number = BlockNumber>,
     BE: Backend<B> + 'static,

--- a/finality-aleph/src/session_map.rs
+++ b/finality-aleph/src/session_map.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, marker::PhantomData, ops::Deref, sync::Arc};
 
 use futures::StreamExt;
 use log::{debug, error, trace};
+use pallet_aleph_runtime_api::AlephSessionApi;
 use sc_client_api::{Backend, FinalityNotification};
 use sc_utils::mpsc::TracingUnboundedReceiver;
 use sp_consensus_aura::AuraApi;
@@ -10,12 +11,9 @@ use tokio::sync::{
     oneshot::{Receiver as OneShotReceiver, Sender as OneShotSender},
     RwLock,
 };
-use pallet_aleph_runtime_api::AlephSessionApi;
 
 use crate::{
-    aleph_primitives::{
-        AccountId, AuraId, BlockHash, BlockNumber, SessionAuthorityData,
-    },
+    aleph_primitives::{AccountId, AuraId, BlockHash, BlockNumber, SessionAuthorityData},
     runtime_api::RuntimeApi,
     session::SessionBoundaryInfo,
     ClientForAleph, SessionId, SessionPeriod,

--- a/pallets/aleph-runtime-api/Cargo.toml
+++ b/pallets/aleph-runtime-api/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pallet-aleph-runtime-api"
+version = "0.1.0"
+license = "Apache 2.0"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+sp-api = { workspace = true }
+sp-std = { workspace = true }
+sp-consensus-aura = { workspace = true }
+
+primitives = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "sp-api/std",
+    "sp-std/std",
+    "primitives/std",
+]

--- a/pallets/aleph-runtime-api/LICENSE
+++ b/pallets/aleph-runtime-api/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pallets/aleph-runtime-api/README.md
+++ b/pallets/aleph-runtime-api/README.md
@@ -1,0 +1,5 @@
+# pallet-aleph-runtime-api
+
+Runtime API definition for aleph pallet.
+
+License: Apache-2.0

--- a/pallets/aleph-runtime-api/src/lib.rs
+++ b/pallets/aleph-runtime-api/src/lib.rs
@@ -1,0 +1,33 @@
+//! Runtime API definition for pallet aleph.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
+use primitives::{AuthorityId, SessionAuthorityData, ApiError, Version, SessionIndex, AccountId, SessionCommittee, SessionValidatorError};
+
+sp_api::decl_runtime_apis! {
+    pub trait AlephSessionApi {
+        fn next_session_authorities() -> Result<Vec<AuthorityId>, ApiError>;
+        fn authorities() -> Vec<AuthorityId>;
+        fn next_session_authority_data() -> Result<SessionAuthorityData, ApiError>;
+        fn authority_data() -> SessionAuthorityData;
+        fn session_period() -> u32;
+        fn millisecs_per_block() -> u64;
+        fn finality_version() -> Version;
+        fn next_session_finality_version() -> Version;
+        /// Predict finality committee and block producers for the given session. `session` must be
+        /// within the current era (current, in the staking context).
+        ///
+        /// If the active era `E` starts in the session `a`, and ends in session `b` then from
+        /// session `a` to session `b-1` this function can answer question who will be in the
+        /// committee in the era `E`. In the last session of the era `E` (`b`) this can be used to
+        /// determine all of the sessions in the era `E+1`.
+        fn predict_session_committee(
+            session: SessionIndex
+        ) -> Result<SessionCommittee<AccountId>, SessionValidatorError>;
+        fn next_session_aura_authorities() -> Vec<(AccountId, AuraId)>;
+        /// Returns owner (`AccountId`) corresponding to an AuthorityId (in some contexts referenced
+        /// also as `aleph_key` - consensus engine's part of session keys) in the current session
+        /// of AlephBFT (finalisation committee).
+        fn key_owner(key: AuthorityId) -> Option<AccountId>;
+    }
+}

--- a/pallets/aleph-runtime-api/src/lib.rs
+++ b/pallets/aleph-runtime-api/src/lib.rs
@@ -1,8 +1,11 @@
 //! Runtime API definition for pallet aleph.
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use primitives::{
+    AccountId, ApiError, AuthorityId, SessionAuthorityData, SessionCommittee, SessionIndex,
+    SessionValidatorError, Version,
+};
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use primitives::{AuthorityId, SessionAuthorityData, ApiError, Version, SessionIndex, AccountId, SessionCommittee, SessionValidatorError};
 
 sp_api::decl_runtime_apis! {
     pub trait AlephSessionApi {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -18,8 +18,6 @@ use sp_runtime::{
 pub use sp_staking::{EraIndex, SessionIndex};
 use sp_std::vec::Vec;
 
-pub mod fake_runtime_api;
-
 pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"alp0");
 
 // Same as GRANDPA_ENGINE_ID because as of right now substrate sends only
@@ -321,33 +319,7 @@ pub struct VersionChange {
     pub session: SessionIndex,
 }
 
-sp_api::decl_runtime_apis! {
-    pub trait AlephSessionApi {
-        fn next_session_authorities() -> Result<Vec<AuthorityId>, ApiError>;
-        fn authorities() -> Vec<AuthorityId>;
-        fn next_session_authority_data() -> Result<SessionAuthorityData, ApiError>;
-        fn authority_data() -> SessionAuthorityData;
-        fn session_period() -> u32;
-        fn millisecs_per_block() -> u64;
-        fn finality_version() -> Version;
-        fn next_session_finality_version() -> Version;
-        /// Predict finality committee and block producers for the given session. `session` must be
-        /// within the current era (current, in the staking context).
-        ///
-        /// If the active era `E` starts in the session `a`, and ends in session `b` then from
-        /// session `a` to session `b-1` this function can answer question who will be in the
-        /// committee in the era `E`. In the last session of the era `E` (`b`) this can be used to
-        /// determine all of the sessions in the era `E+1`.
-        fn predict_session_committee(
-            session: SessionIndex
-        ) -> Result<SessionCommittee<AccountId>, SessionValidatorError>;
-        fn next_session_aura_authorities() -> Vec<(AccountId, AuraId)>;
-        /// Returns owner (`AccountId`) corresponding to an AuthorityId (in some contexts referenced
-        /// also as `aleph_key` - consensus engine's part of session keys) in the current session
-        /// of AlephBFT (finalisation committee).
-        fn key_owner(key: AuthorityId) -> Option<AccountId>;
-    }
-}
+
 
 pub trait BanHandler {
     type AccountId;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -319,8 +319,6 @@ pub struct VersionChange {
     pub session: SessionIndex,
 }
 
-
-
 pub trait BanHandler {
     type AccountId;
     /// returns whether the account can be banned


### PR DESCRIPTION
# Description

As per Substarte impl, traits for runtime API for a given pallets are separate crates inside the pallet, e.g. https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame/nomination-pools/runtime-api  . We should do the same with code  https://github.com/Cardinal-Cryptography/aleph-node/blob/main/primitives/src/lib.rs#L322-L348

`fake_runtime_api` module needs to be extracted to a separate crate as well, as it is used by `primitives` and `finality_aleph`, and it cannot be part of `primitives` as it depends on `pallet-aleph-runtime-api`, so there would be a cyclic dependency.

## Type of change

Please delete options that are not relevant.

- refactor

# Checklist:

