### PR TITLE
A0-4251: Cherry pick

### DIFF
--- a/aleph-client/Cargo.lock
+++ b/aleph-client/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.7.3"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aleph-client/Cargo.toml
+++ b/aleph-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph_client"
-version = "3.7.3"
+version = "3.8.0"
 edition = "2021"
 authors = ["Cardinal"]
 documentation = "https://docs.rs/aleph_client"

--- a/aleph-client/src/contract/event.rs
+++ b/aleph-client/src/contract/event.rs
@@ -56,7 +56,7 @@ pub struct ContractEvent {
 /// # async fn example(conn: Connection, signed_conn: SignedConnection, address: AccountId, path: &str) -> Result<()> {
 /// let contract = ContractInstance::new(address, path)?;
 ///
-/// let tx_info = contract.contract_exec0(&signed_conn, "some_method").await?;
+/// let tx_info = contract.exec0(&signed_conn, "some_method", Default::default()).await?;
 ///
 /// println!("Received events {:?}", get_contract_events(&conn, &contract, tx_info).await);
 ///
@@ -110,8 +110,8 @@ pub async fn get_contract_events(
 /// };
 /// let join = tokio::spawn(listen());
 ///
-/// contract1.contract_exec0(&signed_conn, "some_method").await?;
-/// contract2.contract_exec0(&signed_conn, "some_other_method").await?;
+/// contract1.exec0(&signed_conn, "some_method", Default::default()).await?;
+/// contract2.exec0(&signed_conn, "some_other_method", Default::default()).await?;
 ///
 /// println!("Received event {:?}", rx.next().await);
 ///

--- a/aleph-client/src/pallets/contract.rs
+++ b/aleph-client/src/pallets/contract.rs
@@ -97,9 +97,13 @@ pub trait ContractsUserApi {
 #[async_trait::async_trait]
 pub trait ContractRpc {
     /// API for [`call`](https://paritytech.github.io/substrate/master/pallet_contracts/trait.ContractsApi.html#method.call) call.
+    /// * `args` - Arguments for the call.
+    /// * `at` - Optional hash of a block, the state of which should be used.
+    ///          If `None`, state associated with the best block is queried.
     async fn call_and_get(
         &self,
         args: ContractCallArgs,
+        at: Option<BlockHash>,
     ) -> anyhow::Result<ContractExecResult<Balance, EventRecord>>;
 }
 
@@ -203,8 +207,9 @@ impl<C: ConnectionApi> ContractRpc for C {
     async fn call_and_get(
         &self,
         args: ContractCallArgs,
+        block_hash: Option<BlockHash>,
     ) -> anyhow::Result<ContractExecResult<Balance, EventRecord>> {
-        let params = rpc_params!["ContractsApi_call", Bytes(args.encode())];
+        let params = rpc_params!["ContractsApi_call", Bytes(args.encode()), block_hash];
         self.rpc_call("state_call".to_string(), params).await
     }
 }

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.7.3"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/src/test/adder.rs
+++ b/e2e-tests/src/test/adder.rs
@@ -1,17 +1,18 @@
-use std::{fmt::Debug, str::FromStr, sync::Arc};
-
 use aleph_client::{
     contract::{
         event::{get_contract_events, listen_contract_events},
-        ContractInstance,
+        ContractInstance, ExecCallParams, ReadonlyCallParams,
     },
     contract_transcode::Value,
     pallets::system::SystemApi,
-    AccountId, ConnectionApi, SignedConnectionApi, TxInfo,
+    sp_weights::weight_v2::Weight,
+    utility::BlocksApi,
+    AccountId, BlockHash, ConnectionApi, SignedConnectionApi, TxInfo,
 };
 use anyhow::{anyhow, Context, Result};
 use assert2::assert;
 use futures::{channel::mpsc::unbounded, StreamExt};
+use std::{fmt::Debug, str::FromStr, sync::Arc};
 
 use crate::{config::setup_test, test::helpers::basic_test_context};
 
@@ -143,6 +144,92 @@ pub async fn adder_dry_run_failure() -> Result<()> {
 struct AdderInstance {
     contract: ContractInstance,
 }
+/// Test read only contract calls.
+#[tokio::test]
+pub async fn adder_readonly_calls() -> Result<()> {
+    let config = setup_test();
+
+    let (conn, _authority, account) = basic_test_context(config).await?;
+
+    let contract = AdderInstance::new(
+        &config.test_case_params.adder,
+        &config.test_case_params.adder_metadata,
+    )?;
+
+    let base = contract.get(&conn).await?;
+    let block_with_state_0 = conn
+        .get_block_hash(conn.get_best_block().await?.unwrap())
+        .await
+        .unwrap()
+        .unwrap();
+    let block_with_state_1 = contract.add(&account.sign(&conn), 1).await?.block_hash;
+    let block_with_state_2 = contract.add(&account.sign(&conn), 1).await?.block_hash;
+
+    assert_eq!(contract.get_at(&conn, block_with_state_0).await?, base);
+    assert_eq!(contract.get_at(&conn, block_with_state_1).await?, base + 1);
+    assert_eq!(contract.get_at(&conn, block_with_state_2).await?, base + 2);
+    assert_eq!(contract.get(&conn).await?, base + 2);
+
+    Ok(())
+}
+
+/// Test setting gas limits for contract calls.
+#[tokio::test]
+pub async fn adder_setting_gas_limits() -> Result<()> {
+    let config = setup_test();
+    let (conn, _authority, account) = basic_test_context(config).await?;
+    let contract = AdderInstance::new(
+        &config.test_case_params.adder,
+        &config.test_case_params.adder_metadata,
+    )?;
+
+    let dry_run_result = contract
+        .contract
+        .exec_dry_run(
+            &conn,
+            account.account_id().clone(),
+            "add",
+            &["1"],
+            Default::default(),
+        )
+        .await?;
+    let gas_required = dry_run_result.gas_required;
+
+    assert!(contract
+        .add_with_params(
+            &account.sign(&conn),
+            1,
+            ExecCallParams::new().gas_limit(Weight::new(
+                gas_required.ref_time() - 1,
+                gas_required.proof_size()
+            ))
+        )
+        .await
+        .is_err());
+    assert!(contract
+        .add_with_params(
+            &account.sign(&conn),
+            1,
+            ExecCallParams::new().gas_limit(Weight::new(
+                gas_required.ref_time(),
+                gas_required.proof_size() - 1
+            ))
+        )
+        .await
+        .is_err());
+    assert!(contract
+        .add_with_params(
+            &account.sign(&conn),
+            1,
+            ExecCallParams::new().gas_limit(Weight::new(
+                gas_required.ref_time(),
+                gas_required.proof_size()
+            ))
+        )
+        .await
+        .is_ok());
+    Ok(())
+}
 
 impl<'a> From<&'a AdderInstance> for &'a ContractInstance {
     fn from(instance: &'a AdderInstance) -> Self {
@@ -171,12 +258,27 @@ impl AdderInstance {
     }
 
     pub async fn get<C: ConnectionApi>(&self, conn: &C) -> Result<u32> {
-        self.contract.contract_read0(conn, "get").await
+        self.contract.read0(conn, "get", Default::default()).await
+    }
+
+    pub async fn get_at<C: ConnectionApi>(&self, conn: &C, at: BlockHash) -> Result<u32> {
+        self.contract
+            .read0(conn, "get", ReadonlyCallParams::new().at(at))
+            .await
     }
 
     pub async fn add<S: SignedConnectionApi>(&self, conn: &S, value: u32) -> Result<TxInfo> {
+        self.add_with_params(conn, value, Default::default()).await
+    }
+
+    pub async fn add_with_params<S: SignedConnectionApi>(
+        &self,
+        conn: &S,
+        value: u32,
+        params: ExecCallParams,
+    ) -> Result<TxInfo> {
         self.contract
-            .contract_exec(conn, "add", &[value.to_string()])
+            .exec(conn, "add", &[value.to_string()], params)
             .await
     }
 
@@ -194,11 +296,16 @@ impl AdderInstance {
             },
         );
 
-        self.contract.contract_exec(conn, "set_name", &[name]).await
+        self.contract
+            .exec(conn, "set_name", &[name], Default::default())
+            .await
     }
 
     pub async fn get_name<C: ConnectionApi>(&self, conn: &C) -> Result<Option<String>> {
-        let res: Option<String> = self.contract.contract_read0(conn, "get_name").await?;
+        let res: Option<String> = self
+            .contract
+            .read0(conn, "get_name", Default::default())
+            .await?;
         Ok(res.map(|name| name.replace('\0', "")))
     }
 }


### PR DESCRIPTION
# Description
Manual cherry-pick of https://github.com/Cardinal-Cryptography/aleph-node/pull/1679. E2e test run: https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/8847540121, in particular containing cherry-picked tests of adder contract, which test the new functionality.

Client versioning is non-obvious, bumped one minor version and hope it'd avoid conflicts.

# Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have added tests
- I have made corresponding changes to the existing documentation
- I have created new documentation
- I have bumped aleph-client version if relevant