### PR TITLE
A0-3010: Fix reorg metrics buckets

### DIFF
--- a/finality-aleph/src/metrics/chain_state.rs
+++ b/finality-aleph/src/metrics/chain_state.rs
@@ -85,7 +85,7 @@ impl ChainStateMetrics {
             reorgs: register(
                 Histogram::with_opts(
                     HistogramOpts::new("aleph_reorgs", "Number of reorgs by length")
-                        .buckets(vec![1., 2., 3., 5., 10.]),
+                        .buckets(vec![1., 2., 4., 9.]),
                 )?,
                 &registry,
             )?,

--- a/finality-aleph/src/metrics/chain_state.rs
+++ b/finality-aleph/src/metrics/chain_state.rs
@@ -85,7 +85,7 @@ impl ChainStateMetrics {
             reorgs: register(
                 Histogram::with_opts(
                     HistogramOpts::new("aleph_reorgs", "Number of reorgs by length")
-                        .buckets(vec![1., 2., 4., 5., 9.]),
+                        .buckets(vec![1., 2., 4., 9.]),
                 )?,
                 &registry,
             )?,

--- a/finality-aleph/src/metrics/chain_state.rs
+++ b/finality-aleph/src/metrics/chain_state.rs
@@ -85,7 +85,7 @@ impl ChainStateMetrics {
             reorgs: register(
                 Histogram::with_opts(
                     HistogramOpts::new("aleph_reorgs", "Number of reorgs by length")
-                        .buckets(vec![1., 2., 4., 9.]),
+                        .buckets(vec![1., 2., 4., 5., 9.]),
                 )?,
                 &registry,
             )?,


### PR DESCRIPTION
# Description

Changing buckets, because I set them incorectly previously. For slo, we want to measure reorgs of length >= 1, >= 2, >= 3, >= 5 and >= 10. In Prometheus, buckets are [0; x] for some values of x, so to count e.g. reorgs of length >= 5 we have to subtract those <= 4 from all the reorgs.
Hence, I decreased all bucket values by 1.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist: