### PR TITLE
A0-2980: Fix sync handler rejecting proper blocks.

### DIFF
--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -879,7 +879,10 @@ mod tests {
         },
         session::{SessionBoundaryInfo, SessionId},
         sync::{
-            data::{BranchKnowledge::*, NetworkData, Request, ResponseItem, ResponseItems, State},
+            data::{
+                BranchKnowledge::{self, *},
+                NetworkData, Request, ResponseItem, ResponseItems, State,
+            },
             forest::{ExtensionRequest, Interest},
             handler::Action,
             Justification, MockPeerId,

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -652,7 +652,7 @@ where
         }
         if !self.forest.importable(&h.id())
             && !last_imported
-                .map(|id| h.parent_id().map(|p_id| id == p_id).unwrap_or(false))
+                .and_then(|id| h.parent_id().map(|p_id| id == p_id))
                 .unwrap_or(false)
         {
             return Err(Error::HeaderNotRequired(h.id()));

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -643,6 +643,36 @@ where
         (new_highest, None)
     }
 
+    fn handle_header(
+        &mut self,
+        header: UnverifiedHeaderFor<J>,
+        peer: I,
+        equivocation_proofs: &mut Vec<V::EquivocationProof>,
+        last_imported: Option<BlockId>,
+    ) -> Result<(), <Self as HandlerTypes>::Error> {
+        let h = match self.verify_header(header, false) {
+            Ok(VerifiedHeader {
+                header: h,
+                maybe_equivocation_proof,
+            }) => {
+                maybe_equivocation_proof.map(|proof| equivocation_proofs.push(proof));
+                h
+            }
+            Err(e) => return Err(e),
+        };
+        if let Err(e) = self.forest.update_header(&h, Some(peer), false) {
+            return Err(Error::Forest(e));
+        }
+        if !self.forest.importable(&h.id())
+            && !last_imported
+                .map(|id| h.parent_id().map(|p_id| id == p_id).unwrap_or(false))
+                .unwrap_or(false)
+        {
+            return Err(Error::HeaderNotRequired(h.id()));
+        }
+        Ok(())
+    }
+
     /// Handle a request response returning whether it resulted in a new highest justified block,
     /// a list of detected equivocations, and possibly an error.
     ///
@@ -666,7 +696,7 @@ where
         let mut equivocation_proofs = vec![];
         let mut new_highest = false;
         // Lets us import descendands of importable blocks, useful for favourite blocks.
-        let mut last_imported_block: Option<BlockId> = None;
+        let mut last_imported: Option<BlockId> = None;
         for item in response_items {
             match item {
                 ResponseItem::Justification(j) => {
@@ -679,56 +709,34 @@ where
                     if self.forest.skippable(&h.id()) {
                         continue;
                     }
-                    let h = match self.verify_header(h, false) {
-                        Ok(VerifiedHeader {
-                            header: h,
-                            maybe_equivocation_proof: Some(proof),
-                        }) => {
-                            equivocation_proofs.push(proof);
-                            h
-                        }
-                        Ok(VerifiedHeader {
-                            header: h,
-                            maybe_equivocation_proof: None,
-                        }) => h,
-                        Err(e) => return (new_highest, equivocation_proofs, Some(e)),
-                    };
-                    if let Err(e) = self.forest.update_header(&h, Some(peer.clone()), false) {
-                        return (new_highest, equivocation_proofs, Some(Error::Forest(e)));
-                    }
-                    if !self.forest.importable(&h.id()) {
-                        return (
-                            new_highest,
-                            equivocation_proofs,
-                            Some(Error::HeaderNotRequired(h.id())),
-                        );
+                    if let Err(e) =
+                        self.handle_header(h, peer.clone(), &mut equivocation_proofs, None)
+                    {
+                        return (new_highest, equivocation_proofs, Some(e));
                     }
                 }
                 ResponseItem::Block(b) => {
                     if self.forest.skippable(&b.header().id()) {
                         continue;
                     }
-                    match self.forest.importable(&b.header().id())
-                        || last_imported_block
-                            .map(|id| id == b.header().id())
-                            .unwrap_or(false)
+                    if let Err(e) =
+                        self.handle_header(b.header().clone(), peer.clone(), &mut equivocation_proofs, last_imported)
                     {
-                        true => {
-                            last_imported_block = Some(b.header().id());
-                            match self.import_block(b, false) {
-                                Ok(Some(proof)) => equivocation_proofs.push(proof),
-                                Ok(None) => (),
-                                Err(e) => return (new_highest, equivocation_proofs, Some(e)),
-                            }
-                        }
-                        false => {
-                            return (
-                                new_highest,
-                                equivocation_proofs,
-                                Some(Error::BlockNotImportable(b.header().id())),
-                            )
-                        }
-                    };
+                        return (
+                            new_highest,
+                            equivocation_proofs,
+                            Some(match e {
+                                Error::HeaderNotRequired(id) => Error::BlockNotImportable(id),
+                                _ => e,
+                            }),
+                        );
+                    }
+                    last_imported = Some(b.header().id());
+                    match self.import_block(b, false) {
+                        Ok(Some(proof)) => equivocation_proofs.push(proof),
+                        Ok(None) => (),
+                        Err(e) => return (new_highest, equivocation_proofs, Some(e)),
+                    }
                 }
             }
         }
@@ -2878,5 +2886,52 @@ mod tests {
                 assert!(matches!(response, Ok((Action::Noop, None))));
             }
         }
+    }
+
+    #[tokio::test]
+    async fn accepts_chain_extension_branch() {
+        let (mut h1, mut b1, mut n1, genesis) = setup();
+        let (mut h2, b2, n2, g2) = setup();
+
+        assert_eq!(genesis, g2);
+
+        // make h1 aware of 2 headers
+        let branch = grow_light_branch(&mut h1, &genesis, 2, 0);
+
+        // import the corresponding 2 blocks in h1
+        for h in branch.clone() {
+            let block = MockBlock::new(h.clone(), true);
+            b1.import_block(block, false);
+            match n1.next().await {
+                Ok(BlockImported(header)) => {
+                    h1.block_imported(header)
+                        .expect("block imported should succeed");
+                }
+                _ => panic!("should notify about imported block"),
+            }
+        }
+
+        // h1 gets the ChainExtension request
+        let state_h2 = h2.state().unwrap();
+        let action = h1.handle_chain_extension_request(state_h2).unwrap();
+
+        // the response should contian the blocks and justifications in proper order
+        use SimplifiedItem::B;
+        let items = match action {
+            Action::Response(items) => {
+                assert_eq!(
+                    SimplifiedItem::from_response_items(items.clone()),
+                    vec![B(1), B(2)],
+                );
+                items
+            }
+            _ => panic!("should be response"),
+        };
+
+        // the result should be handled correctly, blocks should get imported
+        let (new_justified, equivocations, maybe_error) = h2.handle_request_response(items, 1);
+        assert_eq!(new_justified, false);
+        assert!(equivocations.is_empty());
+        assert!(matches!(maybe_error, None));
     }
 }

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -719,9 +719,12 @@ where
                     if self.forest.skippable(&b.header().id()) {
                         continue;
                     }
-                    if let Err(e) =
-                        self.handle_header(b.header().clone(), peer.clone(), &mut equivocation_proofs, last_imported)
-                    {
+                    if let Err(e) = self.handle_header(
+                        b.header().clone(),
+                        peer.clone(),
+                        &mut equivocation_proofs,
+                        last_imported,
+                    ) {
                         return (
                             new_highest,
                             equivocation_proofs,
@@ -2891,9 +2894,7 @@ mod tests {
     #[tokio::test]
     async fn accepts_chain_extension_branch() {
         let (mut h1, mut b1, mut n1, genesis) = setup();
-        let (mut h2, b2, n2, g2) = setup();
-
-        assert_eq!(genesis, g2);
+        let (mut h2, _, _, _) = setup();
 
         // make h1 aware of 2 headers
         let branch = grow_light_branch(&mut h1, &genesis, 2, 0);

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -2917,8 +2917,6 @@ mod tests {
             }
         }
 
-        println!("kurcze 1");
-
         // h1 gets the ChainExtension request.
         let state_h2 = h2.state().unwrap();
         let action = h1.handle_chain_extension_request(state_h2).unwrap();
@@ -2935,8 +2933,6 @@ mod tests {
             }
             _ => panic!("should be response"),
         };
-
-        println!("kurcze 2");
 
         // The result should be handled correctly, blocks should get imported.
         let (new_justified, equivocations, maybe_error) = h2.handle_request_response(items, 1);

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -742,10 +742,8 @@ where
                         );
                     }
                     last_imported = Some(b.header().id());
-                    match self.import_block(b, false) {
-                        Ok(Some(proof)) => equivocation_proofs.push(proof),
-                        Ok(None) => (),
-                        Err(e) => return (new_highest, equivocation_proofs, Some(e)),
+                    if let Err(e) = self.import_block(b, false) {
+                        return (new_highest, equivocation_proofs, Some(e));
                     }
                 }
             }
@@ -2901,7 +2899,7 @@ mod tests {
     #[tokio::test]
     async fn accepts_chain_extension_branch() {
         let (mut h1, mut b1, mut n1, genesis) = setup();
-        let (mut h2, _, _, _) = setup();
+        let (mut h2, _b2, _n2, _genesis) = setup();
 
         // Make h1 aware of 2 headers.
         let branch = grow_light_branch(&mut h1, &genesis, 2, 0);
@@ -2919,6 +2917,8 @@ mod tests {
             }
         }
 
+        println!("kurcze 1");
+
         // h1 gets the ChainExtension request.
         let state_h2 = h2.state().unwrap();
         let action = h1.handle_chain_extension_request(state_h2).unwrap();
@@ -2935,6 +2935,8 @@ mod tests {
             }
             _ => panic!("should be response"),
         };
+
+        println!("kurcze 2");
 
         // The result should be handled correctly, blocks should get imported.
         let (new_justified, equivocations, maybe_error) = h2.handle_request_response(items, 1);

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -879,10 +879,7 @@ mod tests {
         },
         session::{SessionBoundaryInfo, SessionId},
         sync::{
-            data::{
-                BranchKnowledge::{self, *},
-                NetworkData, Request, ResponseItem, ResponseItems, State,
-            },
+            data::{BranchKnowledge::*, NetworkData, Request, ResponseItem, ResponseItems, State},
             forest::{ExtensionRequest, Interest},
             handler::Action,
             Justification, MockPeerId,

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -2612,11 +2612,8 @@ mod tests {
             .block_imported(header)
             .expect("correct")
             .expect("known");
-        match result.get(0).expect("the header is there") {
-            ResponseItem::Header(header) => assert_eq!(header, block.header()),
-            other => panic!("expected header item, got {:?}", other),
-        }
-        match result.get(1).expect("the block is there") {
+        assert_eq!(result.len(), 1);
+        match result.first().expect("the block is there") {
             ResponseItem::Block(block_item) => assert_eq!(block_item.header(), block.header()),
             other => panic!("expected block item, got {:?}", other),
         }

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -2903,10 +2903,10 @@ mod tests {
         let (mut h1, mut b1, mut n1, genesis) = setup();
         let (mut h2, _, _, _) = setup();
 
-        // make h1 aware of 2 headers
+        // Make h1 aware of 2 headers.
         let branch = grow_light_branch(&mut h1, &genesis, 2, 0);
 
-        // import the corresponding 2 blocks in h1
+        // Import the corresponding 2 blocks in h1.
         for h in branch.clone() {
             let block = MockBlock::new(h.clone(), true);
             b1.import_block(block, false);
@@ -2919,11 +2919,11 @@ mod tests {
             }
         }
 
-        // h1 gets the ChainExtension request
+        // h1 gets the ChainExtension request.
         let state_h2 = h2.state().unwrap();
         let action = h1.handle_chain_extension_request(state_h2).unwrap();
 
-        // the response should contian the blocks and justifications in proper order
+        // The response should contian the two blocks.
         use SimplifiedItem::B;
         let items = match action {
             Action::Response(items) => {
@@ -2936,7 +2936,7 @@ mod tests {
             _ => panic!("should be response"),
         };
 
-        // the result should be handled correctly, blocks should get imported
+        // The result should be handled correctly, blocks should get imported.
         let (new_justified, equivocations, maybe_error) = h2.handle_request_response(items, 1);
         assert!(!new_justified);
         assert!(equivocations.is_empty());

--- a/finality-aleph/src/sync/handler/request_handler.rs
+++ b/finality-aleph/src/sync/handler/request_handler.rs
@@ -254,7 +254,7 @@ where
 
     fn single_block(block: B) -> Self {
         let mut result = Self::empty();
-        result.add_block_and_header(block);
+        result.add_block(block);
         result
     }
 


### PR DESCRIPTION
# Description

When a block comes as a response to a request, we first process its header, similarly as we would get this header in a response. 

Additionally, next to making the `forest.importable(header.id)` check in `handle_header` which checks if forest would accept the corresponding block, we also allow for imports in a sequence. This means that if in the same response processing we imported the parent of the block, then we can also import the block, no matter what `forest.importable(...)` has returned.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have added tests
- I have made corresponding changes to the existing documentation
- I have created new documentation
