### PR TITLE
A0-4268: Add curl to chain-bootstrapper docker image

### DIFF
--- a/bin/chain-bootstrapper/Dockerfile
+++ b/bin/chain-bootstrapper/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:jammy
 
+RUN apt update && \
+        apt install curl -y
+
 COPY target/release/chain-bootstrapper /usr/local/bin
 RUN chmod +x /usr/local/bin/chain-bootstrapper
 


### PR DESCRIPTION
# Description

As per PR's title.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
