### PR TITLE
L1-220: Request chain extension more liberally

### DIFF
--- a/finality-aleph/src/sync/forest/mod.rs
+++ b/finality-aleph/src/sync/forest/mod.rs
@@ -359,7 +359,7 @@ where
 
     /// Updates the provided header, returns:
     /// 1. If required is set whether it became a new explicitly required.
-    /// 2. Otherwise whether it's a new header above the favourite block.
+    /// 2. Otherwise whether it's a new header with a number greater than the favourite block.
     pub fn update_header(
         &mut self,
         header: &J::Header,

--- a/finality-aleph/src/sync/forest/mod.rs
+++ b/finality-aleph/src/sync/forest/mod.rs
@@ -359,25 +359,25 @@ where
 
     /// Updates the provided header, returns:
     /// 1. If required is set whether it became a new explicitly required.
-    /// 2. Otherwise whether it's a new descendant of the highest justified.
+    /// 2. Otherwise whether it's a new header above the favourite block.
     pub fn update_header(
         &mut self,
         header: &J::Header,
         holder: Option<I>,
         required: bool,
     ) -> Result<bool, Error> {
-        let (id, parent_id) = self.process_header(header)?;
-        let mut new_descendant = parent_id == self.root.id();
+        let (id, _) = self.process_header(header)?;
+        let mut new_above = id.number() > self.favourite.id().number();
         self.insert_id(id.clone(), holder.clone())?;
         if let VertexHandleMut::Candidate(mut entry) = self.get_mut(&id) {
             if !entry.get_mut().vertex.insert_header(header.clone(), holder) {
-                new_descendant = false;
+                new_above = false;
             }
             self.connect_parent(&id);
         }
         match required {
             true => Ok(self.set_explicitly_required(&id)),
-            false => Ok(new_descendant),
+            false => Ok(new_above),
         }
     }
 
@@ -773,10 +773,10 @@ mod tests {
         let grandchild = child.random_child();
         let grandpeer_id = rand::random();
         assert!(
-            !forest
+            forest
                 .update_header(&grandchild, Some(grandpeer_id), false)
                 .expect("header was correct"),
-            "should not count as a child of the favourite",
+            "should count as above the favourite",
         );
         assert!(forest.try_finalize(&1).is_none());
         assert!(matches!(
@@ -1220,9 +1220,12 @@ mod tests {
         let favourite_block = fork_branch.last().expect("the fork is not empty");
         let fork_child = favourite_block.random_child();
         let fork_child_peer_id = rand::random();
-        assert!(!forest
-            .update_header(&fork_child, Some(fork_child_peer_id), false)
-            .expect("header was correct"));
+        assert!(
+            forest
+                .update_header(&fork_child, Some(fork_child_peer_id), false)
+                .expect("header was correct"),
+            "header is above favourite"
+        );
         let fork_child_know_most = HashSet::from([fork_child_peer_id]);
         let know_most = fork_child_know_most.clone();
         assert_eq!(forest.extension_request(), FavouriteBlock { know_most });
@@ -1271,9 +1274,12 @@ mod tests {
         assert!(forest.importable(&header.id()));
         let header = &branch[1];
         let peer_id = rand::random();
-        assert!(!forest
-            .update_header(header, Some(peer_id), false)
-            .expect("header was correct"));
+        assert!(
+            forest
+                .update_header(header, Some(peer_id), false)
+                .expect("header was correct"),
+            "header is above favourite"
+        );
         assert!(matches!(
             forest.request_interest(&header.id()),
             Uninterested
@@ -1291,9 +1297,12 @@ mod tests {
         assert!(forest.importable(&header.id()));
         let header = &branch[2];
         let peer_id = rand::random();
-        assert!(!forest
-            .update_header(header, Some(peer_id), false)
-            .expect("header was correct"));
+        assert!(
+            forest
+                .update_header(header, Some(peer_id), false)
+                .expect("header was correct"),
+            "header above favourite"
+        );
         for header in branch.iter().take(3) {
             assert!(forest.importable(&header.id()));
         }
@@ -1320,9 +1329,12 @@ mod tests {
         // skip branch[1]
         let header = &branch[2];
         let peer_id = rand::random();
-        assert!(!forest
-            .update_header(header, Some(peer_id), false)
-            .expect("header was correct"));
+        assert!(
+            forest
+                .update_header(header, Some(peer_id), false)
+                .expect("header was correct"),
+            "header is above favourite"
+        );
         assert!(matches!(
             forest.request_interest(&header.id()),
             Uninterested
@@ -1350,9 +1362,12 @@ mod tests {
         // fill the gap
         let header = &branch[1];
         let peer_id = rand::random();
-        assert!(!forest
-            .update_header(header, Some(peer_id), false)
-            .expect("header was correct"));
+        assert!(
+            forest
+                .update_header(header, Some(peer_id), false)
+                .expect("header was correct"),
+            "header above favourite"
+        );
         for header in branch.iter().take(3) {
             assert!(matches!(
                 forest.request_interest(&header.id()),
@@ -1510,10 +1525,10 @@ mod tests {
         for header in branch.iter().take(HUGE_BRANCH_LENGTH - 1) {
             let peer_id = rand::random();
             assert!(
-                !forest
+                forest
                     .update_header(header, Some(peer_id), false)
-                    .expect("header was correct")
-                    || header.id().number() == initial_header.id().number() + 1
+                    .expect("header was correct"),
+                "header is above favourite"
             );
             assert!(matches!(
                 forest.request_interest(&header.id()),

--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -774,8 +774,8 @@ where
                     maybe_equivocation_proof,
                 } = self.verify_header(state.favourite_block(), false)?;
                 maybe_proof = maybe_equivocation_proof;
-                let new_descendant = self.forest.update_header(&header, Some(peer), false)?;
-                HandleStateAction::maybe_extend(higher_justification || new_descendant)
+                let new_above = self.forest.update_header(&header, Some(peer), false)?;
+                HandleStateAction::maybe_extend(higher_justification || new_above)
             }
             // same session
             Some(0) => match remote_top_number >= local_top_number {
@@ -788,8 +788,8 @@ where
                     maybe_proof = maybe_equivocation_proof;
                     let higher_justification =
                         self.handle_justification(state.top_justification(), Some(peer.clone()))?;
-                    let new_descendant = self.forest.update_header(&header, Some(peer), false)?;
-                    HandleStateAction::maybe_extend(higher_justification || new_descendant)
+                    let new_above = self.forest.update_header(&header, Some(peer), false)?;
+                    HandleStateAction::maybe_extend(higher_justification || new_above)
                 }
                 // remote top justification lower than ours, we can send a response
                 false => HandleStateAction::response(local_top.into_unverified(), None),


### PR DESCRIPTION
# Description

Now any header with a number higher than the local favourite block can trigger a chain extension request. This makes the new sync keep up with blocks much better.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- I have made corresponding changes to the existing documentation