### PR TITLE
A0-2999: Update all actions to run on node20

### DIFF
--- a/.github/actions/store-node-and-runtime/action.yml
+++ b/.github/actions/store-node-and-runtime/action.yml
@@ -56,7 +56,7 @@ runs:
         path: target/${{ steps.get-local-envs.outputs.cargo_profile }}/wbuild/aleph-runtime
 
     - name: Configure AWS credentials for S3 AWS
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       env:
         AWS_ACCESS_KEY_ID: ""
         AWS_SECRET_ACCESS_KEY: ""

--- a/.github/workflows/_unit-tests-and-static-checks.yml
+++ b/.github/workflows/_unit-tests-and-static-checks.yml
@@ -19,14 +19,9 @@ jobs:
         uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v6
 
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        env:
-          # https://github.com/mozilla/sccache/issues/966
-          RUSTC_WRAPPER: ""
-          RUSTC_WORKSPACE_WRAPPER: sccache
-        with:
-          command: clippy
-          args: --all-targets --workspace --exclude baby-liminal-extension -- --no-deps -D warnings
+        run: |
+          cargo clippy \
+            --all-targets --workspace --exclude baby-liminal-extension -- --no-deps -D warnings
 
       # Run clippy for the chain extension: it requires a different setup.
       - name: Run clippy for chain extension
@@ -47,10 +42,9 @@ jobs:
         uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v6
 
       - name: Run Unit Test Suite
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --exclude baby-liminal-extension -- --skip clique_network
+        run: |
+          cargo test \
+            --workspace --exclude baby-liminal-extension -- --skip clique_network
 
   unit-tests-chain-extension:
     name: Run unit tests for chain extension

--- a/.github/workflows/_update-node-image-infra.yml
+++ b/.github/workflows/_update-node-image-infra.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Call action get-ref-properties
         id: get-ref-properties
-        # yamllint disable-line rule:line-length
         uses: Cardinal-Cryptography/github-actions/get-ref-properties@v6
 
       - name: Call action Get ECR image names

--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -32,10 +32,8 @@ jobs:
         uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v6
 
       - name: Run Test Suite
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --exclude baby-liminal-extension
+        run: |
+          cargo test --workspace --exclude baby-liminal-extension
 
       - name: Install Rust Toolchain For Chain Extension Tests
         uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v6


### PR DESCRIPTION
# Description

See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ for more info.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

