### PR TITLE
A0-4306: Migrate to docker compose from docker-compose

### DIFF
--- a/.github/scripts/run_consensus.sh
+++ b/.github/scripts/run_consensus.sh
@@ -118,7 +118,7 @@ function run_containers() {
   for index in $(seq 0 "${authorities_count}"); do
     containers+=("Node${index}")
   done
-  docker-compose $(get_compose_file_list "${docker_compose_file}" "${override_file}") up -d "${containers[@]}"
+  docker compose $(get_compose_file_list "${docker_compose_file}" "${override_file}") up -d "${containers[@]}"
 }
 
 function archive_logs() {
@@ -133,7 +133,7 @@ function archive_logs() {
   pushd $(mktemp -d) > /dev/null
   for index in $(seq 0 "${node_count}"); do
     echo "Archiving "Node${index}" logs..."
-    docker-compose ${compose_file_list} logs --no-color --no-log-prefix "Node${index}" > "Node${index}.log"
+    docker compose ${compose_file_list} logs --no-color --no-log-prefix "Node${index}" > "Node${index}.log"
   done
   tar -czf "${tarball_output}" Node*
   popd > /dev/null
@@ -163,12 +163,12 @@ else
   exit 1
 fi
 
-if docker inspect ${NODE_IMAGE} > /dev/null; then
-  echo "aleph-node image tag ${NODE_IMAGE} found locally"
+if docker inspect ${CHAIN_BOOTSTRAPPER_IMAGE} > /dev/null; then
+  echo "chain-bootstrapper image tag ${CHAIN_BOOTSTRAPPER_IMAGE} found locally"
 else
-  echo "${NODE_IMAGE} not found locally."
+  echo "${CHAIN_BOOTSTRAPPER_IMAGE} not found locally."
   echo "Build image first with:"
-  echo "docker build -t ${NODE_IMAGE} -f docker/Dockerfile ."
+  echo "docker build -t ${CHAIN_BOOTSTRAPPER_IMAGE} -f ./bin/chain-bootstrapper/Dockerfile ."
   exit 1
 fi
 

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -91,4 +91,5 @@ jobs:
         uses: ./.github/actions/run-e2e-test
         with:
           test-case: token_transfer
-          aleph-e2e-client-image: ${{ inputs.aleph-e2e-client-image }}
+          # yamllint disable-line rule:line-length
+          aleph-e2e-client-image:  ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -92,4 +92,4 @@ jobs:
         with:
           test-case: token_transfer
           # yamllint disable-line rule:line-length
-          aleph-e2e-client-image:  ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
+          aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -75,3 +75,20 @@ jobs:
           test-case: finalization::finalization
           # yamllint disable-line rule:line-length
           aleph-e2e-client-image: ${{ needs.build-aleph-e2e-client-image.outputs.aleph-e2e-client-image }}
+
+  run-e2e-token-transfer-test:
+    name: Run e2e token transfer test
+    needs:
+      - build-test-node
+      - build-aleph-e2e-client-image
+      - build-chain-bootstrapper
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Run e2e test
+        uses: ./.github/actions/run-e2e-test
+        with:
+          test-case: token_transfer
+          aleph-e2e-client-image: ${{ inputs.aleph-e2e-client-image }}

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/scripts/run_local_e2e_pipeline.sh
+++ b/scripts/run_local_e2e_pipeline.sh
@@ -2,10 +2,11 @@
 
 set -e
 
-# build release binary
-cargo build --release -p aleph-node --features "short_session enable_treasury_proposals"
-# build docker image
+cargo build --release -p aleph-node
 docker build --tag aleph-node:latest -f ./docker/Dockerfile .
+
+cargo build --release -p chain-bootstrapper --features short_session
+docker build --tag chain-bootstrapper:latest -f ./bin/chain-bootstrapper/Dockerfile .
 
 # run the chain and the tests in two separate tmux windows
 tmux new-session -d -s aleph0 './.github/scripts/run_consensus.sh';

--- a/scripts/synthetic-network/README.md
+++ b/scripts/synthetic-network/README.md
@@ -10,7 +10,7 @@ page, i.e. :3001 is Node1, ...).
 
 Main file in this folder is `run_consensus_synthetic-network.sh`. It builds a docker-image containing `aleph-node` and some
 arbitrary set of networking and debugging tools. It also consists of files required to spawn an instance of the
-synthetic-network. Its requirements are: docker, docker-compose, git, `aleph-node:latest` docker-image.
+synthetic-network. Its requirements are: docker, docker compose, git, `aleph-node:latest` docker-image.
 
 `set_defaults_synthetic-network.sh` allows you to reset settings of the synthetic-network to some sane defaults. You might need
 to use it when you set too restrictive values for some of its parameters, i.e. rate limit that make you unable to further

--- a/scripts/synthetic-network/run_script_for_synthetic-network.sh
+++ b/scripts/synthetic-network/run_script_for_synthetic-network.sh
@@ -10,7 +10,7 @@ Usage:
   $0
   This script allows you to run a custom .js script using the synthetic-network network simulation tool.
   IMPORTANT: first you need to call 'scripts/run_consensus_synthetic-network.sh' and let it run in background.
-             It spawns docker-compose configured with synthetic-network.
+             It spawns docker compose configured with synthetic-network.
              It requires node.js to run.
     --script-path scripts/vendor/synthetic-network/frontend/udp_rate_sine_demo.js
         path to a synthetic-network scrypt. Default is a demo scripts/vendor/synthetic-network/frontend/udp_rate_sine_demo.js


### PR DESCRIPTION
# Description

* Migrate to docker compose from docker-compose, as the former works both on ubuntu 20 and 22.
* Add a token transfer test to the PR pipeline. It is important to see if the chain's basic functionality works. It is currently expected to fail, as it does on `main`.
* fix some logging in `run_conensus.sh`

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- bug fix
