### PR TITLE
L1-55 Run check pr title only on pull request

### DIFF
--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -16,6 +16,7 @@ jobs:
   check-pr-title:
     name: Check PR title
     runs-on: ubuntu-20.04
+    if: github.event_name == 'pull_request'
     steps:
       - name: Check PR title
         uses: Cardinal-Cryptography/github-actions/check-pr-title@v7


### PR DESCRIPTION
# Description

The change https://github.com/Cardinal-Cryptography/aleph-node/commit/a0faac51f21f46a90bc1e4000c6ca9211616dd87 had a bug that ran the `PR check title` job also on the `merge_group` trigger. It should run only on a PR. 

It fixes https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/9188416432/job/25268221144

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

