### PR TITLE
L1-66: Pallet operations latest changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4095,6 +4095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5647,11 +5653,13 @@ dependencies = [
 name = "pallet-operations"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
  "log",
  "pallet-balances",
+ "pallet-contracts",
  "pallet-session",
  "pallet-staking",
  "pallet-timestamp",
@@ -5661,6 +5669,8 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
+ "sp-std",
+ "wat",
 ]
 
 [[package]]
@@ -10581,6 +10591,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41763f20eafed1399fff1afb466496d3a959f58241436cfdc17e3f5ca954de16"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-instrument"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10896,6 +10915,27 @@ dependencies = [
  "serde",
  "thiserror",
  "wasmparser",
+]
+
+[[package]]
+name = "wast"
+version = "63.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2560471f60a48b77fccefaf40796fda61c97ce1e790b59dfcec9dc3995c9f63a"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bdc306c2c4c2f2bf2ba69e083731d0d2a77437fc6a350a19db139636e7e416c"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -385,6 +385,7 @@ impl pallet_operations::Config for Runtime {
     type BalancesProvider = Balances;
     type NextKeysSessionProvider = Session;
     type BondedStashProvider = Staking;
+    type ContractInfoProvider = Contracts;
 }
 
 impl pallet_committee_management::Config for Runtime {

--- a/pallets/operations/Cargo.toml
+++ b/pallets/operations/Cargo.toml
@@ -16,14 +16,20 @@ frame-system = { workspace = true }
 pallet-session = { workspace = true }
 pallet-balances = { workspace = true }
 pallet-staking = { workspace = true }
+pallet-contracts = { workspace = true }
+
 sp-runtime = { workspace = true }
 sp-core = { workspace = true }
 sp-staking = { workspace = true }
+sp-std = { workspace = true }
 
 [dev-dependencies]
 sp-io = { workspace = true }
 pallet-timestamp = { workspace = true }
 frame-election-provider-support = { workspace = true }
+anyhow = "1.0.86"
+# Version compatible with Rust 1.74.X
+wat = "=1.0.70"
 
 [features]
 default = ["std"]
@@ -37,11 +43,13 @@ std = [
     "pallet-session/std",
     "pallet-balances/std",
     "pallet-staking/std",
+    "pallet-contracts/std",
     "pallet-timestamp/std",
     "frame-election-provider-support/std",
     "sp-runtime/std",
     "sp-core/std",
     "sp-staking/std",
+    "sp-std/std",
 ]
 
 try-runtime = [

--- a/pallets/operations/src/impls.rs
+++ b/pallets/operations/src/impls.rs
@@ -1,45 +1,56 @@
 #![allow(clippy::nonminimal_bool)]
 
-use frame_support::{dispatch::DispatchResult, traits::LockIdentifier, WeakBoundedVec};
-use pallet_balances::BalanceLock;
+use frame_support::dispatch::DispatchResult;
 use parity_scale_codec::Encode;
 use sp_core::hexdisplay::HexDisplay;
 use sp_runtime::DispatchError;
 
 use crate::{
     pallet::{Config, Event, Pallet},
-    traits::{AccountInfoProvider, BalancesProvider, BondedStashProvider, NextKeysSessionProvider},
-    LOG_TARGET, STAKING_ID,
+    traits::{
+        AccountInfoProvider, BalancesProvider, BondedStashProvider, ContractInfoProvider,
+        NextKeysSessionProvider,
+    },
+    LOG_TARGET,
 };
 
 impl<T: Config> Pallet<T> {
-    /// Checks if account has an underflow of `consumers` counter. In such case, it increments
-    /// it by one.
-    pub fn fix_underflow_consumer_counter(who: T::AccountId) -> DispatchResult {
+    /// Calculate expected consumers counter for a `who` account, and if actual
+    /// counter is not as expected, increment or decrement current counter
+    pub fn fix_consumer_counter(who: T::AccountId) -> DispatchResult {
         let current_consumers = T::AccountInfoProvider::get_consumers(&who);
         let mut expected_consumers: u32 = 0;
 
         if Self::reserved_or_frozen_non_zero(&who) {
             expected_consumers += 1;
         }
-        let has_staking_lock = Self::has_staking_lock(&who);
-        if has_staking_lock {
+        if Self::is_contract_account(&who) {
+            expected_consumers += 1;
+        }
+        if Self::is_bonded(&who) {
             expected_consumers += 1;
         }
         if Self::has_next_session_keys_and_account_is_controller(&who) {
             expected_consumers += 1;
         }
 
+        #[allow(clippy::comparison_chain)]
         if current_consumers < expected_consumers {
             log::debug!(
                 target: LOG_TARGET,
-                "Account {:?} has current consumers {} less than expected consumers {:?}, incrementing ",
+                "Account {:?} has consumers underflow: current({}) < expected ({}), incrementing ",
                 HexDisplay::from(&who.encode()), current_consumers, expected_consumers);
-            Self::increment_consumers(who)?;
-        } else {
+            Self::increment_consumers(&who)?;
+        } else if current_consumers > expected_consumers {
             log::debug!(
                 target: LOG_TARGET,
-                "Account {:?} does not have consumers underflow, not incrementing",
+                "Account {:?} has consumers overflow: current({}) > expected ({}), decrementing ",
+                HexDisplay::from(&who.encode()), current_consumers, expected_consumers);
+            Self::decrement_consumers(&who);
+        } else {
+            log::trace!(
+                target: LOG_TARGET,
+                "Account {:?} neither has underflow nor overflow of consumers counter.",
                 HexDisplay::from(&who.encode())
             );
         }
@@ -51,9 +62,12 @@ impl<T: Config> Pallet<T> {
         !T::BalancesProvider::is_reserved_zero(who) || !T::BalancesProvider::is_frozen_zero(who)
     }
 
-    fn has_staking_lock(who: &T::AccountId) -> bool {
-        let locks = T::BalancesProvider::locks(who);
-        Self::has_lock(&locks, STAKING_ID)
+    fn is_bonded(who: &T::AccountId) -> bool {
+        T::BondedStashProvider::get_controller(who).is_some()
+    }
+
+    fn is_contract_account(who: &T::AccountId) -> bool {
+        T::ContractInfoProvider::is_contract_account(who)
     }
 
     fn has_next_session_keys_and_account_is_controller(who: &T::AccountId) -> bool {
@@ -73,13 +87,18 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    fn has_lock<U, V>(locks: &WeakBoundedVec<BalanceLock<U>, V>, id: LockIdentifier) -> bool {
-        locks.iter().any(|x| x.id == id)
+    fn increment_consumers(who: &T::AccountId) -> Result<(), DispatchError> {
+        frame_system::Pallet::<T>::inc_consumers_without_limit(who)?;
+        Self::deposit_event(Event::ConsumersCounterIncremented { who: who.clone() });
+        Ok(())
     }
 
-    fn increment_consumers(who: T::AccountId) -> Result<(), DispatchError> {
-        frame_system::Pallet::<T>::inc_consumers_without_limit(&who)?;
-        Self::deposit_event(Event::ConsumersUnderflowFixed { who });
-        Ok(())
+    fn decrement_consumers(who: &T::AccountId) {
+        // dec_consumers does not return any error when current counter is 0, hence we need to
+        // handle such case manually
+        if T::AccountInfoProvider::get_consumers(who) > 0 {
+            frame_system::Pallet::<T>::dec_consumers(who);
+            Self::deposit_event(Event::ConsumersCounterDecremented { who: who.clone() });
+        }
     }
 }

--- a/pallets/operations/src/tests/data/transfer_return_code.wat
+++ b/pallets/operations/src/tests/data/transfer_return_code.wat
@@ -1,0 +1,34 @@
+;; This transfers 100 balance to the zero account and copies the return code
+;; of this transfer to the output buffer.
+(module
+	(import "seal0" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "env" "memory" (memory 1 1))
+
+	;; [0, 32) zero-adress
+	(data (i32.const 0)
+		"\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+		"\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+	)
+
+	;; [32, 40) 100 balance
+	(data (i32.const 32) "\64\00\00\00\00\00\00\00")
+
+	;; [40, 44) here we store the return code of the transfer
+
+	(func (export "deploy"))
+
+	(func (export "call")
+		(i32.store
+			(i32.const 40)
+			(call $seal_transfer
+				(i32.const 0) ;; ptr to destination address
+				(i32.const 32) ;; length of destination address
+				(i32.const 32) ;; ptr to value to transfer
+				(i32.const 8) ;; length of value to transfer
+			)
+		)
+		;; exit with success and take transfer return code to the output buffer
+		(call $seal_return (i32.const 0) (i32.const 40) (i32.const 4))
+	)
+)

--- a/pallets/operations/src/tests/suite.rs
+++ b/pallets/operations/src/tests/suite.rs
@@ -1,8 +1,13 @@
+use std::{env::var, path::PathBuf};
+
 use frame_support::{
     assert_ok,
     traits::{Currency, LockableCurrency, ReservableCurrency, WithdrawReasons},
+    weights::Weight,
 };
+use pallet_contracts::{Code, CollectEvents, DebugInfo};
 use pallet_staking::RewardDestination;
+use sp_runtime::traits::Hash;
 
 use super::setup::*;
 use crate::VESTING_ID;
@@ -49,6 +54,28 @@ fn pallet_operations_events() -> Vec<crate::Event<TestRuntime>> {
         .collect()
 }
 
+fn wat_root_dir() -> PathBuf {
+    match var("CARGO_MANIFEST_DIR") {
+        // When `CARGO_MANIFEST_DIR` is not set, Rust resolves relative paths from the root folder
+        Err(_) => "pallets/operations/src/tests/data".into(),
+        Ok(path) => PathBuf::from(path).join("src/tests/data"),
+    }
+}
+
+/// Load a given wasm module represented by a .wat file and returns a wasm binary contents along
+/// with its hash.
+///
+/// The fixture files are located under the `fixtures/` directory.
+fn compile_module<T>(fixture_name: &str) -> anyhow::Result<(Vec<u8>, <T::Hashing as Hash>::Output)>
+where
+    T: frame_system::Config,
+{
+    let fixture_path = wat_root_dir().join(format!("{fixture_name}.wat"));
+    let wasm_binary = wat::parse_file(fixture_path)?;
+    let code_hash = T::Hashing::hash(&wasm_binary);
+    Ok((wasm_binary, code_hash))
+}
+
 #[test]
 fn given_accounts_with_initial_balance_then_balances_data_and_counters_are_valid() {
     let authority_id = 1_u64;
@@ -63,12 +90,15 @@ fn given_accounts_with_initial_balance_then_balances_data_and_counters_are_valid
         assert_eq!(total_balance(authority_id), total_balance_authority);
         assert_eq!(free_balance(authority_id), total_balance_authority);
         assert_eq!(reserved_balance(authority_id), 0);
-        // there are > 0 consumers, so we can't transfer everything
-        assert_eq!(usable_balance(authority_id), total_balance_authority - ed());
 
         assert_eq!(providers(authority_id), 1);
         // +1 consumers due to session keys are set
-        assert_eq!(consumers(authority_id), 1);
+        // +1 consumers due to frozen > 0
+        // +1 consumers due to bond()
+        assert_eq!(consumers(authority_id), 3);
+        // since there are > 0 consumers, so we can't transfer everything - half ot total
+        // balance is locked due to bond()
+        assert_eq!(usable_balance(authority_id), total_balance_authority / 2);
 
         assert_eq!(total_balance(non_authority_id), total_balance_non_authority);
         assert_eq!(free_balance(non_authority_id), total_balance_non_authority);
@@ -96,26 +126,6 @@ fn given_accounts_with_initial_balance_when_reserving_then_balances_data_and_cou
     .execute_with(|| {
         let reserved_amount = 3_u128;
         assert_ok!(pallet_balances::Pallet::<TestRuntime>::reserve(
-            &authority_id,
-            reserved_amount
-        ));
-        assert_eq!(total_balance(authority_id), total_balance_authority);
-        assert_eq!(
-            free_balance(authority_id),
-            total_balance_authority - reserved_amount
-        );
-        assert_eq!(reserved_balance(authority_id), reserved_amount);
-        // since consumers > 0
-        assert_eq!(
-            usable_balance(authority_id),
-            total_balance_authority - reserved_amount - ed()
-        );
-        assert_eq!(providers(authority_id), 1);
-        // +1 consumers due to session keys are set
-        // +1 consumers since there is reserved balance
-        assert_eq!(consumers(authority_id), 2);
-
-        assert_ok!(pallet_balances::Pallet::<TestRuntime>::reserve(
             &non_authority_id,
             reserved_amount
         ));
@@ -125,14 +135,14 @@ fn given_accounts_with_initial_balance_when_reserving_then_balances_data_and_cou
             total_balance_non_authority - reserved_amount
         );
         assert_eq!(reserved_balance(non_authority_id), reserved_amount);
-        // free - ed - reserved since consumers > 0
+        assert_eq!(providers(non_authority_id), 1);
+        // +1 consumers since there is reserved balance
+        assert_eq!(consumers(non_authority_id), 1);
+        // since consumers > 0
         assert_eq!(
             usable_balance(non_authority_id),
             total_balance_non_authority - reserved_amount - ed()
         );
-        assert_eq!(providers(non_authority_id), 1);
-        // +1 consumers since there is reserved balance
-        assert_eq!(consumers(authority_id), 2);
     });
 }
 
@@ -149,25 +159,6 @@ fn given_account_with_initial_balance_when_bonding_then_balances_data_and_counte
     .execute_with(|| {
         let bonded = 123_u128;
         assert_ok!(pallet_staking::Pallet::<TestRuntime>::bond(
-            RuntimeOrigin::signed(authority_id),
-            bonded,
-            RewardDestination::Stash
-        ));
-        assert_eq!(total_balance(authority_id), total_balance_authority);
-        assert_eq!(free_balance(authority_id), total_balance_authority);
-        assert_eq!(reserved_balance(authority_id), 0_u128);
-        assert_eq!(
-            usable_balance(authority_id),
-            total_balance_authority - bonded
-        );
-        assert_eq!(providers(authority_id), 1);
-        // +1 consumers due to session keys are set
-        // +1 consumers since there is frozen balance
-        // +1 consumers since there is at least one lock
-        // +1 consumers from bond()
-        assert_eq!(consumers(authority_id), 3);
-
-        assert_ok!(pallet_staking::Pallet::<TestRuntime>::bond(
             RuntimeOrigin::signed(non_authority_id),
             bonded,
             RewardDestination::Stash
@@ -182,14 +173,13 @@ fn given_account_with_initial_balance_when_bonding_then_balances_data_and_counte
         );
         assert_eq!(providers(non_authority_id), 1);
         // +1 consumers since there is frozen balance
-        // +1 consumers since there is at least one lock
         // +1 consumers from bond()
         assert_eq!(consumers(non_authority_id), 2);
     });
 }
 
 #[test]
-fn given_accounts_with_initial_balance_when_fixing_consumers_then_accounts_do_not_change() {
+fn given_accounts_with_initial_balance_when_fixing_consumers_then_counters_are_valid() {
     let authority_id = 1_u64;
     let non_authority_id = 2_u64;
     let total_balance_authority = 1000_u128;
@@ -199,28 +189,30 @@ fn given_accounts_with_initial_balance_when_fixing_consumers_then_accounts_do_no
         (non_authority_id, false, total_balance_non_authority),
     ])
     .execute_with(|| {
-        assert_eq!(consumers(authority_id), 1);
+        assert_eq!(consumers(authority_id), 3);
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(authority_id),
                 authority_id
             )
         );
-        assert_eq!(consumers(authority_id), 1);
+        assert_eq!(consumers(authority_id), 3);
 
         assert_eq!(consumers(non_authority_id), 0);
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(authority_id),
                 non_authority_id
             )
         );
         assert_eq!(consumers(non_authority_id), 0);
+
+        assert_eq!(pallet_operations_events().len(), 0);
     });
 }
 
 #[test]
-fn given_accounts_with_reserved_balance_when_fixing_consumers_then_accounts_do_not_change() {
+fn given_accounts_with_reserved_balance_when_fixing_consumers_then_counters_are_valid() {
     let authority_id = 1_u64;
     let non_authority_id = 2_u64;
     let total_balance_authority = 1000_u128;
@@ -235,14 +227,14 @@ fn given_accounts_with_reserved_balance_when_fixing_consumers_then_accounts_do_n
             &authority_id,
             reserved_amount
         ));
-        assert_eq!(consumers(authority_id), 2);
+        assert_eq!(consumers(authority_id), 3);
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(authority_id),
                 authority_id
             )
         );
-        assert_eq!(consumers(authority_id), 2);
+        assert_eq!(consumers(authority_id), 3);
 
         assert_ok!(pallet_balances::Pallet::<TestRuntime>::reserve(
             &non_authority_id,
@@ -250,17 +242,19 @@ fn given_accounts_with_reserved_balance_when_fixing_consumers_then_accounts_do_n
         ));
         assert_eq!(consumers(non_authority_id), 1);
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(authority_id),
                 non_authority_id
             )
         );
         assert_eq!(consumers(non_authority_id), 1);
+
+        assert_eq!(pallet_operations_events().len(), 0);
     });
 }
 
 #[test]
-fn given_bonded_accounts_balance_when_fixing_consumers_then_accounts_do_not_change() {
+fn given_bonded_accounts_balance_when_fixing_consumers_then_counters_are_valid() {
     let authority_id = 1_u64;
     let non_authority_id = 2_u64;
     let total_balance_authority = 1000_u128;
@@ -272,33 +266,64 @@ fn given_bonded_accounts_balance_when_fixing_consumers_then_accounts_do_not_chan
     .execute_with(|| {
         let bonded = 123_u128;
         assert_ok!(pallet_staking::Pallet::<TestRuntime>::bond(
-            RuntimeOrigin::signed(authority_id),
-            bonded,
-            RewardDestination::Stash
-        ));
-
-        assert_eq!(consumers(authority_id), 3);
-        assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
-                RuntimeOrigin::signed(authority_id),
-                authority_id
-            )
-        );
-        assert_eq!(consumers(authority_id), 3);
-
-        assert_ok!(pallet_staking::Pallet::<TestRuntime>::bond(
             RuntimeOrigin::signed(non_authority_id),
             bonded,
             RewardDestination::Stash
         ));
         assert_eq!(consumers(non_authority_id), 2);
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(authority_id),
                 non_authority_id
             )
         );
         assert_eq!(consumers(non_authority_id), 2);
+
+        assert_eq!(pallet_operations_events().len(), 0);
+    });
+}
+
+#[test]
+fn given_contract_accounts_when_fixing_consumers_then_counters_are_valid() {
+    let authority_id = 1_u64;
+    let non_authority_id = 2_u64;
+    let total_balance_authority = UNITS * 100;
+    let total_balance_non_authority = UNITS * 100;
+
+    let (wasm, _code_hash) = compile_module::<TestRuntime>("transfer_return_code").unwrap();
+
+    new_test_ext(&[
+        (authority_id, true, total_balance_authority),
+        (non_authority_id, false, total_balance_non_authority),
+    ])
+    .execute_with(|| {
+        let contract_addr = pallet_contracts::Pallet::<TestRuntime>::bare_instantiate(
+            non_authority_id,
+            100,
+            Weight::from_parts(100_000_000_000, 3 * 1024 * 1024),
+            None,
+            Code::Upload(wasm),
+            vec![],
+            vec![],
+            DebugInfo::Skip,
+            CollectEvents::Skip,
+        )
+        .result
+        .unwrap()
+        .account_id;
+
+        // +1 since it's a contract account
+        // +1 since it has some reserved funds
+        assert_eq!(consumers(contract_addr), 2);
+        assert_ok!(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
+                RuntimeOrigin::signed(authority_id),
+                non_authority_id
+            )
+        );
+        assert_eq!(consumers(contract_addr), 2);
+
+        assert_eq!(pallet_operations_events().len(), 0);
     });
 }
 
@@ -323,14 +348,14 @@ fn given_account_zero_consumers_some_reserved_when_fixing_consumers_then_consume
         frame_system::Pallet::<TestRuntime>::reset_events();
         assert_eq!(pallet_operations_events().len(), 0);
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(authority_id),
                 non_authority_id
             )
         );
         assert_eq!(
             pallet_operations_events(),
-            [crate::Event::ConsumersUnderflowFixed {
+            [crate::Event::ConsumersCounterIncremented {
                 who: non_authority_id
             }]
         );
@@ -339,7 +364,7 @@ fn given_account_zero_consumers_some_reserved_when_fixing_consumers_then_consume
 }
 
 #[test]
-fn given_non_staking_account_with_vesting_lock_when_fixing_consumers_then_consumers_increase() {
+fn given_non_staking_account_with_vesting_lock_when_fixing_consumers_then_counters_are_valid() {
     let authority_id = 1_u64;
     let non_authority_id = 2_u64;
     let total_balance_authority = 1000_u128;
@@ -349,6 +374,7 @@ fn given_non_staking_account_with_vesting_lock_when_fixing_consumers_then_consum
         (non_authority_id, false, total_balance_non_authority),
     ])
     .execute_with(|| {
+        assert_eq!(consumers(non_authority_id), 0);
         let locked = 3_u128;
         pallet_balances::Pallet::<TestRuntime>::set_lock(
             VESTING_ID,
@@ -356,21 +382,19 @@ fn given_non_staking_account_with_vesting_lock_when_fixing_consumers_then_consum
             locked,
             WithdrawReasons::all(),
         );
-        frame_system::Pallet::<TestRuntime>::dec_consumers(&non_authority_id);
-        assert_eq!(consumers(non_authority_id), 0);
+        // +1 due to frozen > 0
+        // locks does not contribute to consumers counter anymore
+        assert_eq!(consumers(non_authority_id), 1);
+
         frame_system::Pallet::<TestRuntime>::reset_events();
         assert_eq!(pallet_operations_events().len(), 0);
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(authority_id),
                 non_authority_id
             )
         );
-        assert_eq!(
-            pallet_operations_events(),
-            [crate::Event::ConsumersUnderflowFixed { who: 2 }]
-        );
-
+        assert_eq!(pallet_operations_events().len(), 0);
         assert_eq!(consumers(non_authority_id), 1);
     });
 }
@@ -392,19 +416,24 @@ fn given_nominator_account_with_staking_lock_when_fixing_consumers_then_consumer
             bonded,
             RewardDestination::Stash
         ));
+        // +1 due to frozen > 0
+        // +1 due to bond()
+        assert_eq!(consumers(non_authority_id), 2);
         frame_system::Pallet::<TestRuntime>::dec_consumers(&non_authority_id);
         assert_eq!(consumers(non_authority_id), 1);
         frame_system::Pallet::<TestRuntime>::reset_events();
         assert_eq!(pallet_operations_events().len(), 0);
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(authority_id),
                 non_authority_id
             )
         );
         assert_eq!(
             pallet_operations_events(),
-            [crate::Event::ConsumersUnderflowFixed { who: 2 }]
+            [crate::Event::ConsumersCounterIncremented {
+                who: non_authority_id
+            }]
         );
 
         assert_eq!(consumers(non_authority_id), 2);
@@ -422,25 +451,23 @@ fn given_validator_with_stash_equal_to_consumer_when_fixing_consumers_then_consu
         (non_authority_id, false, total_balance_non_authority),
     ])
     .execute_with(|| {
-        let bonded = 123_u128;
-        assert_ok!(pallet_staking::Pallet::<TestRuntime>::bond(
-            RuntimeOrigin::signed(authority_id),
-            bonded,
-            RewardDestination::Stash
-        ));
+        // +1 due to frozen > 0
+        // +1 due to bond()
+        // +1 due to session keys
+        assert_eq!(consumers(authority_id), 3);
         frame_system::Pallet::<TestRuntime>::dec_consumers(&authority_id);
         assert_eq!(consumers(authority_id), 2);
         frame_system::Pallet::<TestRuntime>::reset_events();
         assert_eq!(pallet_operations_events().len(), 0);
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(non_authority_id),
                 authority_id
             )
         );
         assert_eq!(
             pallet_operations_events(),
-            [crate::Event::ConsumersUnderflowFixed { who: authority_id }]
+            [crate::Event::ConsumersCounterIncremented { who: authority_id }]
         );
 
         assert_eq!(consumers(authority_id), 3);
@@ -459,12 +486,10 @@ fn given_validator_with_stash_not_equal_to_controller_when_fixing_consumers_then
         (non_authority_id, false, total_balance_non_authority),
     ])
     .execute_with(|| {
-        let bonded = 123_u128;
-        assert_ok!(pallet_staking::Pallet::<TestRuntime>::bond(
-            RuntimeOrigin::signed(authority_id),
-            bonded,
-            RewardDestination::Stash
-        ));
+        // +1 due to frozen > 0
+        // +1 due to bond()
+        // +1 due to session keys
+        assert_eq!(consumers(authority_id), 3);
         // direct manipulation on pallet storage is not possible from end user perspective,
         // but to mimic that scenario we need to directly set Bonded so stash != controller,
         // that is not possible to do via pallet staking API anymore
@@ -480,7 +505,7 @@ fn given_validator_with_stash_not_equal_to_controller_when_fixing_consumers_then
         frame_system::Pallet::<TestRuntime>::reset_events();
         assert_eq!(pallet_operations_events().len(), 0);
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(non_authority_id),
                 authority_id
             )
@@ -489,17 +514,78 @@ fn given_validator_with_stash_not_equal_to_controller_when_fixing_consumers_then
         assert_eq!(consumers(authority_id), 2);
 
         assert_ok!(
-            crate::Pallet::<TestRuntime>::fix_accounts_consumers_underflow(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
                 RuntimeOrigin::signed(authority_id),
                 non_authority_id
             )
         );
         assert_eq!(
             pallet_operations_events(),
-            [crate::Event::ConsumersUnderflowFixed {
+            [crate::Event::ConsumersCounterIncremented {
                 who: non_authority_id
             }]
         );
         assert_eq!(consumers(non_authority_id), 1);
+    });
+}
+
+#[test]
+fn given_account_zero_consumers_when_fixing_consumers_then_nothing_changes() {
+    let authority_id = 1_u64;
+    let non_authority_id = 2_u64;
+    let total_balance_authority = 1000_u128;
+    let total_balance_non_authority = 999_u128;
+    new_test_ext(&[
+        (authority_id, true, total_balance_authority),
+        (non_authority_id, false, total_balance_non_authority),
+    ])
+    .execute_with(|| {
+        assert_eq!(consumers(non_authority_id), 0);
+        frame_system::Pallet::<TestRuntime>::reset_events();
+        assert_eq!(pallet_operations_events().len(), 0);
+        assert_ok!(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
+                RuntimeOrigin::signed(authority_id),
+                non_authority_id
+            )
+        );
+        assert_eq!(pallet_operations_events().len(), 0);
+        assert_eq!(consumers(non_authority_id), 0);
+    });
+}
+
+#[test]
+fn given_nominator_account_with_staking_lock_and_consumer_overflow_when_fixing_consumers_then_consumers_decrease(
+) {
+    let authority_id = 1_u64;
+    let non_authority_id = 2_u64;
+    let total_balance_authority = 1000_u128;
+    let total_balance_non_authority = 999_u128;
+    new_test_ext(&[
+        (authority_id, true, total_balance_authority),
+        (non_authority_id, false, total_balance_non_authority),
+    ])
+    .execute_with(|| {
+        // +1 from bond
+        // +1 from frozen > 0
+        // +1 from session keys
+        // locks does not contribute to consumers counter anymore
+        assert_eq!(consumers(authority_id), 3);
+        frame_system::Pallet::<TestRuntime>::inc_consumers_without_limit(&authority_id).unwrap();
+        assert_eq!(consumers(authority_id), 4);
+        frame_system::Pallet::<TestRuntime>::reset_events();
+        assert_eq!(pallet_operations_events().len(), 0);
+        assert_ok!(
+            crate::Pallet::<TestRuntime>::fix_accounts_consumers_counter(
+                RuntimeOrigin::signed(non_authority_id),
+                authority_id
+            )
+        );
+        assert_eq!(
+            pallet_operations_events(),
+            [crate::Event::ConsumersCounterDecremented { who: authority_id }]
+        );
+
+        assert_eq!(consumers(authority_id), 3);
     });
 }

--- a/pallets/operations/src/traits.rs
+++ b/pallets/operations/src/traits.rs
@@ -1,5 +1,4 @@
-use frame_support::{traits::StoredMap, WeakBoundedVec};
-use pallet_balances::BalanceLock;
+use frame_support::traits::StoredMap;
 use sp_runtime::traits::Zero;
 use sp_staking::StakingAccount;
 
@@ -30,23 +29,17 @@ pub trait BalancesProvider {
     type AccountId;
     /// Balance type used by runtime
     type Balance;
-    /// Max locks constant used by runtime
-    type MaxLocks;
 
     /// Returns reserved funds of an account
     fn is_reserved_zero(who: &Self::AccountId) -> bool;
 
     /// Returns frozen funds of an account
     fn is_frozen_zero(who: &Self::AccountId) -> bool;
-
-    /// Retrieves account's balance locks (e.g. staking or vesting)
-    fn locks(who: &Self::AccountId) -> WeakBoundedVec<BalanceLock<Self::Balance>, Self::MaxLocks>;
 }
 
 impl<T: pallet_balances::Config<I>, I: 'static> BalancesProvider for pallet_balances::Pallet<T, I> {
     type AccountId = T::AccountId;
     type Balance = T::Balance;
-    type MaxLocks = T::MaxLocks;
 
     fn is_reserved_zero(who: &Self::AccountId) -> bool {
         T::AccountStore::get(who).reserved.is_zero()
@@ -54,10 +47,6 @@ impl<T: pallet_balances::Config<I>, I: 'static> BalancesProvider for pallet_bala
 
     fn is_frozen_zero(who: &Self::AccountId) -> bool {
         T::AccountStore::get(who).frozen.is_zero()
-    }
-
-    fn locks(who: &Self::AccountId) -> WeakBoundedVec<BalanceLock<Self::Balance>, Self::MaxLocks> {
-        pallet_balances::Locks::<T, I>::get(who)
     }
 }
 
@@ -93,6 +82,14 @@ pub trait BondedStashProvider {
     fn get_stash(stash: &Self::AccountId) -> Option<Self::AccountId>;
 }
 
+pub trait ContractInfoProvider {
+    /// Account id type used by runtime
+    type AccountId;
+
+    /// Returns true if `who` is a contract account
+    fn is_contract_account(who: &Self::AccountId) -> bool;
+}
+
 impl<T> BondedStashProvider for pallet_staking::Pallet<T>
 where
     T: frame_system::Config + pallet_staking::Config,
@@ -107,5 +104,13 @@ where
         pallet_staking::Pallet::<T>::ledger(StakingAccount::Controller(controller.clone()))
             .ok()
             .map(|ledger| ledger.stash)
+    }
+}
+
+impl<T: pallet_contracts::Config> ContractInfoProvider for pallet_contracts::Pallet<T> {
+    type AccountId = T::AccountId;
+
+    fn is_contract_account(who: &Self::AccountId) -> bool {
+        pallet_contracts::Pallet::<T>::code_hash(who).is_some()
     }
 }


### PR DESCRIPTION
# Description

This PR extends and makes final logic changes for pallet operations. Now, it works in general mode, which calculates the expected `consumers` counter, compares it to the current one, and decreases or increases it when necessary. There are two main additions to pallet logic:
* It is now aware of whether an account is a contract one - in such cases it needs +1 `consumers`
* from `polkadot-sdk 1.4.0`, balance locks do not contribute to the `consumers` counter anymore. Hence, that logic was removed from pallet operations. 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Companion PRs

https://github.com/Cardinal-Cryptography/aleph-node/pull/1760

