### PR TITLE
L1-271: Improve flaky session map test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,6 @@ name = "aleph-node"
 version = "14.0.0+dev"
 dependencies = [
  "aleph-runtime",
- "aleph-runtime-interfaces",
  "fake-runtime-api",
  "finality-aleph",
  "frame-benchmarking",
@@ -380,17 +379,6 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
-]
-
-[[package]]
-name = "aleph-runtime-interfaces"
-version = "0.1.0"
-dependencies = [
- "halo2_proofs",
- "log",
- "parity-scale-codec",
- "rand",
- "sp-runtime-interface",
 ]
 
 [[package]]
@@ -968,7 +956,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array 0.14.7",
 ]
 
@@ -980,12 +967,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bounded-collections"
@@ -2262,7 +2243,6 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "bitvec",
  "rand_core 0.6.4",
  "subtle 2.5.0",
 ]
@@ -3016,43 +2996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "halo2_proofs"
-version = "0.2.0"
-source = "git+https://github.com/Cardinal-Cryptography/pse-halo2?branch=aleph#6747312150634f2fd8f7a563448306132e0fd89e"
-dependencies = [
- "blake2b_simd",
- "ff",
- "group",
- "halo2curves",
- "maybe-rayon",
- "rand",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "sha3 0.9.1",
- "tracing",
-]
-
-[[package]]
-name = "halo2curves"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b1142bd1059aacde1b477e0c80c142910f1ceae67fc619311d6a17428007ab"
-dependencies = [
- "blake2b_simd",
- "ff",
- "group",
- "lazy_static",
- "num-bigint",
- "num-traits",
- "pasta_curves",
- "paste",
- "rand",
- "rand_core 0.6.4",
- "static_assertions",
- "subtle 2.5.0",
-]
-
-[[package]]
 name = "handlebars"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,9 +3733,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin 0.5.2",
-]
 
 [[package]]
 name = "lazycell"
@@ -4511,15 +4451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4694,7 +4625,7 @@ dependencies = [
  "digest 0.10.7",
  "multihash-derive",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "unsigned-varint",
 ]
 
@@ -5713,21 +5644,6 @@ name = "partial_sort"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7924d1d0ad836f665c9065e26d016c673ece3993f30d340068b16f282afc1156"
-
-[[package]]
-name = "pasta_curves"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
-dependencies = [
- "blake2b_simd",
- "ff",
- "group",
- "lazy_static",
- "rand",
- "static_assertions",
- "subtle 2.5.0",
-]
 
 [[package]]
 name = "paste"
@@ -7983,18 +7899,6 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug 0.3.1",
-]
-
-[[package]]
-name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
@@ -8368,7 +8272,7 @@ dependencies = [
  "byteorder",
  "digest 0.10.7",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "twox-hash",
 ]
 
@@ -9979,7 +9883,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "thiserror",
  "zeroize",
 ]

--- a/finality-aleph/src/session_map.rs
+++ b/finality-aleph/src/session_map.rs
@@ -555,7 +555,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn genesis_catch_up() {
-        let (_sender, receiver) = tracing_unbounded("test", 1_000);
+        let (_, receiver) = tracing_unbounded("test", 1_000);
         let mut mock_provider = MockProvider::new();
         let mock_notifier = MockNotifier::new(receiver);
 
@@ -564,10 +564,7 @@ mod tests {
         let updater = SessionMapUpdater::new(mock_provider, mock_notifier, SessionPeriod(1));
         let session_map = updater.readonly_session_map();
 
-        let _handle = tokio::spawn(updater.run());
-
-        // wait a bit
-        Delay::new(Duration::from_millis(50)).await;
+        updater.run().await;
 
         assert_eq!(
             session_map.get(SessionId(0)).await,
@@ -596,10 +593,8 @@ mod tests {
             sender.unbounded_send(n).unwrap();
         }
 
-        let _handle = tokio::spawn(updater.run());
-
-        // wait a bit
-        Delay::new(Duration::from_millis(50)).await;
+        drop(sender);
+        updater.run().await;
 
         assert_eq!(
             session_map.get(SessionId(0)).await,
@@ -621,7 +616,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn catch_up() {
-        let (_sender, receiver) = tracing_unbounded("test", 1_000);
+        let (_, receiver) = tracing_unbounded("test", 1_000);
         let mut mock_provider = MockProvider::new();
         let mut mock_notificator = MockNotifier::new(receiver);
 
@@ -634,10 +629,7 @@ mod tests {
         let updater = SessionMapUpdater::new(mock_provider, mock_notificator, SessionPeriod(1));
         let session_map = updater.readonly_session_map();
 
-        let _handle = tokio::spawn(updater.run());
-
-        // wait a bit
-        Delay::new(Duration::from_millis(50)).await;
+        updater.run().await;
 
         assert_eq!(
             session_map.get(SessionId(0)).await,
@@ -659,7 +651,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn catch_up_old_sessions() {
-        let (_sender, receiver) = tracing_unbounded("test", 1_000);
+        let (_, receiver) = tracing_unbounded("test", 1_000);
         let mut mock_provider = MockProvider::new();
         let mut mock_notificator = MockNotifier::new(receiver);
 
@@ -672,10 +664,7 @@ mod tests {
         let updater = SessionMapUpdater::new(mock_provider, mock_notificator, SessionPeriod(1));
         let session_map = updater.readonly_session_map();
 
-        let _handle = tokio::spawn(updater.run());
-
-        // wait a bit
-        Delay::new(Duration::from_millis(50)).await;
+        updater.run().await;
 
         for i in 0..FIRST_THRESHOLD {
             assert_eq!(
@@ -695,7 +684,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn deals_with_database_pruned_authorities() {
-        let (_sender, receiver) = tracing_unbounded("test", 1_000);
+        let (_, receiver) = tracing_unbounded("test", 1_000);
         let mut mock_provider = MockProvider::new();
         let mut mock_notificator = MockNotifier::new(receiver);
 
@@ -705,10 +694,7 @@ mod tests {
         let updater = SessionMapUpdater::new(mock_provider, mock_notificator, SessionPeriod(1));
         let session_map = updater.readonly_session_map();
 
-        let _handle = tokio::spawn(updater.run());
-
-        // wait a bit
-        Delay::new(Duration::from_millis(50)).await;
+        updater.run().await;
 
         for i in 0..5 {
             assert_eq!(
@@ -741,14 +727,14 @@ mod tests {
         let updater = SessionMapUpdater::new(mock_provider, mock_notificator, SessionPeriod(1));
         let session_map = updater.readonly_session_map();
 
-        let _handle = tokio::spawn(updater.run());
+        let handle = tokio::spawn(updater.run());
 
         for n in 1..FIRST_THRESHOLD {
             sender.unbounded_send(n).unwrap();
         }
 
         // wait a bit
-        Delay::new(Duration::from_millis(50)).await;
+        Delay::new(Duration::from_millis(100)).await;
 
         for i in 0..=FIRST_THRESHOLD {
             assert_eq!(
@@ -770,7 +756,8 @@ mod tests {
             sender.unbounded_send(n).unwrap();
         }
 
-        Delay::new(Duration::from_millis(50)).await;
+        drop(sender);
+        handle.await.unwrap();
 
         for i in 0..(FIRST_THRESHOLD - 1) {
             assert_eq!(
@@ -784,7 +771,7 @@ mod tests {
             assert_eq!(
                 session_map.get(SessionId(i)).await,
                 Some(authority_data_for_session(i)),
-                "Session {i:?} should be avalable"
+                "Session {i:?} should be available"
             );
         }
     }

--- a/finality-aleph/src/session_map.rs
+++ b/finality-aleph/src/session_map.rs
@@ -748,7 +748,7 @@ mod tests {
             assert_eq!(
                 session_map.get(SessionId(i)).await,
                 None,
-                "Session {i:?} should not be avalable yet"
+                "Session {i:?} should not be available yet"
             );
         }
 


### PR DESCRIPTION
# Description

Recently failed there: https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/9736643972/job/26867555923.
Reason:
```
    ---- session_map::tests::prunes_old_sessions stdout ----
    thread 'session_map::tests::prunes_old_sessions' panicked at finality-aleph/src/session_map.rs:776:13:
    assertion `left == right` failed: Session 0 should be pruned
```
Replaced some delays with `handle.await.unwrap()` and `sender` drop, as such a drop will cause `SessionMapUpdater` to finish.


## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue) [non-prod code]

# Checklist:
