### PR TITLE
A0-4265: Inc testnet sync from snapshot timeout by 30m

### DIFF
--- a/.github/workflows/sync-from-snapshot-testnet.yml
+++ b/.github/workflows/sync-from-snapshot-testnet.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, medium-1000GB]
-    timeout-minutes: 360
+    timeout-minutes: 390
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Increase the test timeout by 30 minutes bc it started failing recently (eg. [here](https://github.com/Cardinal-Cryptography/aleph-node/commit/0757e1b6d8ea5f884fd8448755dbc2904385c4ea/checks) and [there](https://github.com/Cardinal-Cryptography/aleph-node/commit/246fd3f475b09a72f574f6c0934367209bd6dec6/checks)).

# Checklist:

- I have made neccessary updates to the Infrastructure
