### PR TITLE
A0-4265: Inc testnet sync from snapshot remaining timeouts

### DIFF
--- a/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, medium-1000GB]
-    timeout-minutes: 60
+    timeout-minutes: 65
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/sync-from-snapshot-testnet-paritydb.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, medium-1000GB]
-    timeout-minutes: 240
+    timeout-minutes: 260
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Test `Sync from snapshot, Testnet, RocksDB` got an increase of timeout recently from `360` to `390` minutes.
Increase timeouts of the remaining two sync from snapshot test by the same percentage (`390/360=8.(3)%`).
`Sync from snapshot, Testnet, ParityDB non-pruned`: `240 -> 260`
`Sync from snapshot, Testnet, ParityDB pruned`: `60 -> 65`

## Checklist:

* I have made neccessary updates to the Infrastructure
