### PR TITLE
L1-273: chain-bootstrapper cmd line fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "chain-bootstrapper"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aleph-runtime",
  "hex",

--- a/bin/chain-bootstrapper/Cargo.toml
+++ b/bin/chain-bootstrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-bootstrapper"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/bin/chain-bootstrapper/src/chain_spec/builder.rs
+++ b/bin/chain-bootstrapper/src/chain_spec/builder.rs
@@ -66,7 +66,7 @@ fn calculate_initial_endowment(accounts: &[AccountId]) -> u128 {
     // (A0-4258) due to known issue https://github.com/paritytech/polkadot-sdk/pull/2987/files,
     // we need to make sure returned number is in u64 range, otherwise serde_json::json macro fails
     // this is fixed in polkadot-sdk 1.6.0
-    total_issuance / (accounts.len() as u128) / 10
+    total_issuance / (accounts.len() as u128) / 100
 }
 
 /// Configure initial storage state for FRAME modules.

--- a/bin/chain-bootstrapper/src/chain_spec/cli.rs
+++ b/bin/chain-bootstrapper/src/chain_spec/cli.rs
@@ -25,13 +25,13 @@ pub struct ChainSpecParams {
     token_symbol: String,
 
     /// all account ids that needs to have session keys generated when bootstraping chain (comma delimited)
-    #[arg(long, value_delimiter = ',', value_parser = parse_account_id, num_args = 1..)]
+    #[arg(long, value_delimiter = ',', value_parser = parse_account_id)]
     account_ids: Vec<AccountId>,
 
     /// AccountIds of authorities forming the committee at the genesis (comma delimited)
     /// If empty, then `--account-ids` are used as authorities.
-    /// If not empty, it should ba a subset of `--account-ids`.
-    #[arg(long, value_delimiter = ',', value_parser = parse_account_id, num_args = 1..)]
+    /// If not empty, it should be a subset of `--account-ids`.
+    #[arg(long, value_delimiter = ',', value_parser = parse_account_id)]
     authorities_account_ids: Vec<AccountId>,
 
     /// AccountId of the sudo account
@@ -39,7 +39,7 @@ pub struct ChainSpecParams {
     sudo_account_id: AccountId,
 
     /// Accounts that will receive initial endowment in genesis block
-    #[arg(long, value_delimiter = ',', value_parser = parse_account_id, num_args = 1..)]
+    #[arg(long, value_delimiter = ',', value_parser = parse_account_id)]
     rich_account_ids: Option<Vec<AccountId>>,
 
     /// Finality version at chain inception.

--- a/bin/chain-bootstrapper/src/chain_spec/commands.rs
+++ b/bin/chain-bootstrapper/src/chain_spec/commands.rs
@@ -54,7 +54,13 @@ impl BootstrapChainCmd {
         let account_ids = self.chain_spec_params.account_ids();
         let mut authorities = self.chain_spec_params.authorities_account_ids();
         if authorities.is_empty() {
+            if account_ids.is_empty() {
+                return Err(("Both --account-ids and --authorities-account-ids are empty. \
+                              Please specify at least one account.").into())
+            }
             authorities = account_ids.clone();
+        } else if !authorities.iter().all(|authority| account_ids.contains(authority)) {
+            return Err("--authorities-account-ids must be a subset of --accounts-ids.".into())
         }
 
         let account_session_keys = self

--- a/bin/chain-bootstrapper/src/chain_spec/commands.rs
+++ b/bin/chain-bootstrapper/src/chain_spec/commands.rs
@@ -55,12 +55,18 @@ impl BootstrapChainCmd {
         let mut authorities = self.chain_spec_params.authorities_account_ids();
         if authorities.is_empty() {
             if account_ids.is_empty() {
-                return Err(("Both --account-ids and --authorities-account-ids are empty. \
-                              Please specify at least one account.").into())
+                return Err(
+                    ("Both --account-ids and --authorities-account-ids are empty. \
+                              Please specify at least one account.")
+                        .into(),
+                );
             }
             authorities = account_ids.clone();
-        } else if !authorities.iter().all(|authority| account_ids.contains(authority)) {
-            return Err("--authorities-account-ids must be a subset of --accounts-ids.".into())
+        } else if !authorities
+            .iter()
+            .all(|authority| account_ids.contains(authority))
+        {
+            return Err("--authorities-account-ids must be a subset of --accounts-ids.".into());
         }
 
         let account_session_keys = self


### PR DESCRIPTION
# Description

This PR fixes following issues:
* it makes sure `--authorities-accounts-ids` is a subset of `--account-ids`
* `--accounts-ids` should have at least one account
* initial endowment is not in `u64` range when `--accounts-ids` == `--authorities-accounts-ids` == `--sudo account`. This should have been fixed in `polkadot 1.6.0`, but investigation why not is not in the scope of this task. 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


