### PR TITLE
L1-279: Increase timout for Testnet RocksDB snapshotter test

### DIFF
--- a/.github/workflows/sync-from-snapshot-testnet.yml
+++ b/.github/workflows/sync-from-snapshot-testnet.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, medium-1000GB]
-    timeout-minutes: 390
+    timeout-minutes: 450
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Lat run was a genuine timeout.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

