### PR TITLE
A0-4265: Increase all sync from snapshot tests timeouts

### DIFF
--- a/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
@@ -35,7 +35,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, medium-1000GB]
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/sync-from-snapshot-mainnet-paritydb.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-paritydb.yml
@@ -35,7 +35,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, medium-1000GB]
-    timeout-minutes: 240
+    timeout-minutes: 360
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/sync-from-snapshot-mainnet.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet.yml
@@ -35,7 +35,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, medium-1000GB]
-    timeout-minutes: 500
+    timeout-minutes: 600
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, medium-1000GB]
-    timeout-minutes: 65
+    timeout-minutes: 90
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/sync-from-snapshot-testnet-paritydb.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, medium-1000GB]
-    timeout-minutes: 260
+    timeout-minutes: 360
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/sync-from-snapshot-testnet.yml
+++ b/.github/workflows/sync-from-snapshot-testnet.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, medium-1000GB]
-    timeout-minutes: 450
+    timeout-minutes: 600
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4


### PR DESCRIPTION
Increase the timeouts again, this time to significantly larger values to prevent not meaningful test failures.