### PR TITLE
Move abft crypto and types to primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6039,6 +6039,10 @@ dependencies = [
 name = "primitives"
 version = "0.14.0+dev"
 dependencies = [
+ "aleph-bft 0.33.2",
+ "aleph-bft 0.36.5",
+ "aleph-bft-crypto 0.9.0",
+ "derive_more 1.0.0",
  "frame-support",
  "frame-system-rpc-runtime-api",
  "pallet-transaction-payment",

--- a/finality-aleph/src/abft/mod.rs
+++ b/finality-aleph/src/abft/mod.rs
@@ -14,9 +14,6 @@ mod network;
 mod traits;
 mod types;
 
-use std::fmt::Debug;
-
-use aleph_bft_crypto::{PartialMultisignature, Signature};
 pub use crypto::Keychain;
 pub use current::{
     create_aleph_config as current_create_aleph_config, run_member as run_current_member,
@@ -27,71 +24,7 @@ pub use legacy::{
     NetworkData as LegacyNetworkData, VERSION as LEGACY_VERSION,
 };
 pub use network::NetworkWrapper;
-use parity_scale_codec::{Decode, Encode};
 pub use traits::{SpawnHandle, Wrapper as HashWrapper};
 pub use types::{NodeCount, NodeIndex, Recipient};
 
-/// Wrapper for `SignatureSet` to be able to implement both legacy and current `PartialMultisignature` trait.
-/// Inner `SignatureSet` is imported from `aleph_bft_crypto` with fixed version for compatibility reasons:
-/// this is also used in the justification which already exist in our chain history and we
-/// need to be careful with changing this.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Encode, Decode)]
-pub struct SignatureSet<Signature>(pub aleph_bft_crypto::SignatureSet<Signature>);
-
-impl<S: Clone> SignatureSet<S> {
-    pub fn size(&self) -> NodeCount {
-        self.0.size().into()
-    }
-
-    pub fn with_size(len: NodeCount) -> Self {
-        SignatureSet(aleph_bft_crypto::SignatureSet::with_size(len.into()))
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (NodeIndex, &S)> {
-        self.0.iter().map(|(idx, s)| (idx.into(), s))
-    }
-
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (NodeIndex, &mut S)> {
-        self.0.iter_mut().map(|(idx, s)| (idx.into(), s))
-    }
-
-    pub fn add_signature(self, signature: &S, index: NodeIndex) -> Self
-    where
-        S: Signature,
-    {
-        SignatureSet(self.0.add_signature(signature, index.into()))
-    }
-}
-
-impl<S: 'static> IntoIterator for SignatureSet<S> {
-    type Item = (NodeIndex, S);
-    type IntoIter = Box<dyn Iterator<Item = (NodeIndex, S)>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        Box::new(self.0.into_iter().map(|(idx, s)| (idx.into(), s)))
-    }
-}
-
-impl<S: Signature> legacy_aleph_bft::PartialMultisignature for SignatureSet<S> {
-    type Signature = S;
-
-    fn add_signature(
-        self,
-        signature: &Self::Signature,
-        index: legacy_aleph_bft::NodeIndex,
-    ) -> Self {
-        SignatureSet::add_signature(self, signature, index.into())
-    }
-}
-
-impl<S: Signature> current_aleph_bft::PartialMultisignature for SignatureSet<S> {
-    type Signature = S;
-
-    fn add_signature(
-        self,
-        signature: &Self::Signature,
-        index: current_aleph_bft::NodeIndex,
-    ) -> Self {
-        SignatureSet::add_signature(self, signature, index.into())
-    }
-}
+pub use primitives::SignatureSet;

--- a/finality-aleph/src/abft/types.rs
+++ b/finality-aleph/src/abft/types.rs
@@ -1,28 +1,6 @@
 //! Types common for current & legacy abft used across finality-aleph
 
-use derive_more::{From, Into};
-use parity_scale_codec::{Decode, Encode, Error, Input, Output};
-
-/// The index of a node
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, From, Into)]
-pub struct NodeIndex(pub usize);
-
-impl Encode for NodeIndex {
-    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
-        (self.0 as u64).encode_to(dest);
-    }
-}
-
-impl Decode for NodeIndex {
-    fn decode<I: Input>(value: &mut I) -> Result<Self, Error> {
-        Ok(NodeIndex(u64::decode(value)? as usize))
-    }
-}
-
-/// Node count. Right now it doubles as node weight in many places in the code, in the future we
-/// might need a new type for that.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, From, Into)]
-pub struct NodeCount(pub usize);
+pub use primitives::{NodeCount, NodeIndex};
 
 /// A recipient of a message, either a specific node or everyone.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -45,71 +23,6 @@ impl From<current_aleph_bft::Recipient> for Recipient {
         match recipient {
             current_aleph_bft::Recipient::Everyone => Recipient::Everyone,
             current_aleph_bft::Recipient::Node(id) => Recipient::Node(id.into()),
-        }
-    }
-}
-
-impl From<NodeCount> for current_aleph_bft::NodeCount {
-    fn from(count: NodeCount) -> Self {
-        current_aleph_bft::NodeCount(count.0)
-    }
-}
-impl From<NodeCount> for legacy_aleph_bft::NodeCount {
-    fn from(count: NodeCount) -> Self {
-        legacy_aleph_bft::NodeCount(count.0)
-    }
-}
-
-impl From<legacy_aleph_bft::NodeCount> for NodeCount {
-    fn from(count: legacy_aleph_bft::NodeCount) -> Self {
-        Self(count.0)
-    }
-}
-
-impl From<current_aleph_bft::NodeCount> for NodeCount {
-    fn from(count: current_aleph_bft::NodeCount) -> Self {
-        Self(count.0)
-    }
-}
-
-impl From<NodeIndex> for current_aleph_bft::NodeIndex {
-    fn from(idx: NodeIndex) -> Self {
-        current_aleph_bft::NodeIndex(idx.0)
-    }
-}
-
-impl From<NodeIndex> for legacy_aleph_bft::NodeIndex {
-    fn from(idx: NodeIndex) -> Self {
-        legacy_aleph_bft::NodeIndex(idx.0)
-    }
-}
-
-impl From<legacy_aleph_bft::NodeIndex> for NodeIndex {
-    fn from(idx: legacy_aleph_bft::NodeIndex) -> Self {
-        Self(idx.0)
-    }
-}
-
-impl From<current_aleph_bft::NodeIndex> for NodeIndex {
-    fn from(idx: current_aleph_bft::NodeIndex) -> Self {
-        Self(idx.0)
-    }
-}
-
-impl From<Recipient> for current_aleph_bft::Recipient {
-    fn from(recipient: Recipient) -> Self {
-        match recipient {
-            Recipient::Everyone => current_aleph_bft::Recipient::Everyone,
-            Recipient::Node(idx) => current_aleph_bft::Recipient::Node(idx.into()),
-        }
-    }
-}
-
-impl From<Recipient> for legacy_aleph_bft::Recipient {
-    fn from(recipient: Recipient) -> Self {
-        match recipient {
-            Recipient::Everyone => legacy_aleph_bft::Recipient::Everyone,
-            Recipient::Node(idx) => legacy_aleph_bft::Recipient::Node(idx.into()),
         }
     }
 }

--- a/finality-aleph/src/crypto.rs
+++ b/finality-aleph/src/crypto.rs
@@ -7,12 +7,11 @@ use parity_scale_codec::{Decode, Encode};
 use sc_keystore::{Keystore, LocalKeystore};
 use sp_core::crypto::KeyTypeId;
 use sp_keystore::Error as KeystoreError;
-use sp_runtime::RuntimeAppPublic;
 
-use crate::{
-    abft::{NodeCount, NodeIndex, SignatureSet},
-    aleph_primitives::{AuthorityId, AuthoritySignature, KEY_TYPE},
-};
+use crate::aleph_primitives::{AuthorityId, AuthoritySignature, KEY_TYPE};
+
+pub use crate::aleph_primitives::crypto::{AuthorityVerifier, Signature};
+pub use crate::aleph_primitives::NodeIndex;
 
 #[derive(Debug)]
 pub enum Error {
@@ -31,15 +30,6 @@ impl Display for Error {
                 write!(f, "keystore error: {err}")
             }
         }
-    }
-}
-
-#[derive(PartialEq, Eq, Clone, Debug, Hash, Decode, Encode)]
-pub struct Signature(AuthoritySignature);
-
-impl From<AuthoritySignature> for Signature {
-    fn from(authority_signature: AuthoritySignature) -> Signature {
-        Signature(authority_signature)
     }
 }
 
@@ -99,53 +89,6 @@ impl AuthorityPen {
         self.authority_id.clone()
     }
 }
-
-/// Verify the signature given an authority id.
-pub fn verify(authority: &AuthorityId, message: &[u8], signature: &Signature) -> bool {
-    authority.verify(&message, &signature.0)
-}
-
-/// Holds the public authority keys for a session allowing for verification of messages from that
-/// session.
-#[derive(PartialEq, Clone, Debug)]
-pub struct AuthorityVerifier {
-    authorities: Vec<AuthorityId>,
-}
-
-impl AuthorityVerifier {
-    /// Constructs a new authority verifier from a set of public keys.
-    pub fn new(authorities: Vec<AuthorityId>) -> Self {
-        AuthorityVerifier { authorities }
-    }
-
-    /// Verifies whether the message is correctly signed with the signature assumed to be made by a
-    /// node of the given index.
-    pub fn verify(&self, msg: &[u8], sgn: &Signature, index: NodeIndex) -> bool {
-        match self.authorities.get(index.0) {
-            Some(authority) => verify(authority, msg, sgn),
-            None => false,
-        }
-    }
-
-    pub fn node_count(&self) -> NodeCount {
-        self.authorities.len().into()
-    }
-
-    fn threshold(&self) -> usize {
-        2 * self.node_count().0 / 3 + 1
-    }
-
-    /// Verifies whether the given signature set is a correct and complete multisignature of the
-    /// message. Completeness requires more than 2/3 of all authorities.
-    pub fn is_complete(&self, msg: &[u8], partial: &SignatureSet<Signature>) -> bool {
-        let signature_count = partial.iter().count();
-        if signature_count < self.threshold() {
-            return false;
-        }
-        partial.iter().all(|(i, sgn)| self.verify(msg, sgn, i))
-    }
-}
-
 /// Old format of signatures, needed for backwards compatibility.
 #[derive(PartialEq, Eq, Clone, Debug, Decode, Encode)]
 pub struct SignatureV1 {

--- a/finality-aleph/src/network/tcp.rs
+++ b/finality-aleph/src/network/tcp.rs
@@ -13,8 +13,9 @@ use sp_core::crypto::KeyTypeId;
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
 
 use crate::{
+    aleph_primitives::crypto::verify,
     aleph_primitives::AuthorityId,
-    crypto::{verify, AuthorityPen, Signature},
+    crypto::{AuthorityPen, Signature},
     network::{AddressingInformation, NetworkIdentity},
 };
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -12,6 +12,11 @@ parity-scale-codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 
+aleph-bft-crypto = { workspace = true }
+current-aleph-bft = { package = "aleph-bft", version = "0.36" }
+legacy-aleph-bft = { package = "aleph-bft", version = "0.33" }
+derive_more = { workspace = true }
+
 sp-api = { workspace = true }
 sp-application-crypto = { workspace = true }
 sp-core = { workspace = true }

--- a/primitives/src/abft.rs
+++ b/primitives/src/abft.rs
@@ -1,0 +1,139 @@
+use derive_more::{From, Into};
+use parity_scale_codec::{Decode, Encode, Error, Input, Output};
+
+use std::fmt::Debug;
+
+use aleph_bft_crypto::{PartialMultisignature, Signature};
+
+/// The index of a node
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, From, Into)]
+pub struct NodeIndex(pub usize);
+
+impl Encode for NodeIndex {
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        (self.0 as u64).encode_to(dest);
+    }
+}
+
+impl Decode for NodeIndex {
+    fn decode<I: Input>(value: &mut I) -> Result<Self, Error> {
+        Ok(NodeIndex(u64::decode(value)? as usize))
+    }
+}
+
+/// Node count. Right now it doubles as node weight in many places in the code, in the future we
+/// might need a new type for that.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, From, Into)]
+pub struct NodeCount(pub usize);
+
+impl From<NodeCount> for current_aleph_bft::NodeCount {
+    fn from(count: NodeCount) -> Self {
+        current_aleph_bft::NodeCount(count.0)
+    }
+}
+impl From<NodeCount> for legacy_aleph_bft::NodeCount {
+    fn from(count: NodeCount) -> Self {
+        legacy_aleph_bft::NodeCount(count.0)
+    }
+}
+
+impl From<legacy_aleph_bft::NodeCount> for NodeCount {
+    fn from(count: legacy_aleph_bft::NodeCount) -> Self {
+        Self(count.0)
+    }
+}
+
+impl From<current_aleph_bft::NodeCount> for NodeCount {
+    fn from(count: current_aleph_bft::NodeCount) -> Self {
+        Self(count.0)
+    }
+}
+
+impl From<NodeIndex> for current_aleph_bft::NodeIndex {
+    fn from(idx: NodeIndex) -> Self {
+        current_aleph_bft::NodeIndex(idx.0)
+    }
+}
+
+impl From<NodeIndex> for legacy_aleph_bft::NodeIndex {
+    fn from(idx: NodeIndex) -> Self {
+        legacy_aleph_bft::NodeIndex(idx.0)
+    }
+}
+
+impl From<legacy_aleph_bft::NodeIndex> for NodeIndex {
+    fn from(idx: legacy_aleph_bft::NodeIndex) -> Self {
+        Self(idx.0)
+    }
+}
+
+impl From<current_aleph_bft::NodeIndex> for NodeIndex {
+    fn from(idx: current_aleph_bft::NodeIndex) -> Self {
+        Self(idx.0)
+    }
+}
+
+/// Wrapper for `SignatureSet` to be able to implement both legacy and current `PartialMultisignature` trait.
+/// Inner `SignatureSet` is imported from `aleph_bft_crypto` with fixed version for compatibility reasons:
+/// this is also used in the justification which already exist in our chain history and we
+/// need to be careful with changing this.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Encode, Decode)]
+pub struct SignatureSet<Signature>(pub aleph_bft_crypto::SignatureSet<Signature>);
+
+impl<S: Clone> SignatureSet<S> {
+    pub fn size(&self) -> NodeCount {
+        self.0.size().into()
+    }
+
+    pub fn with_size(len: NodeCount) -> Self {
+        SignatureSet(aleph_bft_crypto::SignatureSet::with_size(len.into()))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (NodeIndex, &S)> {
+        self.0.iter().map(|(idx, s)| (idx.into(), s))
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (NodeIndex, &mut S)> {
+        self.0.iter_mut().map(|(idx, s)| (idx.into(), s))
+    }
+
+    pub fn add_signature(self, signature: &S, index: NodeIndex) -> Self
+    where
+        S: Signature,
+    {
+        SignatureSet(self.0.add_signature(signature, index.into()))
+    }
+}
+
+impl<S: 'static> IntoIterator for SignatureSet<S> {
+    type Item = (NodeIndex, S);
+    type IntoIter = Box<dyn Iterator<Item = (NodeIndex, S)>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Box::new(self.0.into_iter().map(|(idx, s)| (idx.into(), s)))
+    }
+}
+
+impl<S: Signature> legacy_aleph_bft::PartialMultisignature for SignatureSet<S> {
+    type Signature = S;
+
+    fn add_signature(
+        self,
+        signature: &Self::Signature,
+        index: legacy_aleph_bft::NodeIndex,
+    ) -> Self {
+        SignatureSet::add_signature(self, signature, index.into())
+    }
+}
+
+impl<S: Signature> current_aleph_bft::PartialMultisignature for SignatureSet<S> {
+    type Signature = S;
+
+    fn add_signature(
+        self,
+        signature: &Self::Signature,
+        index: current_aleph_bft::NodeIndex,
+    ) -> Self {
+        SignatureSet::add_signature(self, signature, index.into())
+    }
+}

--- a/primitives/src/abft_old/common.rs
+++ b/primitives/src/abft_old/common.rs
@@ -1,0 +1,50 @@
+use std::{sync::Arc, time::Duration};
+
+use crate::UnitCreationDelay;
+
+// Chosen as a round number large enough so that given the default 200 ms unit creation delay, and the exponential
+// slowdown consts below, the time to reach the max round noticeably surpasses the required 7 days. With this
+// setting max round should be reached in ~12.5 days.
+pub const MAX_ROUNDS: u16 = 10_000;
+
+// Given the default 200 ms unit creation delay, the expected no-slowdown time will be 7500*200/1000/60 = 25 minutes
+// which is noticeably longer than the expected 15 minutes of session time.
+const EXP_SLOWDOWN_START_ROUND: usize = 7500;
+const EXP_SLOWDOWN_MUL: f64 = 1.004;
+
+fn exponential_slowdown(
+    t: usize,
+    base_delay: f64,
+    start_exp_delay: usize,
+    exp_base: f64,
+) -> Duration {
+    // This gives:
+    // base_delay, for t <= start_exp_delay,
+    // base_delay * exp_base^(t - start_exp_delay), for t > start_exp_delay.
+    let delay = if t < start_exp_delay {
+        base_delay
+    } else {
+        let power = t - start_exp_delay;
+        base_delay * exp_base.powf(power as f64)
+    };
+    let delay = delay.round() as u64;
+    // the above will make it u64::MAX if it exceeds u64
+    Duration::from_millis(delay)
+}
+
+pub type DelaySchedule = Arc<dyn Fn(usize) -> Duration + Sync + Send + 'static>;
+
+pub fn unit_creation_delay_fn(unit_creation_delay: UnitCreationDelay) -> DelaySchedule {
+    Arc::new(move |t| match t {
+        0 => Duration::from_millis(2000),
+        _ => exponential_slowdown(
+            t,
+            unit_creation_delay.0 as f64,
+            EXP_SLOWDOWN_START_ROUND,
+            EXP_SLOWDOWN_MUL,
+        ),
+    })
+}
+
+// 7 days (as milliseconds)
+pub const SESSION_LEN_LOWER_BOUND_MS: u128 = 1000 * 60 * 60 * 24 * 7;

--- a/primitives/src/abft_old/crypto.rs
+++ b/primitives/src/abft_old/crypto.rs
@@ -1,0 +1,150 @@
+use crate::{
+    crypto::{AuthorityPen, AuthorityVerifier, Signature},
+    SignatureSet,
+};
+
+use std::fmt::Debug;
+
+use aleph_bft_crypto::{PartialMultisignature, Signature};
+pub use current::VERSION as CURRENT_VERSION ;
+pub use legacy::VERSION as LEGACY_VERSION ;
+use parity_scale_codec::{Decode, Encode};
+pub use types::{NodeCount, NodeIndex};
+
+
+/// Keychain combines an AuthorityPen and AuthorityVerifier into one object implementing the AlephBFT
+/// MultiKeychain trait.
+#[derive(Clone)]
+pub struct Keychain {
+    id: NodeIndex,
+    authority_pen: AuthorityPen,
+    authority_verifier: AuthorityVerifier,
+}
+
+impl Keychain {
+    /// Constructs a new keychain from a signing contraption and verifier, with the specified node
+    /// index.
+    pub fn new(
+        id: NodeIndex,
+        authority_verifier: AuthorityVerifier,
+        authority_pen: AuthorityPen,
+    ) -> Self {
+        Keychain {
+            id,
+            authority_pen,
+            authority_verifier,
+        }
+    }
+
+    fn index(&self) -> NodeIndex {
+        self.id
+    }
+
+    fn node_count(&self) -> NodeCount {
+        self.authority_verifier.node_count()
+    }
+
+    fn sign(&self, msg: &[u8]) -> Signature {
+        self.authority_pen.sign(msg)
+    }
+
+    fn verify<I: Into<NodeIndex>>(&self, msg: &[u8], sgn: &Signature, index: I) -> bool {
+        self.authority_verifier.verify(msg, sgn, index.into())
+    }
+
+    fn is_complete(&self, msg: &[u8], partial: &SignatureSet<Signature>) -> bool {
+        self.authority_verifier.is_complete(msg, partial)
+    }
+}
+
+impl current_aleph_bft::Index for Keychain {
+    fn index(&self) -> current_aleph_bft::NodeIndex {
+        Keychain::index(self).into()
+    }
+}
+
+impl legacy_aleph_bft::Index for Keychain {
+    fn index(&self) -> legacy_aleph_bft::NodeIndex {
+        Keychain::index(self).into()
+    }
+}
+
+impl current_aleph_bft::Keychain for Keychain {
+    type Signature = Signature;
+
+    fn node_count(&self) -> current_aleph_bft::NodeCount {
+        Keychain::node_count(self).into()
+    }
+
+    fn sign(&self, msg: &[u8]) -> Signature {
+        Keychain::sign(self, msg)
+    }
+
+    fn verify(&self, msg: &[u8], sgn: &Signature, index: current_aleph_bft::NodeIndex) -> bool {
+        Keychain::verify(self, msg, sgn, index)
+    }
+}
+
+impl legacy_aleph_bft::Keychain for Keychain {
+    type Signature = Signature;
+
+    fn node_count(&self) -> legacy_aleph_bft::NodeCount {
+        Keychain::node_count(self).into()
+    }
+
+    fn sign(&self, msg: &[u8]) -> Signature {
+        Keychain::sign(self, msg)
+    }
+
+    fn verify(&self, msg: &[u8], sgn: &Signature, index: legacy_aleph_bft::NodeIndex) -> bool {
+        Keychain::verify(self, msg, sgn, index)
+    }
+}
+
+impl current_aleph_bft::MultiKeychain for Keychain {
+    // Using `SignatureSet` is slow, but Substrate has not yet implemented aggregation.
+    // We probably should do this for them at some point.
+    type PartialMultisignature = SignatureSet<Signature>;
+
+    fn bootstrap_multi(
+        &self,
+        signature: &Signature,
+        index: current_aleph_bft::NodeIndex,
+    ) -> Self::PartialMultisignature {
+        current_aleph_bft::PartialMultisignature::add_signature(
+            SignatureSet(aleph_bft_crypto::SignatureSet::with_size(
+                aleph_bft_crypto::Keychain::node_count(self),
+            )),
+            signature,
+            index,
+        )
+    }
+
+    fn is_complete(&self, msg: &[u8], partial: &Self::PartialMultisignature) -> bool {
+        Keychain::is_complete(self, msg, partial)
+    }
+}
+
+impl legacy_aleph_bft::MultiKeychain for Keychain {
+    // Using `SignatureSet` is slow, but Substrate has not yet implemented aggregation.
+    // We probably should do this for them at some point.
+    type PartialMultisignature = SignatureSet<Signature>;
+
+    fn bootstrap_multi(
+        &self,
+        signature: &Signature,
+        index: legacy_aleph_bft::NodeIndex,
+    ) -> Self::PartialMultisignature {
+        legacy_aleph_bft::PartialMultisignature::add_signature(
+            SignatureSet(aleph_bft_crypto::SignatureSet::with_size(
+                aleph_bft_crypto::Keychain::node_count(self),
+            )),
+            signature,
+            index,
+        )
+    }
+
+    fn is_complete(&self, msg: &[u8], partial: &Self::PartialMultisignature) -> bool {
+        Keychain::is_complete(self, msg, partial)
+    }
+}

--- a/primitives/src/abft_old/mod.rs
+++ b/primitives/src/abft_old/mod.rs
@@ -1,0 +1,139 @@
+use derive_more::{From, Into};
+use parity_scale_codec::{Decode, Encode, Error, Input, Output};
+
+use std::fmt::Debug;
+
+use aleph_bft_crypto::{PartialMultisignature, Signature};
+
+/// The index of a node
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, From, Into)]
+pub struct NodeIndex(pub usize);
+
+impl Encode for NodeIndex {
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        (self.0 as u64).encode_to(dest);
+    }
+}
+
+impl Decode for NodeIndex {
+    fn decode<I: Input>(value: &mut I) -> Result<Self, Error> {
+        Ok(NodeIndex(u64::decode(value)? as usize))
+    }
+}
+
+/// Node count. Right now it doubles as node weight in many places in the code, in the future we
+/// might need a new type for that.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, From, Into)]
+pub struct NodeCount(pub usize);
+
+impl From<NodeCount> for current_aleph_bft::NodeCount {
+    fn from(count: NodeCount) -> Self {
+        current_aleph_bft::NodeCount(count.0)
+    }
+}
+impl From<NodeCount> for legacy_aleph_bft::NodeCount {
+    fn from(count: NodeCount) -> Self {
+        legacy_aleph_bft::NodeCount(count.0)
+    }
+}
+
+impl From<legacy_aleph_bft::NodeCount> for NodeCount {
+    fn from(count: legacy_aleph_bft::NodeCount) -> Self {
+        Self(count.0)
+    }
+}
+
+impl From<current_aleph_bft::NodeCount> for NodeCount {
+    fn from(count: current_aleph_bft::NodeCount) -> Self {
+        Self(count.0)
+    }
+}
+
+impl From<NodeIndex> for current_aleph_bft::NodeIndex {
+    fn from(idx: NodeIndex) -> Self {
+        current_aleph_bft::NodeIndex(idx.0)
+    }
+}
+
+impl From<NodeIndex> for legacy_aleph_bft::NodeIndex {
+    fn from(idx: NodeIndex) -> Self {
+        legacy_aleph_bft::NodeIndex(idx.0)
+    }
+}
+
+impl From<legacy_aleph_bft::NodeIndex> for NodeIndex {
+    fn from(idx: legacy_aleph_bft::NodeIndex) -> Self {
+        Self(idx.0)
+    }
+}
+
+impl From<current_aleph_bft::NodeIndex> for NodeIndex {
+    fn from(idx: current_aleph_bft::NodeIndex) -> Self {
+        Self(idx.0)
+    }
+}
+
+/// Wrapper for `SignatureSet` to be able to implement both legacy and current `PartialMultisignature` trait.
+/// Inner `SignatureSet` is imported from `aleph_bft_crypto` with fixed version for compatibility reasons:
+/// this is also used in the justification which already exist in our chain history and we
+/// need to be careful with changing this.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Encode, Decode)]
+pub struct SignatureSet<Signature>(pub aleph_bft_crypto::SignatureSet<Signature>);
+
+impl<S: Clone> SignatureSet<S> {
+    pub fn size(&self) -> NodeCount {
+        self.0.size().into()
+    }
+
+    pub fn with_size(len: NodeCount) -> Self {
+        SignatureSet(aleph_bft_crypto::SignatureSet::with_size(len.into()))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (NodeIndex, &S)> {
+        self.0.iter().map(|(idx, s)| (idx.into(), s))
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (NodeIndex, &mut S)> {
+        self.0.iter_mut().map(|(idx, s)| (idx.into(), s))
+    }
+
+    pub fn add_signature(self, signature: &S, index: NodeIndex) -> Self
+    where
+        S: Signature,
+    {
+        SignatureSet(self.0.add_signature(signature, index.into()))
+    }
+}
+
+impl<S: 'static> IntoIterator for SignatureSet<S> {
+    type Item = (NodeIndex, S);
+    type IntoIter = Box<dyn Iterator<Item = (NodeIndex, S)>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Box::new(self.0.into_iter().map(|(idx, s)| (idx.into(), s)))
+    }
+}
+
+impl<S: Signature> legacy_aleph_bft::PartialMultisignature for SignatureSet<S> {
+    type Signature = S;
+
+    fn add_signature(
+        self,
+        signature: &Self::Signature,
+        index: legacy_aleph_bft::NodeIndex,
+    ) -> Self {
+        SignatureSet::add_signature(self, signature, index.into())
+    }
+}
+
+impl<S: Signature> current_aleph_bft::PartialMultisignature for SignatureSet<S> {
+    type Signature = S;
+
+    fn add_signature(
+        self,
+        signature: &Self::Signature,
+        index: current_aleph_bft::NodeIndex,
+    ) -> Self {
+        SignatureSet::add_signature(self, signature, index.into())
+    }
+}

--- a/primitives/src/abft_old/network.rs
+++ b/primitives/src/abft_old/network.rs
@@ -1,0 +1,60 @@
+use std::marker::PhantomData;
+
+use log::warn;
+
+use crate::{
+    network::{data::Network, Data},
+    Recipient,
+};
+
+/// A wrapper needed only because of type system theoretical constraints. Sadness.
+pub struct NetworkWrapper<D: Data, DN: Network<D>> {
+    inner: DN,
+    _phantom: PhantomData<D>,
+}
+
+impl<D: Data, DN: Network<D>> From<DN> for NetworkWrapper<D, DN> {
+    fn from(inner: DN) -> Self {
+        NetworkWrapper {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<D: Data, DN: Network<D>> NetworkWrapper<D, DN> {
+    fn send<R>(&self, data: D, recipient: R)
+    where
+        R: Into<Recipient>,
+    {
+        if let Err(e) = self.inner.send(data, recipient.into()) {
+            warn!(target: "aleph-network", "Error '{:?}' while sending an AlephBFT message to the network.", e);
+        }
+    }
+
+    async fn next_event(&mut self) -> Option<D> {
+        self.inner.next().await
+    }
+}
+
+#[async_trait::async_trait]
+impl<D: Data, DN: Network<D>> current_aleph_bft::Network<D> for NetworkWrapper<D, DN> {
+    fn send(&self, data: D, recipient: current_aleph_bft::Recipient) {
+        NetworkWrapper::send(self, data, recipient)
+    }
+
+    async fn next_event(&mut self) -> Option<D> {
+        NetworkWrapper::next_event(self).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<D: Data, DN: Network<D>> legacy_aleph_bft::Network<D> for NetworkWrapper<D, DN> {
+    fn send(&self, data: D, recipient: legacy_aleph_bft::Recipient) {
+        NetworkWrapper::send(self, data, recipient)
+    }
+
+    async fn next_event(&mut self) -> Option<D> {
+        NetworkWrapper::next_event(self).await
+    }
+}

--- a/primitives/src/abft_old/traits.rs
+++ b/primitives/src/abft_old/traits.rs
@@ -1,0 +1,137 @@
+//! Implementations and definitions of traits used in legacy & current abft
+
+use std::{cmp::Ordering, fmt::Debug, hash::Hash as StdHash, marker::PhantomData, pin::Pin};
+
+use futures::{channel::oneshot, Future};
+use network_clique::{SpawnHandleExt, SpawnHandleT};
+use parity_scale_codec::{Decode, Encode};
+use sc_service::SpawnTaskHandle;
+use sp_runtime::traits::Hash as SpHash;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Wrapper<H: SpHash> {
+    phantom: PhantomData<H>,
+}
+
+/// AlephBFT requires an order on hashes and `SpHash` does not have one, so we wrap it to add it.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, StdHash, Encode, Decode)]
+pub struct OrdForHash<O: Eq + Copy + Clone + Send + Debug + StdHash + Encode + Decode + AsRef<[u8]>>
+{
+    inner: O,
+}
+
+impl<O: Eq + Copy + Clone + Send + Sync + Debug + StdHash + Encode + Decode + AsRef<[u8]>>
+    PartialOrd for OrdForHash<O>
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<O: Eq + Copy + Clone + Send + Sync + Debug + StdHash + Encode + Decode + AsRef<[u8]>> Ord
+    for OrdForHash<O>
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.inner.as_ref().cmp(other.inner.as_ref())
+    }
+}
+
+impl<O: Eq + Copy + Clone + Send + Sync + Debug + StdHash + Encode + Decode + AsRef<[u8]>>
+    AsRef<[u8]> for OrdForHash<O>
+{
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_ref()
+    }
+}
+
+impl<H: SpHash> Wrapper<H> {
+    fn hash(s: &[u8]) -> OrdForHash<H::Output> {
+        OrdForHash {
+            inner: <H as SpHash>::hash(s),
+        }
+    }
+}
+
+impl<H: SpHash> current_aleph_bft::Hasher for Wrapper<H> {
+    type Hash = OrdForHash<H::Output>;
+
+    fn hash(s: &[u8]) -> Self::Hash {
+        Wrapper::<H>::hash(s)
+    }
+}
+
+impl<H: SpHash> legacy_aleph_bft::Hasher for Wrapper<H> {
+    type Hash = OrdForHash<H::Output>;
+
+    fn hash(s: &[u8]) -> Self::Hash {
+        Wrapper::<H>::hash(s)
+    }
+}
+
+/// A wrapper for spawning tasks in a way compatible with AlephBFT.
+#[derive(Clone)]
+pub struct SpawnHandle(SpawnTaskHandle);
+
+impl SpawnHandle {
+    pub fn spawn_essential_with_result(
+        &self,
+        name: &'static str,
+        task: impl Future<Output = Result<(), ()>> + Send + 'static,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ()>> + Send>> {
+        let (tx, rx) = oneshot::channel();
+        let wrapped_task = async move {
+            let result = task.await;
+            let _ = tx.send(result);
+        };
+        let result = <Self as SpawnHandleExt>::spawn_essential(self, name, wrapped_task);
+        let wrapped_result = async move {
+            let main_result = result.await;
+            if main_result.is_err() {
+                return Err(());
+            }
+            let rx_result = rx.await;
+            rx_result.unwrap_or(Err(()))
+        };
+        Box::pin(wrapped_result)
+    }
+}
+
+impl From<SpawnTaskHandle> for SpawnHandle {
+    fn from(sth: SpawnTaskHandle) -> Self {
+        SpawnHandle(sth)
+    }
+}
+
+impl SpawnHandleT for SpawnHandle {
+    fn spawn(&self, name: &'static str, task: impl Future<Output = ()> + Send + 'static) {
+        self.0.spawn(name, None, task)
+    }
+}
+
+impl current_aleph_bft::SpawnHandle for SpawnHandle {
+    fn spawn(&self, name: &'static str, task: impl Future<Output = ()> + Send + 'static) {
+        SpawnHandleT::spawn(self, name, task)
+    }
+
+    fn spawn_essential(
+        &self,
+        name: &'static str,
+        task: impl Future<Output = ()> + Send + 'static,
+    ) -> current_aleph_bft::TaskHandle {
+        SpawnHandleExt::spawn_essential(self, name, task)
+    }
+}
+
+impl legacy_aleph_bft::SpawnHandle for SpawnHandle {
+    fn spawn(&self, name: &'static str, task: impl Future<Output = ()> + Send + 'static) {
+        SpawnHandleT::spawn(self, name, task)
+    }
+
+    fn spawn_essential(
+        &self,
+        name: &'static str,
+        task: impl Future<Output = ()> + Send + 'static,
+    ) -> legacy_aleph_bft::TaskHandle {
+        SpawnHandleExt::spawn_essential(self, name, task)
+    }
+}

--- a/primitives/src/abft_old/types.rs
+++ b/primitives/src/abft_old/types.rs
@@ -1,0 +1,115 @@
+//! Types common for current & legacy abft used across finality-aleph
+
+use derive_more::{From, Into};
+use parity_scale_codec::{Decode, Encode, Error, Input, Output};
+
+/// The index of a node
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, From, Into)]
+pub struct NodeIndex(pub usize);
+
+impl Encode for NodeIndex {
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        (self.0 as u64).encode_to(dest);
+    }
+}
+
+impl Decode for NodeIndex {
+    fn decode<I: Input>(value: &mut I) -> Result<Self, Error> {
+        Ok(NodeIndex(u64::decode(value)? as usize))
+    }
+}
+
+/// Node count. Right now it doubles as node weight in many places in the code, in the future we
+/// might need a new type for that.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, From, Into)]
+pub struct NodeCount(pub usize);
+
+/// A recipient of a message, either a specific node or everyone.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Recipient {
+    Everyone,
+    Node(NodeIndex),
+}
+
+impl From<legacy_aleph_bft::Recipient> for Recipient {
+    fn from(recipient: legacy_aleph_bft::Recipient) -> Self {
+        match recipient {
+            legacy_aleph_bft::Recipient::Everyone => Recipient::Everyone,
+            legacy_aleph_bft::Recipient::Node(id) => Recipient::Node(id.into()),
+        }
+    }
+}
+
+impl From<current_aleph_bft::Recipient> for Recipient {
+    fn from(recipient: current_aleph_bft::Recipient) -> Self {
+        match recipient {
+            current_aleph_bft::Recipient::Everyone => Recipient::Everyone,
+            current_aleph_bft::Recipient::Node(id) => Recipient::Node(id.into()),
+        }
+    }
+}
+
+impl From<NodeCount> for current_aleph_bft::NodeCount {
+    fn from(count: NodeCount) -> Self {
+        current_aleph_bft::NodeCount(count.0)
+    }
+}
+impl From<NodeCount> for legacy_aleph_bft::NodeCount {
+    fn from(count: NodeCount) -> Self {
+        legacy_aleph_bft::NodeCount(count.0)
+    }
+}
+
+impl From<legacy_aleph_bft::NodeCount> for NodeCount {
+    fn from(count: legacy_aleph_bft::NodeCount) -> Self {
+        Self(count.0)
+    }
+}
+
+impl From<current_aleph_bft::NodeCount> for NodeCount {
+    fn from(count: current_aleph_bft::NodeCount) -> Self {
+        Self(count.0)
+    }
+}
+
+impl From<NodeIndex> for current_aleph_bft::NodeIndex {
+    fn from(idx: NodeIndex) -> Self {
+        current_aleph_bft::NodeIndex(idx.0)
+    }
+}
+
+impl From<NodeIndex> for legacy_aleph_bft::NodeIndex {
+    fn from(idx: NodeIndex) -> Self {
+        legacy_aleph_bft::NodeIndex(idx.0)
+    }
+}
+
+impl From<legacy_aleph_bft::NodeIndex> for NodeIndex {
+    fn from(idx: legacy_aleph_bft::NodeIndex) -> Self {
+        Self(idx.0)
+    }
+}
+
+impl From<current_aleph_bft::NodeIndex> for NodeIndex {
+    fn from(idx: current_aleph_bft::NodeIndex) -> Self {
+        Self(idx.0)
+    }
+}
+
+impl From<Recipient> for current_aleph_bft::Recipient {
+    fn from(recipient: Recipient) -> Self {
+        match recipient {
+            Recipient::Everyone => current_aleph_bft::Recipient::Everyone,
+            Recipient::Node(idx) => current_aleph_bft::Recipient::Node(idx.into()),
+        }
+    }
+}
+
+impl From<Recipient> for legacy_aleph_bft::Recipient {
+    fn from(recipient: Recipient) -> Self {
+        match recipient {
+            Recipient::Everyone => legacy_aleph_bft::Recipient::Everyone,
+            Recipient::Node(idx) => legacy_aleph_bft::Recipient::Node(idx.into()),
+        }
+    }
+}

--- a/primitives/src/crypto.rs
+++ b/primitives/src/crypto.rs
@@ -1,0 +1,73 @@
+use super::{NodeCount, NodeIndex, SignatureSet};
+use parity_scale_codec::{Decode, Encode};
+use sp_core::crypto::KeyTypeId;
+use sp_runtime::RuntimeAppPublic;
+
+pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"alp0");
+
+mod app {
+    use sp_application_crypto::{app_crypto, ed25519};
+    app_crypto!(ed25519, super::KEY_TYPE);
+}
+
+sp_application_crypto::with_pair! {
+    pub type AuthorityPair = app::Pair;
+}
+
+pub type AuthoritySignature = app::Signature;
+pub type AuthorityId = app::Public;
+
+#[derive(PartialEq, Eq, Clone, Debug, Hash, Decode, Encode)]
+pub struct Signature(pub AuthoritySignature);
+
+impl From<AuthoritySignature> for Signature {
+    fn from(authority_signature: AuthoritySignature) -> Signature {
+        Signature(authority_signature)
+    }
+}
+
+/// Verify the signature given an authority id.
+pub fn verify(authority: &AuthorityId, message: &[u8], signature: &Signature) -> bool {
+    authority.verify(&message, &signature.0)
+}
+
+/// Holds the public authority keys for a session allowing for verification of messages from that
+/// session.
+#[derive(PartialEq, Clone, Debug)]
+pub struct AuthorityVerifier {
+    authorities: Vec<AuthorityId>,
+}
+
+impl AuthorityVerifier {
+    /// Constructs a new authority verifier from a set of public keys.
+    pub fn new(authorities: Vec<AuthorityId>) -> Self {
+        AuthorityVerifier { authorities }
+    }
+
+    /// Verifies whether the message is correctly signed with the signature assumed to be made by a
+    /// node of the given index.
+    pub fn verify(&self, msg: &[u8], sgn: &Signature, index: NodeIndex) -> bool {
+        match self.authorities.get(index.0) {
+            Some(authority) => verify(authority, msg, sgn),
+            None => false,
+        }
+    }
+
+    pub fn node_count(&self) -> NodeCount {
+        self.authorities.len().into()
+    }
+
+    fn threshold(&self) -> usize {
+        2 * self.node_count().0 / 3 + 1
+    }
+
+    /// Verifies whether the given signature set is a correct and complete multisignature of the
+    /// message. Completeness requires more than 2/3 of all authorities.
+    pub fn is_complete(&self, msg: &[u8], partial: &SignatureSet<Signature>) -> bool {
+        let signature_count = partial.iter().count();
+        if signature_count < self.threshold() {
+            return false;
+        }
+        partial.iter().all(|(i, sgn)| self.verify(msg, sgn, i))
+    }
+}

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -4,7 +4,6 @@ use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::crypto::KeyTypeId;
 pub use sp_runtime::{
     generic,
     traits::{BlakeTwo256, ConstU32, Header as HeaderT},
@@ -18,23 +17,15 @@ use sp_runtime::{
 pub use sp_staking::{EraIndex, SessionIndex};
 use sp_std::vec::Vec;
 
-pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"alp0");
+mod abft;
+pub use abft::{NodeCount, NodeIndex, SignatureSet};
+pub mod crypto;
+pub use crypto::{AuthorityId, AuthoritySignature, KEY_TYPE};
 
 // Same as GRANDPA_ENGINE_ID because as of right now substrate sends only
 // grandpa justifications over the network.
 // TODO: change this once https://github.com/paritytech/substrate/issues/8172 will be resolved.
 pub const ALEPH_ENGINE_ID: ConsensusEngineId = *b"FRNK";
-
-mod app {
-    use sp_application_crypto::{app_crypto, ed25519};
-    app_crypto!(ed25519, crate::KEY_TYPE);
-}
-
-sp_application_crypto::with_pair! {
-    pub type AuthorityPair = app::Pair;
-}
-pub type AuthoritySignature = app::Signature;
-pub type AuthorityId = app::Public;
 
 impl_opaque_keys! {
     pub struct AlephNodeSessionKeys {


### PR DESCRIPTION
As in the title above. The change is needed for using SignatureSet in the runtime.