### PR TITLE
A0-4574: Update ABFT after release 14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,11 +73,10 @@ dependencies = [
 
 [[package]]
 name = "aggregator"
-version = "0.6.0"
-source = "git+https://github.com/Cardinal-Cryptography/aleph-node.git?tag=r-13.3#87ebe7c4856b4f3365ddba55b55089713a96631a"
+version = "0.7.0"
 dependencies = [
- "aleph-bft-rmc 0.11.1",
- "aleph-bft-types 0.11.0",
+ "aleph-bft-rmc 0.14.0",
+ "aleph-bft-types 0.14.0",
  "async-trait",
  "futures",
  "log",
@@ -88,6 +87,7 @@ dependencies = [
 [[package]]
 name = "aggregator"
 version = "0.7.0"
+source = "git+https://github.com/Cardinal-Cryptography/aleph-node.git?tag=r-14.0-rc1#98091cd2d64d312db08a491f71b3a7bf321d2f5c"
 dependencies = [
  "aleph-bft-rmc 0.13.0",
  "aleph-bft-types 0.13.0",
@@ -133,27 +133,6 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb18f44d79b54d2a6bf6bfe68bb8dcdb87787151c8842bb6428b3118ca5df1d"
-dependencies = [
- "aleph-bft-rmc 0.11.1",
- "aleph-bft-types 0.11.0",
- "anyhow",
- "async-trait",
- "derivative",
- "futures",
- "futures-timer",
- "itertools 0.12.1",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand",
- "thiserror",
-]
-
-[[package]]
-name = "aleph-bft"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f930b4c0d4a6b66533422e7ee62f5bab08949ada6d275298de909e95bc75b4ce"
@@ -170,20 +149,28 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "rand",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "aleph-bft-crypto"
-version = "0.8.0"
+name = "aleph-bft"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a9bcf1ff87c43606157ffd406751deac3accce0db37e1073767bd43c57b12f"
+checksum = "b2fdb6ff0490653cec91cc602dbc711c37e1f088e1b2232f5f0fd4c1d084b3a6"
 dependencies = [
+ "aleph-bft-rmc 0.14.0",
+ "aleph-bft-types 0.14.0",
+ "anyhow",
  "async-trait",
- "bit-vec",
- "derive_more 0.99.18",
+ "derivative",
+ "futures",
+ "futures-timer",
+ "itertools 0.13.0",
  "log",
  "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -201,11 +188,11 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-mock"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6226ba6871e3dd4fcaabe3123fed0b11bb26b72ac3237a2f46151666e9d7f51"
+checksum = "8222fc5e37b3341d6e4fa01054ddd20983fbae2f00d21e438876dc7caf9ed997"
 dependencies = [
- "aleph-bft-types 0.13.0",
+ "aleph-bft-types 0.14.0",
  "async-trait",
  "futures",
  "log",
@@ -217,26 +204,11 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-rmc"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc92d611c1f3400972d875759db7a5831bdcb5d92d41bdf4952f26ed56a61eb"
-dependencies = [
- "aleph-bft-crypto 0.8.0",
- "aleph-bft-types 0.11.0",
- "async-trait",
- "futures",
- "futures-timer",
- "log",
- "parity-scale-codec",
-]
-
-[[package]]
-name = "aleph-bft-rmc"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878948f17ae09afc0b62162a22325b8828fa1f46c90109bde7261224e2e09e34"
 dependencies = [
- "aleph-bft-crypto 0.9.0",
+ "aleph-bft-crypto",
  "aleph-bft-types 0.13.0",
  "async-trait",
  "futures",
@@ -246,14 +218,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "aleph-bft-types"
-version = "0.11.0"
+name = "aleph-bft-rmc"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa07c102591d09fd7b06fff71d60d2a068f81e63ad46078ef7e6810f2d70151"
+checksum = "795fad15176131c019e71ae7319bff398ad00e4079922ad368b7014e9068f03c"
 dependencies = [
- "aleph-bft-crypto 0.8.0",
+ "aleph-bft-crypto",
+ "aleph-bft-types 0.14.0",
  "async-trait",
  "futures",
+ "futures-timer",
+ "log",
  "parity-scale-codec",
 ]
 
@@ -263,7 +238,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bca9d19f587215da2b6c50b5e71f9addbf2305153f850dad3f9496ed67e28bb"
 dependencies = [
- "aleph-bft-crypto 0.9.0",
+ "aleph-bft-crypto",
+ "async-trait",
+ "futures",
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "aleph-bft-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8986b69d48e1dd4ea1a6b0ca820321dddbf4089efca3301d479ec45dcb167dea"
+dependencies = [
+ "aleph-bft-crypto",
  "async-trait",
  "futures",
  "parity-scale-codec",
@@ -317,7 +304,7 @@ dependencies = [
  "static_assertions",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -653,7 +640,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -1100,7 +1087,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2237,7 +2224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182f7dbc2ef73d9ef67351c5fbbea084729c48362d3ce9dd44c28e32e277fe5"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2292,13 +2279,13 @@ dependencies = [
 name = "finality-aleph"
 version = "0.11.0"
 dependencies = [
- "aggregator 0.6.0",
  "aggregator 0.7.0",
- "aleph-bft 0.33.2",
+ "aggregator 0.7.0 (git+https://github.com/Cardinal-Cryptography/aleph-node.git?tag=r-14.0-rc1)",
  "aleph-bft 0.36.5",
- "aleph-bft-crypto 0.9.0",
- "aleph-bft-rmc 0.11.1",
+ "aleph-bft 0.39.0",
+ "aleph-bft-crypto",
  "aleph-bft-rmc 0.13.0",
+ "aleph-bft-rmc 0.14.0",
  "array-bytes 6.2.3",
  "async-trait",
  "bytes",
@@ -2520,7 +2507,7 @@ dependencies = [
  "sp-storage",
  "sp-trie",
  "sp-wasm-interface",
- "thiserror",
+ "thiserror 1.0.69",
  "thousands",
 ]
 
@@ -3005,7 +2992,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3636,6 +3623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,7 +3689,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -3743,7 +3739,7 @@ dependencies = [
  "beef",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -3928,7 +3924,7 @@ dependencies = [
  "rand",
  "rw-stream-sink",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "unsigned-varint",
  "void",
 ]
@@ -3965,7 +3961,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "void",
 ]
 
@@ -3983,7 +3979,7 @@ dependencies = [
  "quick-protobuf",
  "rand",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -4009,7 +4005,7 @@ dependencies = [
  "rand",
  "sha2 0.10.8",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "uint",
  "unsigned-varint",
  "void",
@@ -4068,7 +4064,7 @@ dependencies = [
  "sha2 0.10.8",
  "snow",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.69",
  "x25519-dalek 1.1.1",
  "zeroize",
 ]
@@ -4108,7 +4104,7 @@ dependencies = [
  "quinn-proto",
  "rand",
  "rustls 0.20.9",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -4189,7 +4185,7 @@ dependencies = [
  "rcgen",
  "ring 0.16.20",
  "rustls 0.20.9",
- "thiserror",
+ "thiserror 1.0.69",
  "webpki",
  "x509-parser",
  "yasna",
@@ -4237,7 +4233,7 @@ dependencies = [
  "futures",
  "libp2p-core",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "yamux",
 ]
 
@@ -4632,7 +4628,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_distr",
  "subtle 2.4.1",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -4802,7 +4798,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "paste",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4816,7 +4812,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -4838,7 +4834,7 @@ name = "network-clique"
 version = "0.6.0"
 dependencies = [
  "aleph-bft-mock",
- "aleph-bft-types 0.13.0",
+ "aleph-bft-types 0.14.0",
  "async-trait",
  "bytes",
  "env_logger",
@@ -5760,7 +5756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -6067,7 +6063,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
  "toml 0.5.11",
 ]
 
@@ -6135,7 +6131,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot 0.12.3",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6248,7 +6244,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror",
+ "thiserror 1.0.69",
  "unsigned-varint",
 ]
 
@@ -6275,7 +6271,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.20.9",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
  "tracing",
  "webpki",
@@ -6439,7 +6435,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6603,7 +6599,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "nix",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -6802,7 +6798,7 @@ dependencies = [
  "log",
  "sp-core",
  "sp-wasm-interface",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6915,7 +6911,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-runtime",
  "sp-version",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -6994,7 +6990,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "substrate-prometheus-endpoint",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7023,7 +7019,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7079,7 +7075,7 @@ dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
  "sp-wasm-interface",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-instrument 0.3.0",
 ]
 
@@ -7129,7 +7125,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7158,7 +7154,7 @@ dependencies = [
  "sp-keystore",
  "sp-mixnet",
  "sp-runtime",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7196,7 +7192,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "unsigned-varint",
@@ -7220,7 +7216,7 @@ dependencies = [
  "sc-network",
  "sp-blockchain",
  "sp-runtime",
- "thiserror",
+ "thiserror 1.0.69",
  "unsigned-varint",
 ]
 
@@ -7259,7 +7255,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7293,7 +7289,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
 ]
@@ -7409,7 +7405,7 @@ dependencies = [
  "sp-rpc",
  "sp-runtime",
  "sp-version",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7451,7 +7447,7 @@ dependencies = [
  "sp-rpc",
  "sp-runtime",
  "sp-version",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
 ]
@@ -7513,7 +7509,7 @@ dependencies = [
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -7565,7 +7561,7 @@ dependencies = [
  "sc-utils",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-timer",
 ]
 
@@ -7593,7 +7589,7 @@ dependencies = [
  "sp-rpc",
  "sp-runtime",
  "sp-tracing",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -7633,7 +7629,7 @@ dependencies = [
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7649,7 +7645,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8105,7 +8101,7 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "sp-version",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8175,7 +8171,7 @@ dependencies = [
  "sp-database",
  "sp-runtime",
  "sp-state-machine",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8190,7 +8186,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8298,7 +8294,7 @@ dependencies = [
  "sp-storage",
  "ss58-registry",
  "substrate-bip39",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "w3f-bls",
  "zeroize",
@@ -8379,7 +8375,7 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8425,7 +8421,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "sp-core",
  "sp-externalities",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8433,7 +8429,7 @@ name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
 source = "git+https://github.com/Cardinal-Cryptography/polkadot-sdk.git?branch=aleph-v1.6.0#e31391cc77babda6ffe9062527ab3f1f6208d22f"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
  "zstd 0.12.4",
 ]
 
@@ -8604,7 +8600,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-std",
  "sp-trie",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "trie-db",
 ]
@@ -8629,7 +8625,7 @@ dependencies = [
  "sp-runtime",
  "sp-runtime-interface",
  "sp-std",
- "thiserror",
+ "thiserror 1.0.69",
  "x25519-dalek 2.0.1",
 ]
 
@@ -8661,7 +8657,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-std",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8718,7 +8714,7 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-std",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "trie-db",
  "trie-root",
@@ -8738,7 +8734,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -9010,7 +9006,7 @@ dependencies = [
  "hyper",
  "log",
  "prometheus",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -9251,7 +9247,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -9259,6 +9264,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9344,7 +9360,7 @@ dependencies = [
  "rand",
  "rustc-hash",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
@@ -9661,7 +9677,7 @@ dependencies = [
  "rand",
  "smallvec",
  "socket2 0.4.10",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
  "tokio",
  "tracing",
@@ -9682,7 +9698,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "trust-dns-proto",
@@ -9882,7 +9898,7 @@ dependencies = [
  "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -10023,7 +10039,7 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-opt-cxx-sys",
  "wasm-opt-sys",
 ]
@@ -10201,7 +10217,7 @@ dependencies = [
  "log",
  "object 0.30.4",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmparser 0.102.0",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
@@ -10236,7 +10252,7 @@ dependencies = [
  "object 0.30.4",
  "serde",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmparser 0.102.0",
  "wasmtime-types",
 ]
@@ -10319,7 +10335,7 @@ checksum = "a4f6fffd2a1011887d57f07654dd112791e872e3ff4a2e626aee8059ee17f06f"
 dependencies = [
  "cranelift-entity",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmparser 0.102.0",
 ]
 
@@ -10762,7 +10778,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ repository = "https://github.com/Cardinal-Cryptography/aleph-node"
 
 [workspace.dependencies]
 aleph-bft-crypto = { version = "0.9" }
-aleph-bft-mock = { version = "0.14" }
-aleph-bft-rmc = { version = "0.13" }
-aleph-bft-types = { version = "0.13" }
+aleph-bft-mock = { version = "0.15" }
+aleph-bft-rmc = { version = "0.14" }
+aleph-bft-types = { version = "0.14" }
 async-trait = { version = "0.1" }
 array-bytes = { version = "6" }
 bytes = { version = "1.8" }

--- a/finality-aleph/Cargo.toml
+++ b/finality-aleph/Cargo.toml
@@ -11,14 +11,15 @@ repository.workspace = true
 # fixed version to 'freeze' some types used in abft, mainly `SignatureSet` used in justification and signature aggregation
 aleph-bft-crypto = { workspace = true }
 
-current-aleph-bft = { package = "aleph-bft", version = "0.36" }
-current-aleph-bft-rmc = { package = "aleph-bft-rmc", version = "0.13" }
-legacy-aleph-bft = { package = "aleph-bft", version = "0.33" }
-legacy-aleph-bft-rmc = { package = "aleph-bft-rmc", version = "0.11" }
+current-aleph-bft = { package = "aleph-bft", version = "0.39" }
+current-aleph-bft-rmc = { package = "aleph-bft-rmc", version = "0.14" }
+legacy-aleph-bft = { package = "aleph-bft", version = "0.36" }
+legacy-aleph-bft-rmc = { package = "aleph-bft-rmc", version = "0.13" }
 
 network-clique = { workspace = true }
 primitives = { workspace = true }
-legacy-aleph-aggregator = { package = "aggregator", git = "https://github.com/Cardinal-Cryptography/aleph-node.git", tag = "r-13.3" }
+# TODO: update this to the appropriate release tag once it exists
+legacy-aleph-aggregator = { package = "aggregator", git = "https://github.com/Cardinal-Cryptography/aleph-node.git", tag = "r-14.0-rc1" }
 current-aleph-aggregator = { path = "../aggregator", package = "aggregator" }
 rate-limiter = { package = "rate-limiter", path = "../rate-limiter" }
 fake-runtime-api = { workspace = true, features = ["std"] }

--- a/finality-aleph/src/abft/crypto.rs
+++ b/finality-aleph/src/abft/crypto.rs
@@ -48,34 +48,14 @@ impl Keychain {
     }
 }
 
-impl current_aleph_bft::Index for Keychain {
-    fn index(&self) -> current_aleph_bft::NodeIndex {
-        Keychain::index(self).into()
-    }
-}
-
+// Currently the traits for legacy and current match, so only one implementation needed.
 impl legacy_aleph_bft::Index for Keychain {
     fn index(&self) -> legacy_aleph_bft::NodeIndex {
         Keychain::index(self).into()
     }
 }
 
-impl current_aleph_bft::Keychain for Keychain {
-    type Signature = Signature;
-
-    fn node_count(&self) -> current_aleph_bft::NodeCount {
-        Keychain::node_count(self).into()
-    }
-
-    fn sign(&self, msg: &[u8]) -> Signature {
-        Keychain::sign(self, msg)
-    }
-
-    fn verify(&self, msg: &[u8], sgn: &Signature, index: current_aleph_bft::NodeIndex) -> bool {
-        Keychain::verify(self, msg, sgn, index)
-    }
-}
-
+// Currently the traits for legacy and current match, so only one implementation needed.
 impl legacy_aleph_bft::Keychain for Keychain {
     type Signature = Signature;
 
@@ -92,30 +72,7 @@ impl legacy_aleph_bft::Keychain for Keychain {
     }
 }
 
-impl current_aleph_bft::MultiKeychain for Keychain {
-    // Using `SignatureSet` is slow, but Substrate has not yet implemented aggregation.
-    // We probably should do this for them at some point.
-    type PartialMultisignature = SignatureSet<Signature>;
-
-    fn bootstrap_multi(
-        &self,
-        signature: &Signature,
-        index: current_aleph_bft::NodeIndex,
-    ) -> Self::PartialMultisignature {
-        current_aleph_bft::PartialMultisignature::add_signature(
-            SignatureSet(aleph_bft_crypto::SignatureSet::with_size(
-                aleph_bft_crypto::Keychain::node_count(self),
-            )),
-            signature,
-            index,
-        )
-    }
-
-    fn is_complete(&self, msg: &[u8], partial: &Self::PartialMultisignature) -> bool {
-        Keychain::is_complete(self, msg, partial)
-    }
-}
-
+// Currently the traits for legacy and current match, so only one implementation needed.
 impl legacy_aleph_bft::MultiKeychain for Keychain {
     // Using `SignatureSet` is slow, but Substrate has not yet implemented aggregation.
     // We probably should do this for them at some point.

--- a/finality-aleph/src/abft/current/mod.rs
+++ b/finality-aleph/src/abft/current/mod.rs
@@ -37,7 +37,7 @@ pub fn run_member<H, C, ADN, V>(
     multikeychain: Keychain,
     config: Config,
     network: WrappedNetwork<H::Unverified, ADN>,
-    data_provider: impl current_aleph_bft::DataProvider<AlephData<H::Unverified>> + 'static,
+    data_provider: impl current_aleph_bft::DataProvider<Output = AlephData<H::Unverified>> + 'static,
     ordered_data_interpreter: OrderedDataInterpreter<SubstrateChainInfoProvider<H, C>, H, V>,
     backup: ABFTBackup,
 ) -> Task
@@ -53,7 +53,12 @@ where
     } = subtask_common;
     let (stop, exit) = oneshot::channel();
     let member_terminator = Terminator::create_root(exit, "member");
-    let local_io = LocalIO::new(data_provider, ordered_data_interpreter, backup.0, backup.1);
+    let local_io = LocalIO::new_with_unit_finalization_handler(
+        data_provider,
+        ordered_data_interpreter,
+        backup.0,
+        backup.1,
+    );
 
     let task = {
         let spawn_handle = spawn_handle.clone();

--- a/finality-aleph/src/abft/current/traits.rs
+++ b/finality-aleph/src/abft/current/traits.rs
@@ -2,23 +2,36 @@
 use crate::{
     block::{Header, HeaderVerifier, UnverifiedHeader},
     data_io::{AlephData, ChainInfoProvider, DataProvider, OrderedDataInterpreter},
+    Hasher,
 };
 
 #[async_trait::async_trait]
-impl<UH: UnverifiedHeader> current_aleph_bft::DataProvider<AlephData<UH>> for DataProvider<UH> {
+impl<UH: UnverifiedHeader> current_aleph_bft::DataProvider for DataProvider<UH> {
+    type Output = AlephData<UH>;
+
     async fn get_data(&mut self) -> Option<AlephData<UH>> {
         DataProvider::get_data(self).await
     }
 }
 
-impl<CIP, H, V> current_aleph_bft::FinalizationHandler<AlephData<H::Unverified>>
-    for OrderedDataInterpreter<CIP, H, V>
+impl<CIP, H, V> current_aleph_bft::UnitFinalizationHandler for OrderedDataInterpreter<CIP, H, V>
 where
     CIP: ChainInfoProvider,
     H: Header,
     V: HeaderVerifier<H>,
 {
-    fn data_finalized(&mut self, data: AlephData<H::Unverified>) {
-        OrderedDataInterpreter::data_finalized(self, data)
+    type Data = AlephData<H::Unverified>;
+    type Hasher = Hasher;
+
+    fn batch_finalized(
+        &mut self,
+        batch: Vec<current_aleph_bft::OrderedUnit<Self::Data, Self::Hasher>>,
+    ) {
+        // TODO(A0-4575): compute performance scores.
+        for unit in batch {
+            if let Some(data) = unit.data {
+                self.data_finalized(data)
+            }
+        }
     }
 }

--- a/finality-aleph/src/abft/legacy/mod.rs
+++ b/finality-aleph/src/abft/legacy/mod.rs
@@ -1,4 +1,4 @@
-use std::{pin::Pin, time::Duration};
+use std::time::Duration;
 
 use legacy_aleph_bft::{create_config, default_delay_config, Config, LocalIO, Terminator};
 use log::debug;
@@ -52,12 +52,7 @@ where
     } = subtask_common;
     let (stop, exit) = oneshot::channel();
     let member_terminator = Terminator::create_root(exit, "member");
-    let local_io = LocalIO::new(
-        data_provider,
-        ordered_data_interpreter,
-        Pin::into_inner(backup.0),
-        Pin::into_inner(backup.1),
-    );
+    let local_io = LocalIO::new(data_provider, ordered_data_interpreter, backup.0, backup.1);
 
     let task = {
         let spawn_handle = spawn_handle.clone();

--- a/finality-aleph/src/abft/legacy/traits.rs
+++ b/finality-aleph/src/abft/legacy/traits.rs
@@ -18,11 +18,7 @@ where
     H: Header,
     V: HeaderVerifier<H>,
 {
-    fn data_finalized(
-        &mut self,
-        data: AlephData<H::Unverified>,
-        _creator: legacy_aleph_bft::NodeIndex,
-    ) {
+    fn data_finalized(&mut self, data: AlephData<H::Unverified>) {
         OrderedDataInterpreter::data_finalized(self, data)
     }
 }

--- a/finality-aleph/src/abft/mod.rs
+++ b/finality-aleph/src/abft/mod.rs
@@ -72,6 +72,7 @@ impl<S: 'static> IntoIterator for SignatureSet<S> {
     }
 }
 
+// Currently the traits for legacy and current match, so only one implementation needed.
 impl<S: Signature> legacy_aleph_bft::PartialMultisignature for SignatureSet<S> {
     type Signature = S;
 
@@ -79,18 +80,6 @@ impl<S: Signature> legacy_aleph_bft::PartialMultisignature for SignatureSet<S> {
         self,
         signature: &Self::Signature,
         index: legacy_aleph_bft::NodeIndex,
-    ) -> Self {
-        SignatureSet::add_signature(self, signature, index.into())
-    }
-}
-
-impl<S: Signature> current_aleph_bft::PartialMultisignature for SignatureSet<S> {
-    type Signature = S;
-
-    fn add_signature(
-        self,
-        signature: &Self::Signature,
-        index: current_aleph_bft::NodeIndex,
     ) -> Self {
         SignatureSet::add_signature(self, signature, index.into())
     }

--- a/finality-aleph/src/abft/network.rs
+++ b/finality-aleph/src/abft/network.rs
@@ -38,7 +38,7 @@ impl<D: Data, DN: Network<D>> NetworkWrapper<D, DN> {
 }
 
 #[async_trait::async_trait]
-impl<D: Data, DN: Network<D>> current_aleph_bft::Network<D> for NetworkWrapper<D, DN> {
+impl<D: Data, DN: Network<D> + 'static> current_aleph_bft::Network<D> for NetworkWrapper<D, DN> {
     fn send(&self, data: D, recipient: current_aleph_bft::Recipient) {
         NetworkWrapper::send(self, data, recipient)
     }

--- a/finality-aleph/src/abft/types.rs
+++ b/finality-aleph/src/abft/types.rs
@@ -49,49 +49,30 @@ impl From<current_aleph_bft::Recipient> for Recipient {
     }
 }
 
-impl From<NodeCount> for current_aleph_bft::NodeCount {
-    fn from(count: NodeCount) -> Self {
-        current_aleph_bft::NodeCount(count.0)
-    }
-}
+// Currently the traits for legacy and current match, so only one implementation needed.
 impl From<NodeCount> for legacy_aleph_bft::NodeCount {
     fn from(count: NodeCount) -> Self {
         legacy_aleph_bft::NodeCount(count.0)
     }
 }
 
+// Currently the traits for legacy and current match, so only one implementation needed.
 impl From<legacy_aleph_bft::NodeCount> for NodeCount {
     fn from(count: legacy_aleph_bft::NodeCount) -> Self {
         Self(count.0)
     }
 }
 
-impl From<current_aleph_bft::NodeCount> for NodeCount {
-    fn from(count: current_aleph_bft::NodeCount) -> Self {
-        Self(count.0)
-    }
-}
-
-impl From<NodeIndex> for current_aleph_bft::NodeIndex {
-    fn from(idx: NodeIndex) -> Self {
-        current_aleph_bft::NodeIndex(idx.0)
-    }
-}
-
+// Currently the traits for legacy and current match, so only one implementation needed.
 impl From<NodeIndex> for legacy_aleph_bft::NodeIndex {
     fn from(idx: NodeIndex) -> Self {
         legacy_aleph_bft::NodeIndex(idx.0)
     }
 }
 
+// Currently the traits for legacy and current match, so only one implementation needed.
 impl From<legacy_aleph_bft::NodeIndex> for NodeIndex {
     fn from(idx: legacy_aleph_bft::NodeIndex) -> Self {
-        Self(idx.0)
-    }
-}
-
-impl From<current_aleph_bft::NodeIndex> for NodeIndex {
-    fn from(idx: current_aleph_bft::NodeIndex) -> Self {
         Self(idx.0)
     }
 }


### PR DESCRIPTION
# Description

Updates ABFT to 0.39. Starts using the extended finalization handler, but in a trivial way, the actual scoring will happen in a separate PR.

Note that this shouldn't break the pipelines that connect to test/mainnet (like #1842 did), even though it technically makes `main` incompatible, since the incompatibility is limited to validation. However I might be wrong, so keep that in mind.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- I have made corresponding changes to the existing documentation
- I have created new documentation
