### PR TITLE
L1-55 Fixed on push tag workflow

### DIFF
--- a/.github/workflows/on-push-release-tag.yml
+++ b/.github/workflows/on-push-release-tag.yml
@@ -36,8 +36,8 @@ jobs:
         run: |
           # cut release candidate part of the tag
           tag=$(echo '${{ steps.get-ref-properties.outputs.tag }}' | sed 's/-rc[0-9]*$//g')
-          # cut major version from Cargo.toml
-          expected_tag=r-$(echo '${{ steps.read-node-version.outputs.value }}' | sed -e 's/^[0-9]\+\.//g')
+          # expected tag is r-<version> from Cargo.toml
+          expected_tag=r-$(echo '${{ steps.read-node-version.outputs.value }}')
           if [[ ${tag} != ${expected_tag} ]]; then
             echo "Error: tag version does not match version in bin/node/Cargo.toml"
             echo "Non-release candidate part of the tag is ${tag}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-node"
-version = "14.0.0+dev"
+version = "14.0.0"
 dependencies = [
  "aleph-runtime",
  "fake-runtime-api",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-node"
-version = "14.0.0+dev"
+version = "14.0.0"
 description = "Aleph node binary"
 build = "build.rs"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
# Description

Since [we changed](https://github.com/Cardinal-Cryptography/aleph-node/commit/a0faac51f21f46a90bc1e4000c6ca9211616dd87) versioning scheme, we need to adapt check in workflow on tag push. Previously [it worked](https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/11235658890/job/31234074222) since `version` in node's `Cargo.toml` was `0.X.Y`, now it is `X.Y.Z`.  Now it [does not](https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/12140381720/job/33850050691), which this PR fixes.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
