### PR TITLE
Try-runtime is not supported in aleph-node anymore.

### DIFF
--- a/.github/workflows/nightly-check-node-features-build.yml
+++ b/.github/workflows/nightly-check-node-features-build.yml
@@ -26,18 +26,12 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: aleph-runtime with try-runtime
-        run: cargo check --profile production -p aleph-runtime --features try-runtime --locked
-
       - name: aleph-runtime with runtime-benchmarks
         # yamllint disable-line rule:line-length
         run: cargo check --profile production -p aleph-runtime --features runtime-benchmarks --locked
 
       - name: aleph-node with runtime-benchmarks
         run: cargo check --profile production -p aleph-node --features runtime-benchmarks --locked
-
-      - name: aleph-node with try-runtime
-        run: cargo check --profile production -p aleph-node --features try-runtime --locked
 
       - name: aleph-node with aleph-runtime-native
         run: cargo check --profile dev -p aleph-node --features aleph-runtime-native --locked


### PR DESCRIPTION
# Description

Fix for https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/12147201626/job/33872892632
After change https://github.com/Cardinal-Cryptography/aleph-node/commit/9c2036b80165ca15fda513011bdd901f65869e0c we don't support `try-runtime` feature anymore. 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
