### PR TITLE
A0-4343: Implement runtime api for storing abft scores on chain.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5023,7 +5023,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pallet-aleph"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/aleph-client/src/aleph_zero.rs
+++ b/aleph-client/src/aleph_zero.rs
@@ -1209,6 +1209,32 @@ pub mod api {
                         ],
                     )
                 }
+                #[doc = " Submits score for a nonce in a session of performance of finality committee members."]
+                pub fn submit_abft_score(
+                    &self,
+                    nonce: ::core::primitive::u32,
+                    score: ::std::vec::Vec<::core::primitive::u32>,
+                    signature: runtime_types::primitives::crypto::SignatureSet<
+                        runtime_types::primitives::app::Signature,
+                    >,
+                ) -> ::subxt::runtime_api::Payload<types::SubmitAbftScore, ::core::option::Option<()>>
+                {
+                    ::subxt::runtime_api::Payload::new_static(
+                        "AlephSessionApi",
+                        "submit_abft_score",
+                        types::SubmitAbftScore {
+                            nonce,
+                            score,
+                            signature,
+                        },
+                        [
+                            94u8, 155u8, 191u8, 188u8, 112u8, 196u8, 193u8, 140u8, 106u8, 206u8,
+                            196u8, 140u8, 93u8, 129u8, 83u8, 204u8, 117u8, 80u8, 155u8, 115u8,
+                            195u8, 178u8, 98u8, 20u8, 99u8, 169u8, 105u8, 175u8, 220u8, 20u8,
+                            250u8, 216u8,
+                        ],
+                    )
+                }
             }
             pub mod types {
                 use super::runtime_types;
@@ -1398,6 +1424,26 @@ pub mod api {
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
                 pub struct CurrentEraPayout {}
+                #[derive(
+                    :: subxt :: ext :: codec :: Decode,
+                    :: subxt :: ext :: codec :: Encode,
+                    :: subxt :: ext :: scale_decode :: DecodeAsType,
+                    :: subxt :: ext :: scale_encode :: EncodeAsType,
+                    Clone,
+                    Debug,
+                    Eq,
+                    PartialEq,
+                )]
+                # [codec (crate = :: subxt :: ext :: codec)]
+                #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
+                #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
+                pub struct SubmitAbftScore {
+                    pub nonce: ::core::primitive::u32,
+                    pub score: ::std::vec::Vec<::core::primitive::u32>,
+                    pub signature: runtime_types::primitives::crypto::SignatureSet<
+                        runtime_types::primitives::app::Signature,
+                    >,
+                }
             }
         }
         pub mod nomination_pools_api {
@@ -2140,9 +2186,9 @@ pub mod api {
             .hash();
         runtime_metadata_hash
             == [
-                215u8, 214u8, 136u8, 251u8, 152u8, 78u8, 98u8, 58u8, 80u8, 188u8, 2u8, 21u8, 206u8,
-                234u8, 19u8, 30u8, 163u8, 128u8, 7u8, 43u8, 216u8, 246u8, 5u8, 46u8, 207u8, 1u8,
-                142u8, 26u8, 146u8, 247u8, 88u8, 215u8,
+                31u8, 115u8, 72u8, 107u8, 237u8, 34u8, 72u8, 178u8, 161u8, 241u8, 99u8, 155u8,
+                183u8, 144u8, 34u8, 56u8, 216u8, 36u8, 64u8, 205u8, 84u8, 84u8, 200u8, 224u8, 11u8,
+                175u8, 65u8, 217u8, 190u8, 31u8, 131u8, 7u8,
             ]
     }
     pub mod system {
@@ -3542,9 +3588,9 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            39u8, 214u8, 15u8, 254u8, 124u8, 249u8, 179u8, 227u8, 232u8, 87u8,
-                            66u8, 177u8, 4u8, 147u8, 96u8, 142u8, 162u8, 63u8, 124u8, 112u8, 169u8,
-                            81u8, 160u8, 94u8, 52u8, 196u8, 85u8, 87u8, 6u8, 101u8, 84u8, 73u8,
+                            165u8, 27u8, 106u8, 96u8, 215u8, 34u8, 194u8, 38u8, 222u8, 251u8, 87u8,
+                            233u8, 206u8, 38u8, 7u8, 160u8, 38u8, 59u8, 88u8, 81u8, 51u8, 178u8,
+                            64u8, 77u8, 100u8, 15u8, 115u8, 13u8, 226u8, 213u8, 68u8, 64u8,
                         ],
                     )
                 }
@@ -3589,10 +3635,9 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            223u8, 154u8, 164u8, 114u8, 172u8, 104u8, 216u8, 156u8, 162u8, 124u8,
-                            217u8, 56u8, 182u8, 36u8, 156u8, 182u8, 19u8, 194u8, 227u8, 114u8,
-                            92u8, 27u8, 3u8, 32u8, 133u8, 86u8, 121u8, 77u8, 56u8, 95u8, 18u8,
-                            58u8,
+                            7u8, 17u8, 174u8, 12u8, 155u8, 32u8, 253u8, 82u8, 232u8, 92u8, 99u8,
+                            131u8, 96u8, 82u8, 41u8, 69u8, 229u8, 164u8, 89u8, 125u8, 163u8, 125u8,
+                            48u8, 22u8, 175u8, 172u8, 239u8, 109u8, 166u8, 236u8, 253u8, 74u8,
                         ],
                     )
                 }
@@ -3633,9 +3678,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            8u8, 202u8, 115u8, 159u8, 71u8, 203u8, 73u8, 117u8, 208u8, 113u8, 92u8,
-                            200u8, 184u8, 220u8, 50u8, 77u8, 35u8, 142u8, 218u8, 81u8, 64u8, 160u8,
-                            50u8, 40u8, 186u8, 13u8, 241u8, 14u8, 66u8, 193u8, 127u8, 51u8,
+                            135u8, 84u8, 233u8, 165u8, 40u8, 196u8, 162u8, 29u8, 161u8, 105u8,
+                            230u8, 223u8, 163u8, 137u8, 61u8, 51u8, 159u8, 44u8, 175u8, 83u8,
+                            213u8, 5u8, 38u8, 46u8, 105u8, 222u8, 244u8, 209u8, 237u8, 210u8,
+                            126u8, 78u8,
                         ],
                     )
                 }
@@ -3662,9 +3708,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            178u8, 33u8, 133u8, 210u8, 91u8, 94u8, 201u8, 58u8, 226u8, 94u8, 188u8,
-                            27u8, 29u8, 84u8, 132u8, 233u8, 167u8, 82u8, 204u8, 68u8, 233u8, 119u8,
-                            173u8, 225u8, 35u8, 178u8, 106u8, 54u8, 103u8, 204u8, 181u8, 140u8,
+                            250u8, 250u8, 194u8, 172u8, 227u8, 215u8, 25u8, 167u8, 239u8, 217u8,
+                            84u8, 87u8, 127u8, 88u8, 89u8, 58u8, 21u8, 171u8, 21u8, 243u8, 22u8,
+                            145u8, 81u8, 33u8, 63u8, 232u8, 199u8, 11u8, 252u8, 146u8, 200u8,
+                            225u8,
                         ],
                     )
                 }
@@ -9350,6 +9397,8 @@ pub mod api {
     }
     pub mod aleph {
         use super::{root_mod, runtime_types};
+        #[doc = "The `Error` enum of this pallet."]
+        pub type Error = runtime_types::pallet_aleph::pallet::Error;
         #[doc = "Contains a variant per dispatchable extrinsic that this pallet has."]
         pub type Call = runtime_types::pallet_aleph::pallet::Call;
         pub mod calls {
@@ -9419,6 +9468,30 @@ pub mod api {
                     const PALLET: &'static str = "Aleph";
                     const CALL: &'static str = "set_inflation_parameters";
                 }
+                #[derive(
+                    :: subxt :: ext :: codec :: Decode,
+                    :: subxt :: ext :: codec :: Encode,
+                    :: subxt :: ext :: scale_decode :: DecodeAsType,
+                    :: subxt :: ext :: scale_encode :: EncodeAsType,
+                    Clone,
+                    Debug,
+                    Eq,
+                    PartialEq,
+                )]
+                # [codec (crate = :: subxt :: ext :: codec)]
+                #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
+                #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
+                pub struct UnsignedSubmitAbftScore {
+                    pub nonce: ::core::primitive::u32,
+                    pub score: ::std::vec::Vec<::core::primitive::u32>,
+                    pub signature: runtime_types::primitives::crypto::SignatureSet<
+                        runtime_types::primitives::app::Signature,
+                    >,
+                }
+                impl ::subxt::blocks::StaticExtrinsic for UnsignedSubmitAbftScore {
+                    const PALLET: &'static str = "Aleph";
+                    const CALL: &'static str = "unsigned_submit_abft_score";
+                }
             }
             pub struct TransactionApi;
             impl TransactionApi {
@@ -9478,6 +9551,31 @@ pub mod api {
                             172u8, 23u8, 138u8, 41u8, 247u8, 219u8, 124u8, 241u8, 198u8, 164u8,
                             169u8, 7u8, 107u8, 249u8, 167u8, 58u8, 17u8, 105u8, 97u8, 139u8, 124u8,
                             94u8, 130u8, 248u8, 140u8, 31u8, 71u8, 11u8, 197u8, 49u8, 45u8, 247u8,
+                        ],
+                    )
+                }
+                #[doc = "See [`Pallet::unsigned_submit_abft_score`]."]
+                pub fn unsigned_submit_abft_score(
+                    &self,
+                    nonce: ::core::primitive::u32,
+                    score: ::std::vec::Vec<::core::primitive::u32>,
+                    signature: runtime_types::primitives::crypto::SignatureSet<
+                        runtime_types::primitives::app::Signature,
+                    >,
+                ) -> ::subxt::tx::Payload<types::UnsignedSubmitAbftScore> {
+                    ::subxt::tx::Payload::new_static(
+                        "Aleph",
+                        "unsigned_submit_abft_score",
+                        types::UnsignedSubmitAbftScore {
+                            nonce,
+                            score,
+                            signature,
+                        },
+                        [
+                            186u8, 52u8, 102u8, 83u8, 253u8, 148u8, 198u8, 149u8, 138u8, 130u8,
+                            172u8, 140u8, 15u8, 138u8, 184u8, 201u8, 81u8, 190u8, 4u8, 121u8,
+                            141u8, 86u8, 132u8, 138u8, 154u8, 79u8, 56u8, 57u8, 34u8, 128u8, 74u8,
+                            198u8,
                         ],
                     )
                 }
@@ -9779,26 +9877,68 @@ pub mod api {
                         ],
                     )
                 }
-                pub fn abft_signature(
+                pub fn abft_scores(
+                    &self,
+                    _0: impl ::std::borrow::Borrow<::core::primitive::u32>,
+                ) -> ::subxt::storage::address::Address<
+                    ::subxt::storage::address::StaticStorageMapKey,
+                    ::std::vec::Vec<::core::primitive::u32>,
+                    ::subxt::storage::address::Yes,
+                    (),
+                    ::subxt::storage::address::Yes,
+                > {
+                    ::subxt::storage::address::Address::new_static(
+                        "Aleph",
+                        "AbftScores",
+                        vec![::subxt::storage::address::make_static_storage_map_key(
+                            _0.borrow(),
+                        )],
+                        [
+                            126u8, 203u8, 136u8, 245u8, 160u8, 238u8, 244u8, 23u8, 81u8, 37u8,
+                            177u8, 83u8, 204u8, 204u8, 242u8, 185u8, 215u8, 62u8, 40u8, 79u8,
+                            132u8, 129u8, 230u8, 188u8, 233u8, 103u8, 220u8, 117u8, 11u8, 52u8,
+                            1u8, 0u8,
+                        ],
+                    )
+                }
+                pub fn abft_scores_root(
                     &self,
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
-                    runtime_types::primitives::crypto::SignatureSet<
-                        runtime_types::primitives::app::Signature,
-                    >,
-                    ::subxt::storage::address::Yes,
+                    ::std::vec::Vec<::core::primitive::u32>,
                     (),
+                    (),
+                    ::subxt::storage::address::Yes,
+                > {
+                    ::subxt::storage::address::Address::new_static(
+                        "Aleph",
+                        "AbftScores",
+                        Vec::new(),
+                        [
+                            126u8, 203u8, 136u8, 245u8, 160u8, 238u8, 244u8, 23u8, 81u8, 37u8,
+                            177u8, 83u8, 204u8, 204u8, 242u8, 185u8, 215u8, 62u8, 40u8, 79u8,
+                            132u8, 129u8, 230u8, 188u8, 233u8, 103u8, 220u8, 117u8, 11u8, 52u8,
+                            1u8, 0u8,
+                        ],
+                    )
+                }
+                pub fn last_score_nonce(
+                    &self,
+                ) -> ::subxt::storage::address::Address<
+                    ::subxt::storage::address::StaticStorageMapKey,
+                    ::core::primitive::u32,
+                    ::subxt::storage::address::Yes,
+                    ::subxt::storage::address::Yes,
                     (),
                 > {
                     ::subxt::storage::address::Address::new_static(
                         "Aleph",
-                        "AbftSignature",
+                        "LastScoreNonce",
                         vec![],
                         [
-                            41u8, 250u8, 192u8, 238u8, 20u8, 36u8, 104u8, 19u8, 70u8, 209u8, 234u8,
-                            162u8, 46u8, 123u8, 202u8, 47u8, 238u8, 233u8, 157u8, 52u8, 235u8,
-                            122u8, 239u8, 163u8, 195u8, 235u8, 201u8, 183u8, 117u8, 178u8, 236u8,
-                            16u8,
+                            47u8, 152u8, 177u8, 250u8, 49u8, 166u8, 1u8, 46u8, 232u8, 177u8, 38u8,
+                            247u8, 238u8, 52u8, 217u8, 129u8, 225u8, 112u8, 253u8, 20u8, 236u8,
+                            215u8, 88u8, 224u8, 173u8, 47u8, 47u8, 44u8, 40u8, 13u8, 12u8, 202u8,
                         ],
                     )
                 }
@@ -11759,9 +11899,9 @@ pub mod api {
                         "batch",
                         types::Batch { calls },
                         [
-                            57u8, 11u8, 63u8, 124u8, 17u8, 171u8, 210u8, 147u8, 190u8, 115u8,
-                            151u8, 21u8, 148u8, 6u8, 27u8, 96u8, 187u8, 228u8, 71u8, 65u8, 238u8,
-                            12u8, 141u8, 2u8, 209u8, 14u8, 21u8, 240u8, 33u8, 180u8, 152u8, 142u8,
+                            255u8, 25u8, 171u8, 115u8, 188u8, 58u8, 188u8, 1u8, 227u8, 41u8, 148u8,
+                            204u8, 144u8, 84u8, 238u8, 135u8, 117u8, 179u8, 76u8, 236u8, 64u8,
+                            94u8, 167u8, 98u8, 186u8, 4u8, 22u8, 173u8, 123u8, 76u8, 47u8, 206u8,
                         ],
                     )
                 }
@@ -11779,10 +11919,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            90u8, 149u8, 199u8, 144u8, 216u8, 134u8, 119u8, 183u8, 50u8, 114u8,
-                            83u8, 90u8, 27u8, 227u8, 240u8, 99u8, 225u8, 140u8, 111u8, 193u8,
-                            173u8, 237u8, 35u8, 232u8, 206u8, 16u8, 248u8, 103u8, 127u8, 255u8,
-                            242u8, 63u8,
+                            192u8, 135u8, 104u8, 196u8, 1u8, 198u8, 145u8, 235u8, 243u8, 143u8,
+                            223u8, 55u8, 176u8, 15u8, 168u8, 131u8, 149u8, 122u8, 92u8, 78u8,
+                            236u8, 6u8, 170u8, 89u8, 47u8, 173u8, 82u8, 46u8, 192u8, 163u8, 165u8,
+                            230u8,
                         ],
                     )
                 }
@@ -11796,10 +11936,9 @@ pub mod api {
                         "batch_all",
                         types::BatchAll { calls },
                         [
-                            147u8, 167u8, 0u8, 109u8, 245u8, 170u8, 212u8, 105u8, 167u8, 83u8,
-                            182u8, 253u8, 169u8, 177u8, 32u8, 150u8, 226u8, 109u8, 181u8, 132u8,
-                            20u8, 246u8, 179u8, 171u8, 138u8, 211u8, 71u8, 252u8, 104u8, 194u8,
-                            236u8, 117u8,
+                            248u8, 90u8, 145u8, 51u8, 202u8, 156u8, 96u8, 27u8, 25u8, 3u8, 61u8,
+                            44u8, 57u8, 183u8, 222u8, 1u8, 67u8, 150u8, 196u8, 128u8, 61u8, 237u8,
+                            61u8, 90u8, 91u8, 49u8, 41u8, 158u8, 100u8, 96u8, 74u8, 238u8,
                         ],
                     )
                 }
@@ -11817,10 +11956,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            148u8, 215u8, 233u8, 2u8, 12u8, 20u8, 203u8, 143u8, 194u8, 237u8, 9u8,
-                            193u8, 161u8, 54u8, 224u8, 30u8, 254u8, 148u8, 167u8, 237u8, 192u8,
-                            119u8, 181u8, 177u8, 250u8, 51u8, 113u8, 112u8, 32u8, 105u8, 255u8,
-                            16u8,
+                            84u8, 173u8, 58u8, 135u8, 152u8, 65u8, 124u8, 182u8, 195u8, 120u8,
+                            208u8, 228u8, 184u8, 89u8, 107u8, 79u8, 181u8, 41u8, 224u8, 97u8,
+                            200u8, 151u8, 166u8, 159u8, 240u8, 104u8, 35u8, 250u8, 48u8, 207u8,
+                            147u8, 71u8,
                         ],
                     )
                 }
@@ -11834,10 +11973,9 @@ pub mod api {
                         "force_batch",
                         types::ForceBatch { calls },
                         [
-                            124u8, 216u8, 222u8, 157u8, 145u8, 250u8, 156u8, 35u8, 90u8, 3u8,
-                            130u8, 27u8, 16u8, 144u8, 4u8, 213u8, 149u8, 113u8, 120u8, 134u8,
-                            153u8, 192u8, 189u8, 240u8, 30u8, 201u8, 200u8, 130u8, 85u8, 151u8,
-                            161u8, 112u8,
+                            205u8, 70u8, 172u8, 46u8, 208u8, 185u8, 36u8, 80u8, 94u8, 145u8, 13u8,
+                            93u8, 21u8, 96u8, 99u8, 28u8, 115u8, 212u8, 34u8, 177u8, 88u8, 198u8,
+                            239u8, 55u8, 68u8, 8u8, 18u8, 68u8, 170u8, 137u8, 17u8, 102u8,
                         ],
                     )
                 }
@@ -11855,10 +11993,10 @@ pub mod api {
                             weight,
                         },
                         [
-                            195u8, 57u8, 24u8, 15u8, 28u8, 134u8, 238u8, 125u8, 131u8, 123u8,
-                            159u8, 2u8, 15u8, 124u8, 171u8, 46u8, 35u8, 42u8, 93u8, 199u8, 194u8,
-                            185u8, 4u8, 118u8, 195u8, 72u8, 86u8, 146u8, 203u8, 201u8, 120u8,
-                            148u8,
+                            16u8, 51u8, 36u8, 198u8, 117u8, 113u8, 103u8, 115u8, 173u8, 203u8,
+                            153u8, 251u8, 204u8, 63u8, 86u8, 190u8, 248u8, 235u8, 235u8, 126u8,
+                            236u8, 38u8, 32u8, 53u8, 59u8, 114u8, 153u8, 252u8, 106u8, 170u8,
+                            157u8, 82u8,
                         ],
                     )
                 }
@@ -12148,9 +12286,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            0u8, 17u8, 85u8, 217u8, 252u8, 71u8, 193u8, 109u8, 33u8, 234u8, 95u8,
-                            88u8, 46u8, 237u8, 160u8, 221u8, 2u8, 135u8, 18u8, 22u8, 124u8, 179u8,
-                            238u8, 194u8, 206u8, 70u8, 163u8, 218u8, 138u8, 10u8, 48u8, 45u8,
+                            180u8, 107u8, 52u8, 246u8, 196u8, 80u8, 104u8, 216u8, 238u8, 186u8,
+                            213u8, 16u8, 8u8, 68u8, 51u8, 38u8, 249u8, 45u8, 18u8, 43u8, 115u8,
+                            143u8, 60u8, 104u8, 146u8, 77u8, 196u8, 57u8, 181u8, 143u8, 108u8,
+                            241u8,
                         ],
                     )
                 }
@@ -12178,9 +12317,10 @@ pub mod api {
                             max_weight,
                         },
                         [
-                            177u8, 197u8, 141u8, 10u8, 228u8, 86u8, 9u8, 65u8, 125u8, 36u8, 135u8,
-                            44u8, 153u8, 122u8, 80u8, 57u8, 36u8, 167u8, 194u8, 102u8, 77u8, 81u8,
-                            80u8, 252u8, 43u8, 147u8, 229u8, 188u8, 192u8, 133u8, 182u8, 114u8,
+                            183u8, 90u8, 166u8, 148u8, 242u8, 150u8, 206u8, 13u8, 194u8, 168u8,
+                            27u8, 98u8, 29u8, 131u8, 154u8, 243u8, 152u8, 14u8, 201u8, 214u8,
+                            250u8, 229u8, 94u8, 49u8, 76u8, 71u8, 175u8, 234u8, 84u8, 119u8, 167u8,
+                            54u8,
                         ],
                     )
                 }
@@ -12593,9 +12733,9 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            158u8, 62u8, 215u8, 113u8, 153u8, 178u8, 147u8, 161u8, 162u8, 253u8,
-                            152u8, 0u8, 172u8, 149u8, 51u8, 59u8, 254u8, 176u8, 234u8, 3u8, 215u8,
-                            15u8, 4u8, 157u8, 53u8, 105u8, 163u8, 51u8, 155u8, 95u8, 44u8, 184u8,
+                            94u8, 179u8, 34u8, 76u8, 99u8, 239u8, 208u8, 173u8, 98u8, 153u8, 79u8,
+                            195u8, 128u8, 15u8, 63u8, 162u8, 16u8, 137u8, 39u8, 75u8, 39u8, 185u8,
+                            155u8, 24u8, 129u8, 84u8, 62u8, 195u8, 75u8, 212u8, 230u8, 193u8,
                         ],
                     )
                 }
@@ -12613,9 +12753,9 @@ pub mod api {
                             weight,
                         },
                         [
-                            91u8, 109u8, 187u8, 74u8, 5u8, 5u8, 122u8, 239u8, 80u8, 146u8, 72u8,
-                            165u8, 204u8, 33u8, 43u8, 12u8, 129u8, 147u8, 183u8, 31u8, 127u8, 87u8,
-                            190u8, 165u8, 23u8, 21u8, 219u8, 50u8, 237u8, 234u8, 77u8, 166u8,
+                            228u8, 23u8, 85u8, 101u8, 132u8, 89u8, 12u8, 170u8, 209u8, 1u8, 195u8,
+                            26u8, 33u8, 220u8, 134u8, 99u8, 52u8, 18u8, 187u8, 234u8, 109u8, 200u8,
+                            238u8, 212u8, 99u8, 46u8, 74u8, 36u8, 203u8, 25u8, 165u8, 63u8,
                         ],
                     )
                 }
@@ -12655,9 +12795,9 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            44u8, 241u8, 218u8, 101u8, 240u8, 41u8, 91u8, 148u8, 30u8, 206u8, 99u8,
-                            102u8, 238u8, 157u8, 184u8, 169u8, 72u8, 162u8, 218u8, 29u8, 176u8,
-                            33u8, 171u8, 221u8, 142u8, 70u8, 120u8, 25u8, 176u8, 201u8, 95u8, 33u8,
+                            111u8, 20u8, 41u8, 236u8, 152u8, 223u8, 2u8, 13u8, 148u8, 80u8, 249u8,
+                            33u8, 79u8, 130u8, 79u8, 22u8, 193u8, 29u8, 201u8, 118u8, 103u8, 7u8,
+                            50u8, 208u8, 189u8, 78u8, 77u8, 137u8, 38u8, 254u8, 34u8, 107u8,
                         ],
                     )
                 }
@@ -18965,10 +19105,9 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            152u8, 186u8, 14u8, 154u8, 140u8, 78u8, 76u8, 10u8, 127u8, 109u8,
-                            175u8, 235u8, 80u8, 170u8, 172u8, 59u8, 226u8, 197u8, 118u8, 232u8,
-                            84u8, 195u8, 0u8, 37u8, 11u8, 37u8, 214u8, 240u8, 215u8, 15u8, 183u8,
-                            143u8,
+                            61u8, 199u8, 160u8, 155u8, 131u8, 73u8, 44u8, 87u8, 169u8, 42u8, 139u8,
+                            197u8, 19u8, 21u8, 70u8, 75u8, 101u8, 245u8, 238u8, 127u8, 222u8, 46u8,
+                            67u8, 136u8, 192u8, 84u8, 71u8, 235u8, 166u8, 131u8, 93u8, 157u8,
                         ],
                     )
                 }
@@ -19180,9 +19319,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            233u8, 8u8, 208u8, 87u8, 227u8, 220u8, 102u8, 174u8, 52u8, 163u8, 68u8,
-                            197u8, 195u8, 188u8, 193u8, 77u8, 165u8, 2u8, 98u8, 125u8, 131u8, 56u8,
-                            79u8, 181u8, 94u8, 43u8, 82u8, 101u8, 39u8, 152u8, 236u8, 113u8,
+                            140u8, 203u8, 152u8, 185u8, 223u8, 204u8, 168u8, 117u8, 144u8, 255u8,
+                            114u8, 76u8, 9u8, 9u8, 198u8, 187u8, 151u8, 203u8, 226u8, 122u8, 130u8,
+                            159u8, 19u8, 59u8, 102u8, 188u8, 235u8, 243u8, 127u8, 56u8, 126u8,
+                            161u8,
                         ],
                     )
                 }
@@ -20711,6 +20851,8 @@ pub mod api {
                 Staking(runtime_types::pallet_staking::pallet::pallet::Error),
                 #[codec(index = 10)]
                 Session(runtime_types::pallet_session::pallet::Error),
+                #[codec(index = 11)]
+                Aleph(runtime_types::pallet_aleph::pallet::Error),
                 #[codec(index = 12)]
                 Elections(runtime_types::pallet_elections::pallet::Error),
                 #[codec(index = 13)]
@@ -21551,6 +21693,34 @@ pub mod api {
                         azero_cap: ::core::option::Option<::core::primitive::u128>,
                         horizon_millisecs: ::core::option::Option<::core::primitive::u64>,
                     },
+                    #[codec(index = 3)]
+                    #[doc = "See [`Pallet::unsigned_submit_abft_score`]."]
+                    unsigned_submit_abft_score {
+                        nonce: ::core::primitive::u32,
+                        score: ::std::vec::Vec<::core::primitive::u32>,
+                        signature: runtime_types::primitives::crypto::SignatureSet<
+                            runtime_types::primitives::app::Signature,
+                        >,
+                    },
+                }
+                #[derive(
+                    :: subxt :: ext :: codec :: Decode,
+                    :: subxt :: ext :: codec :: Encode,
+                    :: subxt :: ext :: scale_decode :: DecodeAsType,
+                    :: subxt :: ext :: scale_encode :: EncodeAsType,
+                    Clone,
+                    Debug,
+                    Eq,
+                    PartialEq,
+                )]
+                # [codec (crate = :: subxt :: ext :: codec)]
+                #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
+                #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
+                #[doc = "The `Error` enum of this pallet."]
+                pub enum Error {
+                    #[codec(index = 0)]
+                    #[doc = "Duplicated score in the same block"]
+                    DuplicatedScore,
                 }
                 #[derive(
                     :: subxt :: ext :: codec :: Decode,

--- a/aleph-client/src/aleph_zero.rs
+++ b/aleph-client/src/aleph_zero.rs
@@ -2180,9 +2180,9 @@ pub mod api {
             .hash();
         runtime_metadata_hash
             == [
-                245u8, 41u8, 177u8, 60u8, 14u8, 203u8, 151u8, 173u8, 102u8, 231u8, 167u8, 202u8,
-                19u8, 189u8, 87u8, 204u8, 219u8, 223u8, 82u8, 65u8, 37u8, 97u8, 165u8, 66u8, 176u8,
-                41u8, 235u8, 167u8, 96u8, 163u8, 91u8, 63u8,
+                189u8, 1u8, 127u8, 19u8, 36u8, 11u8, 205u8, 128u8, 195u8, 127u8, 6u8, 242u8, 133u8,
+                40u8, 178u8, 27u8, 175u8, 202u8, 182u8, 173u8, 177u8, 211u8, 114u8, 209u8, 204u8,
+                250u8, 176u8, 221u8, 20u8, 78u8, 100u8, 101u8,
             ]
     }
     pub mod system {
@@ -9391,8 +9391,6 @@ pub mod api {
     }
     pub mod aleph {
         use super::{root_mod, runtime_types};
-        #[doc = "The `Error` enum of this pallet."]
-        pub type Error = runtime_types::pallet_aleph::pallet::Error;
         #[doc = "Contains a variant per dispatchable extrinsic that this pallet has."]
         pub type Call = runtime_types::pallet_aleph::pallet::Call;
         pub mod calls {
@@ -20838,8 +20836,6 @@ pub mod api {
                 Staking(runtime_types::pallet_staking::pallet::pallet::Error),
                 #[codec(index = 10)]
                 Session(runtime_types::pallet_session::pallet::Error),
-                #[codec(index = 11)]
-                Aleph(runtime_types::pallet_aleph::pallet::Error),
                 #[codec(index = 12)]
                 Elections(runtime_types::pallet_elections::pallet::Error),
                 #[codec(index = 13)]
@@ -21688,25 +21684,6 @@ pub mod api {
                             runtime_types::primitives::app::Signature,
                         >,
                     },
-                }
-                #[derive(
-                    :: subxt :: ext :: codec :: Decode,
-                    :: subxt :: ext :: codec :: Encode,
-                    :: subxt :: ext :: scale_decode :: DecodeAsType,
-                    :: subxt :: ext :: scale_encode :: EncodeAsType,
-                    Clone,
-                    Debug,
-                    Eq,
-                    PartialEq,
-                )]
-                # [codec (crate = :: subxt :: ext :: codec)]
-                #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
-                #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
-                #[doc = "The `Error` enum of this pallet."]
-                pub enum Error {
-                    #[codec(index = 0)]
-                    #[doc = "Duplicated score in the same block"]
-                    DuplicatedScore,
                 }
                 #[derive(
                     :: subxt :: ext :: codec :: Decode,

--- a/aleph-client/src/aleph_zero.rs
+++ b/aleph-client/src/aleph_zero.rs
@@ -1212,8 +1212,7 @@ pub mod api {
                 #[doc = " Submits score for a nonce in a session of performance of finality committee members."]
                 pub fn submit_abft_score(
                     &self,
-                    nonce: ::core::primitive::u32,
-                    score: ::std::vec::Vec<::core::primitive::u32>,
+                    score: runtime_types::primitives::Score,
                     signature: runtime_types::primitives::crypto::SignatureSet<
                         runtime_types::primitives::app::Signature,
                     >,
@@ -1222,16 +1221,12 @@ pub mod api {
                     ::subxt::runtime_api::Payload::new_static(
                         "AlephSessionApi",
                         "submit_abft_score",
-                        types::SubmitAbftScore {
-                            nonce,
-                            score,
-                            signature,
-                        },
+                        types::SubmitAbftScore { score, signature },
                         [
-                            94u8, 155u8, 191u8, 188u8, 112u8, 196u8, 193u8, 140u8, 106u8, 206u8,
-                            196u8, 140u8, 93u8, 129u8, 83u8, 204u8, 117u8, 80u8, 155u8, 115u8,
-                            195u8, 178u8, 98u8, 20u8, 99u8, 169u8, 105u8, 175u8, 220u8, 20u8,
-                            250u8, 216u8,
+                            140u8, 93u8, 130u8, 205u8, 26u8, 91u8, 15u8, 42u8, 114u8, 53u8, 228u8,
+                            197u8, 231u8, 224u8, 63u8, 33u8, 244u8, 230u8, 47u8, 139u8, 127u8,
+                            145u8, 125u8, 127u8, 28u8, 177u8, 132u8, 104u8, 99u8, 65u8, 170u8,
+                            49u8,
                         ],
                     )
                 }
@@ -1438,8 +1433,7 @@ pub mod api {
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
                 pub struct SubmitAbftScore {
-                    pub nonce: ::core::primitive::u32,
-                    pub score: ::std::vec::Vec<::core::primitive::u32>,
+                    pub score: runtime_types::primitives::Score,
                     pub signature: runtime_types::primitives::crypto::SignatureSet<
                         runtime_types::primitives::app::Signature,
                     >,
@@ -2186,9 +2180,9 @@ pub mod api {
             .hash();
         runtime_metadata_hash
             == [
-                31u8, 115u8, 72u8, 107u8, 237u8, 34u8, 72u8, 178u8, 161u8, 241u8, 99u8, 155u8,
-                183u8, 144u8, 34u8, 56u8, 216u8, 36u8, 64u8, 205u8, 84u8, 84u8, 200u8, 224u8, 11u8,
-                175u8, 65u8, 217u8, 190u8, 31u8, 131u8, 7u8,
+                245u8, 41u8, 177u8, 60u8, 14u8, 203u8, 151u8, 173u8, 102u8, 231u8, 167u8, 202u8,
+                19u8, 189u8, 87u8, 204u8, 219u8, 223u8, 82u8, 65u8, 37u8, 97u8, 165u8, 66u8, 176u8,
+                41u8, 235u8, 167u8, 96u8, 163u8, 91u8, 63u8,
             ]
     }
     pub mod system {
@@ -3588,9 +3582,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            165u8, 27u8, 106u8, 96u8, 215u8, 34u8, 194u8, 38u8, 222u8, 251u8, 87u8,
-                            233u8, 206u8, 38u8, 7u8, 160u8, 38u8, 59u8, 88u8, 81u8, 51u8, 178u8,
-                            64u8, 77u8, 100u8, 15u8, 115u8, 13u8, 226u8, 213u8, 68u8, 64u8,
+                            216u8, 135u8, 112u8, 25u8, 28u8, 96u8, 254u8, 189u8, 10u8, 68u8, 63u8,
+                            70u8, 129u8, 143u8, 24u8, 224u8, 139u8, 138u8, 101u8, 9u8, 195u8,
+                            254u8, 122u8, 234u8, 111u8, 149u8, 196u8, 215u8, 158u8, 234u8, 249u8,
+                            91u8,
                         ],
                     )
                 }
@@ -3635,9 +3630,9 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            7u8, 17u8, 174u8, 12u8, 155u8, 32u8, 253u8, 82u8, 232u8, 92u8, 99u8,
-                            131u8, 96u8, 82u8, 41u8, 69u8, 229u8, 164u8, 89u8, 125u8, 163u8, 125u8,
-                            48u8, 22u8, 175u8, 172u8, 239u8, 109u8, 166u8, 236u8, 253u8, 74u8,
+                            129u8, 97u8, 124u8, 53u8, 208u8, 77u8, 131u8, 116u8, 124u8, 70u8,
+                            107u8, 152u8, 57u8, 6u8, 26u8, 80u8, 242u8, 228u8, 193u8, 197u8, 141u8,
+                            32u8, 217u8, 156u8, 58u8, 188u8, 78u8, 49u8, 122u8, 109u8, 108u8, 90u8,
                         ],
                     )
                 }
@@ -3678,10 +3673,9 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            135u8, 84u8, 233u8, 165u8, 40u8, 196u8, 162u8, 29u8, 161u8, 105u8,
-                            230u8, 223u8, 163u8, 137u8, 61u8, 51u8, 159u8, 44u8, 175u8, 83u8,
-                            213u8, 5u8, 38u8, 46u8, 105u8, 222u8, 244u8, 209u8, 237u8, 210u8,
-                            126u8, 78u8,
+                            199u8, 113u8, 220u8, 8u8, 68u8, 3u8, 155u8, 6u8, 219u8, 61u8, 163u8,
+                            6u8, 128u8, 221u8, 78u8, 133u8, 109u8, 21u8, 164u8, 8u8, 96u8, 58u8,
+                            44u8, 222u8, 244u8, 223u8, 136u8, 5u8, 153u8, 242u8, 8u8, 227u8,
                         ],
                     )
                 }
@@ -3708,10 +3702,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            250u8, 250u8, 194u8, 172u8, 227u8, 215u8, 25u8, 167u8, 239u8, 217u8,
-                            84u8, 87u8, 127u8, 88u8, 89u8, 58u8, 21u8, 171u8, 21u8, 243u8, 22u8,
-                            145u8, 81u8, 33u8, 63u8, 232u8, 199u8, 11u8, 252u8, 146u8, 200u8,
-                            225u8,
+                            211u8, 226u8, 125u8, 86u8, 58u8, 192u8, 171u8, 141u8, 35u8, 105u8,
+                            193u8, 21u8, 210u8, 186u8, 30u8, 168u8, 205u8, 206u8, 105u8, 168u8,
+                            15u8, 120u8, 49u8, 156u8, 145u8, 172u8, 215u8, 28u8, 117u8, 137u8,
+                            130u8, 172u8,
                         ],
                     )
                 }
@@ -9482,8 +9476,7 @@ pub mod api {
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
                 pub struct UnsignedSubmitAbftScore {
-                    pub nonce: ::core::primitive::u32,
-                    pub score: ::std::vec::Vec<::core::primitive::u32>,
+                    pub score: runtime_types::primitives::Score,
                     pub signature: runtime_types::primitives::crypto::SignatureSet<
                         runtime_types::primitives::app::Signature,
                     >,
@@ -9557,8 +9550,7 @@ pub mod api {
                 #[doc = "See [`Pallet::unsigned_submit_abft_score`]."]
                 pub fn unsigned_submit_abft_score(
                     &self,
-                    nonce: ::core::primitive::u32,
-                    score: ::std::vec::Vec<::core::primitive::u32>,
+                    score: runtime_types::primitives::Score,
                     signature: runtime_types::primitives::crypto::SignatureSet<
                         runtime_types::primitives::app::Signature,
                     >,
@@ -9566,16 +9558,11 @@ pub mod api {
                     ::subxt::tx::Payload::new_static(
                         "Aleph",
                         "unsigned_submit_abft_score",
-                        types::UnsignedSubmitAbftScore {
-                            nonce,
-                            score,
-                            signature,
-                        },
+                        types::UnsignedSubmitAbftScore { score, signature },
                         [
-                            186u8, 52u8, 102u8, 83u8, 253u8, 148u8, 198u8, 149u8, 138u8, 130u8,
-                            172u8, 140u8, 15u8, 138u8, 184u8, 201u8, 81u8, 190u8, 4u8, 121u8,
-                            141u8, 86u8, 132u8, 138u8, 154u8, 79u8, 56u8, 57u8, 34u8, 128u8, 74u8,
-                            198u8,
+                            149u8, 135u8, 162u8, 2u8, 161u8, 78u8, 158u8, 8u8, 139u8, 206u8, 234u8,
+                            227u8, 54u8, 92u8, 55u8, 189u8, 24u8, 9u8, 192u8, 155u8, 73u8, 105u8,
+                            254u8, 100u8, 95u8, 146u8, 152u8, 55u8, 71u8, 121u8, 56u8, 14u8,
                         ],
                     )
                 }
@@ -9882,7 +9869,7 @@ pub mod api {
                     _0: impl ::std::borrow::Borrow<::core::primitive::u32>,
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
-                    ::std::vec::Vec<::core::primitive::u32>,
+                    runtime_types::primitives::Score,
                     ::subxt::storage::address::Yes,
                     (),
                     ::subxt::storage::address::Yes,
@@ -9894,10 +9881,10 @@ pub mod api {
                             _0.borrow(),
                         )],
                         [
-                            126u8, 203u8, 136u8, 245u8, 160u8, 238u8, 244u8, 23u8, 81u8, 37u8,
-                            177u8, 83u8, 204u8, 204u8, 242u8, 185u8, 215u8, 62u8, 40u8, 79u8,
-                            132u8, 129u8, 230u8, 188u8, 233u8, 103u8, 220u8, 117u8, 11u8, 52u8,
-                            1u8, 0u8,
+                            61u8, 84u8, 105u8, 208u8, 230u8, 198u8, 161u8, 36u8, 58u8, 245u8,
+                            209u8, 88u8, 181u8, 129u8, 209u8, 232u8, 104u8, 24u8, 251u8, 228u8,
+                            160u8, 196u8, 47u8, 202u8, 243u8, 83u8, 96u8, 225u8, 8u8, 125u8, 201u8,
+                            168u8,
                         ],
                     )
                 }
@@ -9905,7 +9892,7 @@ pub mod api {
                     &self,
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
-                    ::std::vec::Vec<::core::primitive::u32>,
+                    runtime_types::primitives::Score,
                     (),
                     (),
                     ::subxt::storage::address::Yes,
@@ -9915,10 +9902,10 @@ pub mod api {
                         "AbftScores",
                         Vec::new(),
                         [
-                            126u8, 203u8, 136u8, 245u8, 160u8, 238u8, 244u8, 23u8, 81u8, 37u8,
-                            177u8, 83u8, 204u8, 204u8, 242u8, 185u8, 215u8, 62u8, 40u8, 79u8,
-                            132u8, 129u8, 230u8, 188u8, 233u8, 103u8, 220u8, 117u8, 11u8, 52u8,
-                            1u8, 0u8,
+                            61u8, 84u8, 105u8, 208u8, 230u8, 198u8, 161u8, 36u8, 58u8, 245u8,
+                            209u8, 88u8, 181u8, 129u8, 209u8, 232u8, 104u8, 24u8, 251u8, 228u8,
+                            160u8, 196u8, 47u8, 202u8, 243u8, 83u8, 96u8, 225u8, 8u8, 125u8, 201u8,
+                            168u8,
                         ],
                     )
                 }
@@ -11899,9 +11886,9 @@ pub mod api {
                         "batch",
                         types::Batch { calls },
                         [
-                            255u8, 25u8, 171u8, 115u8, 188u8, 58u8, 188u8, 1u8, 227u8, 41u8, 148u8,
-                            204u8, 144u8, 84u8, 238u8, 135u8, 117u8, 179u8, 76u8, 236u8, 64u8,
-                            94u8, 167u8, 98u8, 186u8, 4u8, 22u8, 173u8, 123u8, 76u8, 47u8, 206u8,
+                            167u8, 199u8, 32u8, 167u8, 173u8, 231u8, 211u8, 147u8, 35u8, 151u8,
+                            170u8, 32u8, 16u8, 33u8, 73u8, 77u8, 75u8, 56u8, 145u8, 231u8, 106u8,
+                            112u8, 148u8, 37u8, 121u8, 239u8, 3u8, 137u8, 235u8, 46u8, 45u8, 105u8,
                         ],
                     )
                 }
@@ -11919,10 +11906,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            192u8, 135u8, 104u8, 196u8, 1u8, 198u8, 145u8, 235u8, 243u8, 143u8,
-                            223u8, 55u8, 176u8, 15u8, 168u8, 131u8, 149u8, 122u8, 92u8, 78u8,
-                            236u8, 6u8, 170u8, 89u8, 47u8, 173u8, 82u8, 46u8, 192u8, 163u8, 165u8,
-                            230u8,
+                            73u8, 208u8, 17u8, 101u8, 70u8, 127u8, 192u8, 105u8, 34u8, 136u8,
+                            105u8, 253u8, 107u8, 82u8, 175u8, 250u8, 76u8, 173u8, 247u8, 45u8,
+                            20u8, 56u8, 167u8, 127u8, 149u8, 44u8, 120u8, 26u8, 62u8, 87u8, 198u8,
+                            170u8,
                         ],
                     )
                 }
@@ -11936,9 +11923,10 @@ pub mod api {
                         "batch_all",
                         types::BatchAll { calls },
                         [
-                            248u8, 90u8, 145u8, 51u8, 202u8, 156u8, 96u8, 27u8, 25u8, 3u8, 61u8,
-                            44u8, 57u8, 183u8, 222u8, 1u8, 67u8, 150u8, 196u8, 128u8, 61u8, 237u8,
-                            61u8, 90u8, 91u8, 49u8, 41u8, 158u8, 100u8, 96u8, 74u8, 238u8,
+                            5u8, 193u8, 47u8, 75u8, 176u8, 124u8, 248u8, 182u8, 179u8, 167u8,
+                            210u8, 200u8, 92u8, 61u8, 161u8, 196u8, 50u8, 143u8, 252u8, 94u8, 82u8,
+                            188u8, 188u8, 164u8, 151u8, 65u8, 121u8, 227u8, 89u8, 77u8, 119u8,
+                            220u8,
                         ],
                     )
                 }
@@ -11956,10 +11944,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            84u8, 173u8, 58u8, 135u8, 152u8, 65u8, 124u8, 182u8, 195u8, 120u8,
-                            208u8, 228u8, 184u8, 89u8, 107u8, 79u8, 181u8, 41u8, 224u8, 97u8,
-                            200u8, 151u8, 166u8, 159u8, 240u8, 104u8, 35u8, 250u8, 48u8, 207u8,
-                            147u8, 71u8,
+                            254u8, 180u8, 101u8, 177u8, 115u8, 167u8, 61u8, 33u8, 231u8, 195u8,
+                            85u8, 164u8, 250u8, 175u8, 166u8, 63u8, 12u8, 237u8, 100u8, 147u8,
+                            72u8, 210u8, 110u8, 157u8, 187u8, 70u8, 141u8, 132u8, 252u8, 45u8,
+                            135u8, 213u8,
                         ],
                     )
                 }
@@ -11973,9 +11961,9 @@ pub mod api {
                         "force_batch",
                         types::ForceBatch { calls },
                         [
-                            205u8, 70u8, 172u8, 46u8, 208u8, 185u8, 36u8, 80u8, 94u8, 145u8, 13u8,
-                            93u8, 21u8, 96u8, 99u8, 28u8, 115u8, 212u8, 34u8, 177u8, 88u8, 198u8,
-                            239u8, 55u8, 68u8, 8u8, 18u8, 68u8, 170u8, 137u8, 17u8, 102u8,
+                            254u8, 0u8, 228u8, 197u8, 56u8, 90u8, 56u8, 106u8, 14u8, 122u8, 228u8,
+                            149u8, 13u8, 64u8, 104u8, 114u8, 140u8, 251u8, 27u8, 239u8, 6u8, 241u8,
+                            124u8, 157u8, 164u8, 148u8, 127u8, 75u8, 3u8, 205u8, 182u8, 90u8,
                         ],
                     )
                 }
@@ -11993,10 +11981,9 @@ pub mod api {
                             weight,
                         },
                         [
-                            16u8, 51u8, 36u8, 198u8, 117u8, 113u8, 103u8, 115u8, 173u8, 203u8,
-                            153u8, 251u8, 204u8, 63u8, 86u8, 190u8, 248u8, 235u8, 235u8, 126u8,
-                            236u8, 38u8, 32u8, 53u8, 59u8, 114u8, 153u8, 252u8, 106u8, 170u8,
-                            157u8, 82u8,
+                            253u8, 2u8, 221u8, 250u8, 223u8, 123u8, 175u8, 166u8, 70u8, 21u8, 38u8,
+                            9u8, 82u8, 89u8, 170u8, 1u8, 247u8, 239u8, 227u8, 237u8, 21u8, 250u8,
+                            14u8, 104u8, 142u8, 240u8, 231u8, 91u8, 111u8, 162u8, 219u8, 106u8,
                         ],
                     )
                 }
@@ -12286,10 +12273,9 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            180u8, 107u8, 52u8, 246u8, 196u8, 80u8, 104u8, 216u8, 238u8, 186u8,
-                            213u8, 16u8, 8u8, 68u8, 51u8, 38u8, 249u8, 45u8, 18u8, 43u8, 115u8,
-                            143u8, 60u8, 104u8, 146u8, 77u8, 196u8, 57u8, 181u8, 143u8, 108u8,
-                            241u8,
+                            76u8, 120u8, 75u8, 99u8, 8u8, 58u8, 75u8, 70u8, 35u8, 51u8, 196u8,
+                            250u8, 220u8, 200u8, 108u8, 243u8, 177u8, 70u8, 221u8, 143u8, 98u8,
+                            192u8, 7u8, 198u8, 92u8, 9u8, 34u8, 111u8, 107u8, 250u8, 16u8, 201u8,
                         ],
                     )
                 }
@@ -12317,10 +12303,9 @@ pub mod api {
                             max_weight,
                         },
                         [
-                            183u8, 90u8, 166u8, 148u8, 242u8, 150u8, 206u8, 13u8, 194u8, 168u8,
-                            27u8, 98u8, 29u8, 131u8, 154u8, 243u8, 152u8, 14u8, 201u8, 214u8,
-                            250u8, 229u8, 94u8, 49u8, 76u8, 71u8, 175u8, 234u8, 84u8, 119u8, 167u8,
-                            54u8,
+                            187u8, 105u8, 129u8, 75u8, 77u8, 227u8, 172u8, 6u8, 150u8, 105u8,
+                            222u8, 34u8, 99u8, 14u8, 136u8, 54u8, 168u8, 73u8, 203u8, 65u8, 75u8,
+                            159u8, 81u8, 184u8, 30u8, 52u8, 232u8, 10u8, 1u8, 184u8, 242u8, 51u8,
                         ],
                     )
                 }
@@ -12733,9 +12718,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            94u8, 179u8, 34u8, 76u8, 99u8, 239u8, 208u8, 173u8, 98u8, 153u8, 79u8,
-                            195u8, 128u8, 15u8, 63u8, 162u8, 16u8, 137u8, 39u8, 75u8, 39u8, 185u8,
-                            155u8, 24u8, 129u8, 84u8, 62u8, 195u8, 75u8, 212u8, 230u8, 193u8,
+                            196u8, 155u8, 161u8, 8u8, 124u8, 41u8, 123u8, 119u8, 153u8, 212u8,
+                            106u8, 212u8, 87u8, 141u8, 120u8, 39u8, 106u8, 105u8, 67u8, 242u8,
+                            50u8, 29u8, 35u8, 179u8, 209u8, 150u8, 177u8, 233u8, 99u8, 23u8, 167u8,
+                            243u8,
                         ],
                     )
                 }
@@ -12753,9 +12739,10 @@ pub mod api {
                             weight,
                         },
                         [
-                            228u8, 23u8, 85u8, 101u8, 132u8, 89u8, 12u8, 170u8, 209u8, 1u8, 195u8,
-                            26u8, 33u8, 220u8, 134u8, 99u8, 52u8, 18u8, 187u8, 234u8, 109u8, 200u8,
-                            238u8, 212u8, 99u8, 46u8, 74u8, 36u8, 203u8, 25u8, 165u8, 63u8,
+                            245u8, 117u8, 70u8, 152u8, 64u8, 216u8, 73u8, 166u8, 126u8, 167u8,
+                            247u8, 15u8, 102u8, 35u8, 255u8, 180u8, 41u8, 193u8, 181u8, 95u8,
+                            114u8, 240u8, 124u8, 87u8, 148u8, 79u8, 108u8, 160u8, 208u8, 80u8,
+                            140u8, 47u8,
                         ],
                     )
                 }
@@ -12795,9 +12782,9 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            111u8, 20u8, 41u8, 236u8, 152u8, 223u8, 2u8, 13u8, 148u8, 80u8, 249u8,
-                            33u8, 79u8, 130u8, 79u8, 22u8, 193u8, 29u8, 201u8, 118u8, 103u8, 7u8,
-                            50u8, 208u8, 189u8, 78u8, 77u8, 137u8, 38u8, 254u8, 34u8, 107u8,
+                            0u8, 125u8, 64u8, 32u8, 109u8, 35u8, 27u8, 146u8, 105u8, 178u8, 140u8,
+                            15u8, 175u8, 240u8, 145u8, 184u8, 226u8, 56u8, 123u8, 155u8, 78u8,
+                            127u8, 127u8, 153u8, 125u8, 96u8, 245u8, 33u8, 98u8, 141u8, 11u8, 41u8,
                         ],
                     )
                 }
@@ -19105,9 +19092,9 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            61u8, 199u8, 160u8, 155u8, 131u8, 73u8, 44u8, 87u8, 169u8, 42u8, 139u8,
-                            197u8, 19u8, 21u8, 70u8, 75u8, 101u8, 245u8, 238u8, 127u8, 222u8, 46u8,
-                            67u8, 136u8, 192u8, 84u8, 71u8, 235u8, 166u8, 131u8, 93u8, 157u8,
+                            206u8, 64u8, 21u8, 122u8, 18u8, 20u8, 116u8, 15u8, 191u8, 125u8, 72u8,
+                            140u8, 119u8, 10u8, 93u8, 222u8, 79u8, 7u8, 132u8, 26u8, 202u8, 176u8,
+                            83u8, 51u8, 226u8, 223u8, 164u8, 192u8, 42u8, 152u8, 124u8, 135u8,
                         ],
                     )
                 }
@@ -19319,10 +19306,10 @@ pub mod api {
                             call: ::std::boxed::Box::new(call),
                         },
                         [
-                            140u8, 203u8, 152u8, 185u8, 223u8, 204u8, 168u8, 117u8, 144u8, 255u8,
-                            114u8, 76u8, 9u8, 9u8, 198u8, 187u8, 151u8, 203u8, 226u8, 122u8, 130u8,
-                            159u8, 19u8, 59u8, 102u8, 188u8, 235u8, 243u8, 127u8, 56u8, 126u8,
-                            161u8,
+                            202u8, 188u8, 166u8, 130u8, 234u8, 235u8, 200u8, 156u8, 5u8, 215u8,
+                            139u8, 126u8, 198u8, 252u8, 176u8, 150u8, 169u8, 118u8, 243u8, 33u8,
+                            105u8, 220u8, 199u8, 65u8, 20u8, 117u8, 124u8, 157u8, 250u8, 109u8,
+                            124u8, 87u8,
                         ],
                     )
                 }
@@ -21696,8 +21683,7 @@ pub mod api {
                     #[codec(index = 3)]
                     #[doc = "See [`Pallet::unsigned_submit_abft_score`]."]
                     unsigned_submit_abft_score {
-                        nonce: ::core::primitive::u32,
-                        score: ::std::vec::Vec<::core::primitive::u32>,
+                        score: runtime_types::primitives::Score,
                         signature: runtime_types::primitives::crypto::SignatureSet<
                             runtime_types::primitives::app::Signature,
                         >,
@@ -27525,6 +27511,24 @@ pub mod api {
             pub struct EraValidators<_0> {
                 pub reserved: ::std::vec::Vec<_0>,
                 pub non_reserved: ::std::vec::Vec<_0>,
+            }
+            #[derive(
+                :: subxt :: ext :: codec :: Decode,
+                :: subxt :: ext :: codec :: Encode,
+                :: subxt :: ext :: scale_decode :: DecodeAsType,
+                :: subxt :: ext :: scale_encode :: EncodeAsType,
+                Clone,
+                Debug,
+                Eq,
+                PartialEq,
+            )]
+            # [codec (crate = :: subxt :: ext :: codec)]
+            #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
+            #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
+            pub struct Score {
+                pub session_id: ::core::primitive::u32,
+                pub nonce: ::core::primitive::u32,
+                pub points: ::std::vec::Vec<::core::primitive::u32>,
             }
             #[derive(
                 :: subxt :: ext :: codec :: Decode,

--- a/bin/fake-runtime-api/src/lib.rs
+++ b/bin/fake-runtime-api/src/lib.rs
@@ -9,8 +9,8 @@ use pallet_transaction_payment::FeeDetails;
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
 use primitives::{
     AccountId, ApiError as AlephApiError, AuraId, AuthorityId as AlephId, Balance, Block, Nonce,
-    Perbill, Round, Score, ScoreSignature, SessionAuthorityData, SessionCommittee, SessionIndex,
-    SessionValidatorError, Version as FinalityVersion,
+    Perbill, Score, ScoreNonce, ScoreSignature, SessionAuthorityData, SessionCommittee,
+    SessionIndex, SessionValidatorError, Version as FinalityVersion,
 };
 use sp_consensus_aura::SlotDuration;
 use sp_core::OpaqueMetadata;
@@ -196,7 +196,7 @@ pub mod fake_runtime {
                 unimplemented!()
             }
 
-            fn submit_abft_score(_round: Round, _score: Score, _signature: ScoreSignature) -> Option<()>{
+            fn submit_abft_score(_nonce: ScoreNonce, _score: Score, _signature: ScoreSignature) -> Option<()>{
                 unimplemented!()
             }
         }

--- a/bin/fake-runtime-api/src/lib.rs
+++ b/bin/fake-runtime-api/src/lib.rs
@@ -8,9 +8,9 @@ use pallet_aleph_runtime_api::*;
 use pallet_transaction_payment::FeeDetails;
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
 use primitives::{
-    AccountId, ApiError as AlephApiError, AuraId, AuthorityId as AlephId, Balance, Block, Nonce,
-    Perbill, Score, ScoreNonce, ScoreSignature, SessionAuthorityData, SessionCommittee,
-    SessionIndex, SessionValidatorError, Version as FinalityVersion,
+    crypto::SignatureSet, AccountId, ApiError as AlephApiError, AuraId, AuthorityId as AlephId,
+    AuthoritySignature, Balance, Block, Nonce, Perbill, Score, ScoreNonce, SessionAuthorityData,
+    SessionCommittee, SessionIndex, SessionValidatorError, Version as FinalityVersion,
 };
 use sp_consensus_aura::SlotDuration;
 use sp_core::OpaqueMetadata;
@@ -196,7 +196,7 @@ pub mod fake_runtime {
                 unimplemented!()
             }
 
-            fn submit_abft_score(_nonce: ScoreNonce, _score: Score, _signature: ScoreSignature) -> Option<()>{
+            fn submit_abft_score(_nonce: ScoreNonce, _score: Score, _signature: SignatureSet<AuthoritySignature>) -> Option<()>{
                 unimplemented!()
             }
         }

--- a/bin/fake-runtime-api/src/lib.rs
+++ b/bin/fake-runtime-api/src/lib.rs
@@ -9,7 +9,7 @@ use pallet_transaction_payment::FeeDetails;
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
 use primitives::{
     crypto::SignatureSet, AccountId, ApiError as AlephApiError, AuraId, AuthorityId as AlephId,
-    AuthoritySignature, Balance, Block, Nonce, Perbill, Score, ScoreNonce, SessionAuthorityData,
+    AuthoritySignature, Balance, Block, Nonce, Perbill, Score, SessionAuthorityData,
     SessionCommittee, SessionIndex, SessionValidatorError, Version as FinalityVersion,
 };
 use sp_consensus_aura::SlotDuration;
@@ -196,7 +196,7 @@ pub mod fake_runtime {
                 unimplemented!()
             }
 
-            fn submit_abft_score(_nonce: ScoreNonce, _score: Score, _signature: SignatureSet<AuthoritySignature>) -> Option<()>{
+            fn submit_abft_score(_score: Score, _signature: SignatureSet<AuthoritySignature>) -> Option<()>{
                 unimplemented!()
             }
         }

--- a/bin/fake-runtime-api/src/lib.rs
+++ b/bin/fake-runtime-api/src/lib.rs
@@ -9,8 +9,8 @@ use pallet_transaction_payment::FeeDetails;
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
 use primitives::{
     AccountId, ApiError as AlephApiError, AuraId, AuthorityId as AlephId, Balance, Block, Nonce,
-    Perbill, SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError,
-    Version as FinalityVersion,
+    Perbill, Round, Score, ScoreSignature, SessionAuthorityData, SessionCommittee, SessionIndex,
+    SessionValidatorError, Version as FinalityVersion,
 };
 use sp_consensus_aura::SlotDuration;
 use sp_core::OpaqueMetadata;
@@ -193,6 +193,10 @@ pub mod fake_runtime {
             }
 
             fn current_era_payout() -> (Balance, Balance) {
+                unimplemented!()
+            }
+
+            fn submit_abft_score(_round: Round, _score: Score, _signature: ScoreSignature) -> Option<()>{
                 unimplemented!()
             }
         }

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -44,9 +44,9 @@ use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustm
 use pallet_tx_pause::RuntimeCallNameOf;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use primitives::{
-    staking::MAX_NOMINATORS_REWARDED_PER_VALIDATOR, wrap_methods, Address,
+    crypto::SignatureSet, staking::MAX_NOMINATORS_REWARDED_PER_VALIDATOR, wrap_methods, Address,
     AlephNodeSessionKeys as SessionKeys, ApiError as AlephApiError, AuraId, AuthorityId as AlephId,
-    BlockNumber as AlephBlockNumber, Header as AlephHeader, Score, ScoreNonce, ScoreSignature,
+    AuthoritySignature, BlockNumber as AlephBlockNumber, Header as AlephHeader, Score, ScoreNonce,
     SessionAuthorityData, SessionCommittee, SessionIndex, SessionInfoProvider,
     SessionValidatorError, TotalIssuanceProvider as TotalIssuanceProviderT,
     Version as FinalityVersion, ADDRESSES_ENCODING, DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS,
@@ -1239,7 +1239,7 @@ impl_runtime_apis! {
             ExponentialEraPayout::era_payout(total_issuance, MILLISECONDS_PER_ERA)
         }
 
-        fn submit_abft_score(nonce: ScoreNonce, score: Score, signature: ScoreSignature) -> Option<()> {
+        fn submit_abft_score(nonce: ScoreNonce, score: Score, signature: SignatureSet<AuthoritySignature>) -> Option<()> {
             Aleph::submit_abft_score(nonce, score, signature)
         }
     }

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -46,7 +46,7 @@ use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use primitives::{
     staking::MAX_NOMINATORS_REWARDED_PER_VALIDATOR, wrap_methods, Address,
     AlephNodeSessionKeys as SessionKeys, ApiError as AlephApiError, AuraId, AuthorityId as AlephId,
-    BlockNumber as AlephBlockNumber, Header as AlephHeader, Round, Score, ScoreSignature,
+    BlockNumber as AlephBlockNumber, Header as AlephHeader, Score, ScoreNonce, ScoreSignature,
     SessionAuthorityData, SessionCommittee, SessionIndex, SessionInfoProvider,
     SessionValidatorError, TotalIssuanceProvider as TotalIssuanceProviderT,
     Version as FinalityVersion, ADDRESSES_ENCODING, DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS,
@@ -1239,8 +1239,8 @@ impl_runtime_apis! {
             ExponentialEraPayout::era_payout(total_issuance, MILLISECONDS_PER_ERA)
         }
 
-        fn submit_abft_score(round: Round, score: Score, signature: ScoreSignature) -> Option<()> {
-            Aleph::submit_abft_score(round, score, signature)
+        fn submit_abft_score(nonce: ScoreNonce, score: Score, signature: ScoreSignature) -> Option<()> {
+            Aleph::submit_abft_score(nonce, score, signature)
         }
     }
 

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -46,11 +46,11 @@ use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use primitives::{
     staking::MAX_NOMINATORS_REWARDED_PER_VALIDATOR, wrap_methods, Address,
     AlephNodeSessionKeys as SessionKeys, ApiError as AlephApiError, AuraId, AuthorityId as AlephId,
-    BlockNumber as AlephBlockNumber, Header as AlephHeader, SessionAuthorityData, SessionCommittee,
-    SessionIndex, SessionInfoProvider, SessionValidatorError,
-    TotalIssuanceProvider as TotalIssuanceProviderT, Version as FinalityVersion,
-    ADDRESSES_ENCODING, DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS, DEFAULT_SESSIONS_PER_ERA,
-    DEFAULT_SESSION_PERIOD, MAX_BLOCK_SIZE, MILLISECS_PER_BLOCK, TOKEN,
+    BlockNumber as AlephBlockNumber, Header as AlephHeader, Round, Score, ScoreSignature,
+    SessionAuthorityData, SessionCommittee, SessionIndex, SessionInfoProvider,
+    SessionValidatorError, TotalIssuanceProvider as TotalIssuanceProviderT,
+    Version as FinalityVersion, ADDRESSES_ENCODING, DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS,
+    DEFAULT_SESSIONS_PER_ERA, DEFAULT_SESSION_PERIOD, MAX_BLOCK_SIZE, MILLISECS_PER_BLOCK, TOKEN,
 };
 pub use primitives::{AccountId, AccountIndex, Balance, Hash, Nonce, Signature};
 use sp_api::impl_runtime_apis;
@@ -1237,6 +1237,10 @@ impl_runtime_apis! {
             let total_issuance = pallet_balances::Pallet::<Runtime>::total_issuance();
 
             ExponentialEraPayout::era_payout(total_issuance, MILLISECONDS_PER_ERA)
+        }
+
+        fn submit_abft_score(round: Round, score: Score, signature: ScoreSignature) -> Option<()> {
+            Aleph::submit_abft_score(round, score, signature)
         }
     }
 

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -80,10 +80,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 15_000_000,
+    spec_version: 16_000_000,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 18,
+    transaction_version: 19,
     state_version: 0,
 };
 

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -46,7 +46,7 @@ use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use primitives::{
     crypto::SignatureSet, staking::MAX_NOMINATORS_REWARDED_PER_VALIDATOR, wrap_methods, Address,
     AlephNodeSessionKeys as SessionKeys, ApiError as AlephApiError, AuraId, AuthorityId as AlephId,
-    AuthoritySignature, BlockNumber as AlephBlockNumber, Header as AlephHeader, Score, ScoreNonce,
+    AuthoritySignature, BlockNumber as AlephBlockNumber, Header as AlephHeader, Score,
     SessionAuthorityData, SessionCommittee, SessionIndex, SessionInfoProvider,
     SessionValidatorError, TotalIssuanceProvider as TotalIssuanceProviderT,
     Version as FinalityVersion, ADDRESSES_ENCODING, DEFAULT_BAN_REASON_LENGTH, DEFAULT_MAX_WINNERS,
@@ -1239,8 +1239,8 @@ impl_runtime_apis! {
             ExponentialEraPayout::era_payout(total_issuance, MILLISECONDS_PER_ERA)
         }
 
-        fn submit_abft_score(nonce: ScoreNonce, score: Score, signature: SignatureSet<AuthoritySignature>) -> Option<()> {
-            Aleph::submit_abft_score(nonce, score, signature)
+        fn submit_abft_score(score: Score, signature: SignatureSet<AuthoritySignature>) -> Option<()> {
+            Aleph::submit_abft_score(score, signature)
         }
     }
 

--- a/finality-aleph/src/abft/mod.rs
+++ b/finality-aleph/src/abft/mod.rs
@@ -80,7 +80,7 @@ impl<S: 'static> IntoIterator for SignatureSet<S> {
 
 impl From<SignatureSet<Signature>> for PrimitivesSignatureSet<AuthoritySignature> {
     fn from(signature_set: SignatureSet<Signature>) -> PrimitivesSignatureSet<AuthoritySignature> {
-        let score_sigantures: Vec<IndexedSignature<AuthoritySignature>> = signature_set
+        let score_signatures: Vec<IndexedSignature<AuthoritySignature>> = signature_set
             .0
             .into_iter()
             .map(|(idx, s)| IndexedSignature {
@@ -88,7 +88,7 @@ impl From<SignatureSet<Signature>> for PrimitivesSignatureSet<AuthoritySignature
                 signature: s.0,
             })
             .collect();
-        PrimitivesSignatureSet(score_sigantures)
+        PrimitivesSignatureSet(score_signatures)
     }
 }
 

--- a/pallets/aleph-runtime-api/src/lib.rs
+++ b/pallets/aleph-runtime-api/src/lib.rs
@@ -2,9 +2,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use primitives::{
-    crypto::SignatureSet, AccountId, ApiError, AuthorityId, AuthoritySignature, Balance, Nonce,
-    Perbill, Score, SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError,
-    Version,
+    crypto::SignatureSet, AccountId, ApiError, AuthorityId, AuthoritySignature, Balance, Perbill,
+    Score, SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError, Version,
 };
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_std::vec::Vec;
@@ -39,6 +38,6 @@ sp_api::decl_runtime_apis! {
         /// Returns payout. First tuple item is a validators payout, 2nd is the rest.
         fn current_era_payout() -> (Balance, Balance);
         /// Submits score for a nonce in a session of performance of finality committee members.
-        fn submit_abft_score(nonce: Nonce, score: Score, signature: SignatureSet<AuthoritySignature>) -> Option<()>;
+        fn submit_abft_score(score: Score, signature: SignatureSet<AuthoritySignature>) -> Option<()>;
     }
 }

--- a/pallets/aleph-runtime-api/src/lib.rs
+++ b/pallets/aleph-runtime-api/src/lib.rs
@@ -2,8 +2,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use primitives::{
-    AccountId, ApiError, AuthorityId, Balance, Nonce, Perbill, Score, ScoreSignature,
-    SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError, Version,
+    crypto::SignatureSet, AccountId, ApiError, AuthorityId, AuthoritySignature, Balance, Nonce,
+    Perbill, Score, SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError,
+    Version,
 };
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_std::vec::Vec;
@@ -38,6 +39,6 @@ sp_api::decl_runtime_apis! {
         /// Returns payout. First tuple item is a validators payout, 2nd is the rest.
         fn current_era_payout() -> (Balance, Balance);
         /// Submits score for a nonce in a session of performance of finality committee members.
-        fn submit_abft_score(nonce: Nonce, score: Score, signature: ScoreSignature) -> Option<()>;
+        fn submit_abft_score(nonce: Nonce, score: Score, signature: SignatureSet<AuthoritySignature>) -> Option<()>;
     }
 }

--- a/pallets/aleph-runtime-api/src/lib.rs
+++ b/pallets/aleph-runtime-api/src/lib.rs
@@ -2,8 +2,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use primitives::{
-    AccountId, ApiError, AuthorityId, Balance, Perbill, SessionAuthorityData, SessionCommittee,
-    SessionIndex, SessionValidatorError, Version,
+    AccountId, ApiError, AuthorityId, Balance, Perbill, Round, Score, ScoreSignature,
+    SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError, Version,
 };
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_std::vec::Vec;
@@ -37,5 +37,7 @@ sp_api::decl_runtime_apis! {
         fn yearly_inflation() -> Perbill;
         /// Returns payout. First tuple item is a validators payout, 2nd is the rest.
         fn current_era_payout() -> (Balance, Balance);
+        /// Submits score for a round in a session of performance of finality committee members.
+        fn submit_abft_score(round: Round, score: Score, signature: ScoreSignature) -> Option<()>;
     }
 }

--- a/pallets/aleph-runtime-api/src/lib.rs
+++ b/pallets/aleph-runtime-api/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use primitives::{
-    AccountId, ApiError, AuthorityId, Balance, Perbill, Round, Score, ScoreSignature,
+    AccountId, ApiError, AuthorityId, Balance, Nonce, Perbill, Score, ScoreSignature,
     SessionAuthorityData, SessionCommittee, SessionIndex, SessionValidatorError, Version,
 };
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -37,7 +37,7 @@ sp_api::decl_runtime_apis! {
         fn yearly_inflation() -> Perbill;
         /// Returns payout. First tuple item is a validators payout, 2nd is the rest.
         fn current_era_payout() -> (Balance, Balance);
-        /// Submits score for a round in a session of performance of finality committee members.
-        fn submit_abft_score(round: Round, score: Score, signature: ScoreSignature) -> Option<()>;
+        /// Submits score for a nonce in a session of performance of finality committee members.
+        fn submit_abft_score(nonce: Nonce, score: Score, signature: ScoreSignature) -> Option<()>;
     }
 }

--- a/pallets/aleph/Cargo.toml
+++ b/pallets/aleph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-aleph"
-version = "0.6.0"
+version = "0.7.0"
 license = "Apache 2.0"
 authors.workspace = true
 edition.workspace = true

--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -451,7 +451,7 @@ pub mod pallet {
         pub fn unsigned_submit_abft_score(
             origin: OriginFor<T>,
             score: Score,
-            _signature: SignatureSet<Signature<T>>, // We don't check signature as it was already checked
+            _signature: SignatureSet<Signature<T>>, // We don't check signature as it was checked by ValidateUnsigned trait
         ) -> DispatchResultWithPostInfo {
             ensure_none(origin)?;
             Self::check_session_id(score.session_id).map_err(|e| DispatchError::Other(e.into()))?;

--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -39,9 +39,7 @@ pub mod pallet {
         pallet_prelude::{BlockNumberFor, OriginFor},
     };
     use pallet_session::SessionManager;
-    use primitives::{
-        Score, ScoreNonce, SessionInfoProvider, TotalIssuanceProvider,
-    };
+    use primitives::{Score, ScoreNonce, SessionInfoProvider, TotalIssuanceProvider};
     use sp_runtime::traits::ValidateUnsigned;
     use sp_std::collections::btree_map::BTreeMap;
     #[cfg(feature = "std")]
@@ -320,6 +318,7 @@ pub mod pallet {
             Ok(())
         }
 
+        // Add session id
         fn check_score(
             nonce: &ScoreNonce,
             score: &Score,

--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -481,7 +481,7 @@ pub mod pallet {
                 Self::check_score(nonce, score, signature)?;
                 ValidTransaction::with_tag_prefix("AbftScore")
                     .priority(*nonce as u64) // this ensures that later nonces are first in tx queue
-                    .longevity(TransactionLongevity::max_value()) // consider restricting longevity
+                    .longevity(TransactionLongevity::MAX) // consider restricting longevity
                     .propagate(true)
                     .build()
             } else {

--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -52,7 +52,9 @@ pub mod pallet {
 
     #[pallet::config]
     pub trait Config:
-        frame_system::Config + frame_system::offchain::SendTransactionTypes<Call<Self>>
+        frame_system::Config
+        + frame_system::offchain::SendTransactionTypes<Call<Self>>
+        + pallet_session::Config
     {
         type AuthorityId: Member + Parameter + RuntimeAppPublic + MaybeSerializeDeserialize;
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
@@ -324,14 +326,14 @@ pub mod pallet {
             signature: &ScoreSignature,
         ) -> Result<(), TransactionValidityError> {
             Self::check_nonce(nonce)?;
-            Self::verify_score(nonce, score, sgn)?;
+            Self::verify_score(nonce, score, signature)?;
 
             Ok(())
         }
 
         pub fn verify_score(
-            nonce: ScoreNonce,
-            score: Score,
+            nonce: &ScoreNonce,
+            score: &Score,
             sgn: &SignatureSet<Signature<T>>,
         ) -> Result<(), TransactionValidityError> {
             let session_id = pallet_session::Pallet::<T>::current_index();

--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -444,7 +444,7 @@ pub mod pallet {
             Ok(())
         }
 
-        // fix weight
+        // fix weight, take into account validate_unsigned
         #[pallet::call_index(3)]
         #[pallet::weight(T::BlockWeights::get().max_block * Perbill::from_percent(10))]
         /// Stores abft score
@@ -454,8 +454,6 @@ pub mod pallet {
             _signature: SignatureSet<Signature<T>>, // We don't check signature as it was checked by ValidateUnsigned trait
         ) -> DispatchResultWithPostInfo {
             ensure_none(origin)?;
-            Self::check_session_id(score.session_id).map_err(|e| DispatchError::Other(e.into()))?;
-            Self::check_nonce(score.nonce).map_err(|e| DispatchError::Other(e.into()))?;
 
             <LastScoreNonce<T>>::put(score.nonce);
             AbftScores::<T>::insert(score.session_id, score);
@@ -478,14 +476,6 @@ pub mod pallet {
                     .build()
             } else {
                 InvalidTransaction::Call.into()
-            }
-        }
-
-        fn pre_dispatch(call: &Self::Call) -> Result<(), TransactionValidityError> {
-            if let Call::unsigned_submit_abft_score { score, signature } = call {
-                Self::check_score(score, signature)
-            } else {
-                Err(InvalidTransaction::Call.into())
             }
         }
     }

--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -141,7 +141,7 @@ pub mod pallet {
     // clear this storage on session end
     #[pallet::storage]
     #[pallet::getter(fn abft_scores)]
-    pub type AbftScores<T: Config> = StorageMap<_, Twox64Concat, ScoreNonce, Score>;
+    pub type AbftScores<T: Config> = StorageMap<_, Twox64Concat, SessionIndex, Score>;
 
     #[pallet::storage]
     #[pallet::getter(fn last_score_nonce)]
@@ -458,7 +458,7 @@ pub mod pallet {
             Self::check_nonce(score.nonce).map_err(|e| DispatchError::Other(e.into()))?;
 
             <LastScoreNonce<T>>::put(score.nonce);
-            AbftScores::<T>::insert(score.nonce, score);
+            AbftScores::<T>::insert(score.session_id, score);
 
             Ok(Pays::No.into())
         }

--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -329,7 +329,11 @@ pub mod pallet {
             Ok(())
         }
 
-        pub fn verify_score(nonce: ScoreNonce, score: Score, sgn: &SignatureSet<Signature<T>>) -> Result<(), TransactionValidityError>{
+        pub fn verify_score(
+            nonce: ScoreNonce,
+            score: Score,
+            sgn: &SignatureSet<Signature<T>>,
+        ) -> Result<(), TransactionValidityError> {
             let session_id = pallet_session::Pallet::<T>::current_index();
             let msg = (session_id, nonce, score).encode();
             let authority_verifier = AuthorityVerifier::new(Self::authorities());

--- a/pallets/aleph/src/lib.rs
+++ b/pallets/aleph/src/lib.rs
@@ -50,9 +50,7 @@ pub mod pallet {
 
     #[pallet::config]
     pub trait Config:
-        frame_system::Config
-        + frame_system::offchain::SendTransactionTypes<Call<Self>>
-        + pallet_session::Config
+        frame_system::Config + frame_system::offchain::SendTransactionTypes<Call<Self>>
     {
         type AuthorityId: Member + Parameter + RuntimeAppPublic + MaybeSerializeDeserialize;
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
@@ -311,7 +309,7 @@ pub mod pallet {
         }
 
         fn check_session_id(session_id: SessionIndex) -> Result<(), TransactionValidityError> {
-            let current_session_id = pallet_session::Pallet::<T>::current_index();
+            let current_session_id = Self::current_session();
             if current_session_id < session_id {
                 return Err(InvalidTransaction::Future.into());
             }
@@ -363,12 +361,6 @@ pub mod pallet {
             let call = Call::unsigned_submit_abft_score { score, signature };
             SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()).ok()
         }
-    }
-
-    #[pallet::error]
-    pub enum Error<T> {
-        /// Duplicated score in the same block
-        DuplicatedScore,
     }
 
     #[pallet::call]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -428,13 +428,13 @@ pub mod crypto {
 
     use super::AuthoritySignature;
 
-    #[derive(Decode, Encode, TypeInfo, Debug, Clone)]
+    #[derive(PartialEq, Decode, Encode, TypeInfo, Debug, Clone)]
     pub struct IndexedSignature<S> {
         pub index: u64,
         pub signature: S,
     }
 
-    #[derive(Decode, Encode, TypeInfo, Debug, Clone)]
+    #[derive(PartialEq, Decode, Encode, TypeInfo, Debug, Clone)]
     pub struct SignatureSet<S>(pub Vec<IndexedSignature<S>>);
 
     #[cfg_attr(feature = "std", derive(Hash))]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -416,7 +416,6 @@ pub mod staking {
 
 pub type Score = Vec<u32>;
 pub type ScoreNonce = u32;
-pub type ScoreSignature = u64;
 
 pub mod crypto {
     use core::marker::PhantomData;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -413,3 +413,7 @@ pub mod staking {
         };
     }
 }
+
+pub type Score = Vec<u32>;
+pub type Round = u32;
+pub type ScoreSignature = u64;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -414,8 +414,14 @@ pub mod staking {
     }
 }
 
-pub type Score = Vec<u32>;
 pub type ScoreNonce = u32;
+
+#[derive(PartialEq, Decode, Encode, TypeInfo, Debug, Clone)]
+pub struct Score {
+    pub session_id: SessionIndex,
+    pub nonce: ScoreNonce,
+    pub points: Vec<u32>,
+}
 
 pub mod crypto {
     use core::marker::PhantomData;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -415,5 +415,5 @@ pub mod staking {
 }
 
 pub type Score = Vec<u32>;
-pub type Round = u32;
+pub type ScoreNonce = u32;
 pub type ScoreSignature = u64;


### PR DESCRIPTION
# Description

Adds runtime api for the client side to store abft performance scores on chain. It's implemented using unsigned transactions since finality committee is considerably smaller than block production committee.

## Type of change

- New feature (non-breaking change which adds functionality)
