### PR TITLE
A0-4579: Add ABFT scoring service, currently doing nothing

### DIFF
--- a/finality-aleph/src/abft/current/performance/mod.rs
+++ b/finality-aleph/src/abft/current/performance/mod.rs
@@ -1,0 +1,7 @@
+use crate::{data_io::AlephData, Hasher};
+
+mod service;
+
+pub use service::Service;
+
+type Batch<UH> = Vec<current_aleph_bft::OrderedUnit<AlephData<UH>, Hasher>>;

--- a/finality-aleph/src/abft/current/performance/service.rs
+++ b/finality-aleph/src/abft/current/performance/service.rs
@@ -1,0 +1,105 @@
+use futures::{
+    channel::{mpsc, oneshot},
+    StreamExt,
+};
+use log::{debug, warn};
+
+use crate::{
+    abft::{current::performance::Batch, LOG_TARGET},
+    data_io::AlephData,
+    party::manager::Runnable,
+    Hasher, UnverifiedHeader,
+};
+
+struct FinalizationWrapper<UH, FH>
+where
+    UH: UnverifiedHeader,
+    FH: current_aleph_bft::FinalizationHandler<AlephData<UH>>,
+{
+    finalization_handler: FH,
+    batches_for_scorer: mpsc::UnboundedSender<Batch<UH>>,
+}
+
+impl<UH, FH> FinalizationWrapper<UH, FH>
+where
+    UH: UnverifiedHeader,
+    FH: current_aleph_bft::FinalizationHandler<AlephData<UH>>,
+{
+    fn new(finalization_handler: FH, batches_for_scorer: mpsc::UnboundedSender<Batch<UH>>) -> Self {
+        FinalizationWrapper {
+            finalization_handler,
+            batches_for_scorer,
+        }
+    }
+}
+
+impl<UH, FH> current_aleph_bft::UnitFinalizationHandler for FinalizationWrapper<UH, FH>
+where
+    UH: UnverifiedHeader,
+    FH: current_aleph_bft::FinalizationHandler<AlephData<UH>>,
+{
+    type Data = AlephData<UH>;
+    type Hasher = Hasher;
+
+    fn batch_finalized(&mut self, batch: Batch<UH>) {
+        for unit in &batch {
+            if let Some(data) = &unit.data {
+                self.finalization_handler.data_finalized(data.clone())
+            }
+        }
+        if let Err(err) = self.batches_for_scorer.unbounded_send(batch) {
+            warn!(target: LOG_TARGET, "Failed to send ABFT batch to performance scoring: {}.", err);
+        }
+    }
+}
+
+/// A service computing the performance score of ABFT nodes based on batches of ordered units.
+pub struct Service<UH>
+where
+    UH: UnverifiedHeader,
+{
+    batches_from_abft: mpsc::UnboundedReceiver<Batch<UH>>,
+}
+
+impl<UH> Service<UH>
+where
+    UH: UnverifiedHeader,
+{
+    /// Create a new service, together with a unit finalizaiton handler that should be passed to
+    /// ABFT. It will wrap the provided finalization handler and call it in the background.
+    pub fn new<FH>(
+        finalization_handler: FH,
+    ) -> (
+        Self,
+        impl current_aleph_bft::UnitFinalizationHandler<Data = AlephData<UH>, Hasher = Hasher>,
+    )
+    where
+        FH: current_aleph_bft::FinalizationHandler<AlephData<UH>>,
+    {
+        let (batches_for_us, batches_from_abft) = mpsc::unbounded();
+        (
+            Service { batches_from_abft },
+            FinalizationWrapper::new(finalization_handler, batches_for_us),
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl<UH> Runnable for Service<UH>
+where
+    UH: UnverifiedHeader,
+{
+    async fn run(mut self, mut exit: oneshot::Receiver<()>) {
+        loop {
+            tokio::select! {
+                _maybe_batch = self.batches_from_abft.next() => {
+                    // TODO(A0-4575): actually compute the score form batches etc
+                }
+                _ = &mut exit => {
+                    debug!(target: LOG_TARGET, "ABFT performance scoring task received exit signal. Terminating.");
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/finality-aleph/src/abft/current/performance/service.rs
+++ b/finality-aleph/src/abft/current/performance/service.rs
@@ -65,7 +65,7 @@ impl<UH> Service<UH>
 where
     UH: UnverifiedHeader,
 {
-    /// Create a new service, together with a unit finalizaiton handler that should be passed to
+    /// Create a new service, together with a unit finalization handler that should be passed to
     /// ABFT. It will wrap the provided finalization handler and call it in the background.
     pub fn new<FH>(
         finalization_handler: FH,

--- a/finality-aleph/src/abft/current/traits.rs
+++ b/finality-aleph/src/abft/current/traits.rs
@@ -2,7 +2,6 @@
 use crate::{
     block::{Header, HeaderVerifier, UnverifiedHeader},
     data_io::{AlephData, ChainInfoProvider, DataProvider, OrderedDataInterpreter},
-    Hasher,
 };
 
 #[async_trait::async_trait]
@@ -14,24 +13,14 @@ impl<UH: UnverifiedHeader> current_aleph_bft::DataProvider for DataProvider<UH> 
     }
 }
 
-impl<CIP, H, V> current_aleph_bft::UnitFinalizationHandler for OrderedDataInterpreter<CIP, H, V>
+impl<CIP, H, V> current_aleph_bft::FinalizationHandler<AlephData<H::Unverified>>
+    for OrderedDataInterpreter<CIP, H, V>
 where
     CIP: ChainInfoProvider,
     H: Header,
     V: HeaderVerifier<H>,
 {
-    type Data = AlephData<H::Unverified>;
-    type Hasher = Hasher;
-
-    fn batch_finalized(
-        &mut self,
-        batch: Vec<current_aleph_bft::OrderedUnit<Self::Data, Self::Hasher>>,
-    ) {
-        // TODO(A0-4575): compute performance scores.
-        for unit in batch {
-            if let Some(data) = unit.data {
-                self.data_finalized(data)
-            }
-        }
+    fn data_finalized(&mut self, data: AlephData<H::Unverified>) {
+        OrderedDataInterpreter::data_finalized(self, data)
     }
 }

--- a/finality-aleph/src/abft/mod.rs
+++ b/finality-aleph/src/abft/mod.rs
@@ -20,7 +20,8 @@ use aleph_bft_crypto::{PartialMultisignature, Signature as AbftSignature};
 pub use crypto::Keychain;
 pub use current::{
     create_aleph_config as current_create_aleph_config, run_member as run_current_member,
-    NetworkData as CurrentNetworkData, VERSION as CURRENT_VERSION,
+    NetworkData as CurrentNetworkData, PerformanceService as CurrentPerformanceService,
+    VERSION as CURRENT_VERSION,
 };
 pub use legacy::{
     create_aleph_config as legacy_create_aleph_config, run_member as run_legacy_member,
@@ -36,6 +37,8 @@ pub use traits::{SpawnHandle, Wrapper as HashWrapper};
 pub use types::{NodeCount, NodeIndex, Recipient};
 
 use crate::crypto::Signature;
+
+const LOG_TARGET: &str = "aleph-abft";
 
 /// Wrapper for `SignatureSet` to be able to implement both legacy and current `PartialMultisignature` trait.
 /// Inner `SignatureSet` is imported from `aleph_bft_crypto` with fixed version for compatibility reasons:

--- a/finality-aleph/src/party/manager/task.rs
+++ b/finality-aleph/src/party/manager/task.rs
@@ -61,6 +61,16 @@ pub trait Runnable: Send + 'static {
     async fn run(self, exit: oneshot::Receiver<()>);
 }
 
+/// Will run waiting on an exit signal and doing nothing otherwise.
+pub struct NoopRunnable;
+
+#[async_trait::async_trait]
+impl Runnable for NoopRunnable {
+    async fn run(self, exit: oneshot::Receiver<()>) {
+        let _ = exit.await;
+    }
+}
+
 /// Runs the given task within a single session.
 pub fn task<R: Runnable>(subtask_common: TaskCommon, runnable: R, name: &'static str) -> Task {
     let TaskCommon {


### PR DESCRIPTION
# Description

Adds a service that will be handling the batches returned from ABFT to create scores. This is only the boilerplate code needed for that, the actual logic of creating the scores will be in a separate PR.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have created new documentation
