### PR TITLE
Fix for sync config

### DIFF
--- a/finality-aleph/src/network/base_protocol/config.rs
+++ b/finality-aleph/src/network/base_protocol/config.rs
@@ -6,7 +6,6 @@ use sc_network::{
     NotificationService,
 };
 use sc_network_common::sync::message::BlockAnnouncesHandshake;
-use sp_core::H256;
 use sp_runtime::traits::{Block, Header};
 
 use crate::{BlockHash, BlockNumber};
@@ -47,7 +46,7 @@ where
                 // The best block number, always send a dummy value of 0.
                 0,
                 // The best block hash, always an obviously dummy value.
-                H256([0; 32]),
+                genesis_hash.clone(),
                 genesis_hash,
             ),
         )),


### PR DESCRIPTION
# Description

In aleph-node 13 [polkadot-sdk code](https://github.com/Cardinal-Cryptography/polkadot-sdk/blob/aleph-v1.2.0/substrate/client/network/sync/src/lib.rs#L516) there's a check against 0x0 block hash. This causes to ban nodes on 14 version by nodes on 13 version, causing unwanted behaviour.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

