### PR TITLE
A0-4342: Support for multiple kinds of hashes in aggregator

### DIFF
--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -1,45 +1,15 @@
-use std::{
-    fmt::{Debug, Display},
-    hash::Hash as StdHash,
-};
+use std::fmt::Debug;
 
-use aleph_bft_rmc::{Message as RmcMessage, Signable};
+use aleph_bft_rmc::Message as RmcMessage;
 use aleph_bft_types::Recipient;
-use parity_scale_codec::{Codec, Decode, Encode};
+
+const LOG_TARGET: &str = "aleph-aggregator";
 
 mod aggregator;
 
-pub use crate::aggregator::{BlockSignatureAggregator, IO};
+pub use crate::aggregator::{HashSignatureAggregator, IO};
 
-pub type RmcNetworkData<H, S, SS> = RmcMessage<SignableHash<H>, S, SS>;
-
-/// A convenience trait for gathering all of the desired hash characteristics.
-pub trait Hash: AsRef<[u8]> + StdHash + Eq + Clone + Codec + Debug + Display + Send + Sync {}
-
-impl<T: AsRef<[u8]> + StdHash + Eq + Clone + Codec + Debug + Display + Send + Sync> Hash for T {}
-
-/// A wrapper allowing block hashes to be signed.
-#[derive(PartialEq, Eq, StdHash, Clone, Debug, Default, Encode, Decode)]
-pub struct SignableHash<H: Hash> {
-    hash: H,
-}
-
-impl<H: Hash> SignableHash<H> {
-    pub fn new(hash: H) -> Self {
-        Self { hash }
-    }
-
-    pub fn get_hash(&self) -> H {
-        self.hash.clone()
-    }
-}
-
-impl<H: Hash> Signable for SignableHash<H> {
-    type Hash = H;
-    fn hash(&self) -> Self::Hash {
-        self.hash.clone()
-    }
-}
+pub type RmcNetworkData<H, S, SS> = RmcMessage<H, S, SS>;
 
 #[derive(Debug)]
 pub enum NetworkError {

--- a/finality-aleph/src/aggregation/mod.rs
+++ b/finality-aleph/src/aggregation/mod.rs
@@ -1,13 +1,14 @@
 //! Module to glue legacy and current version of the aggregator;
 
-use std::marker::PhantomData;
+use std::{hash::Hash as StdHash, marker::PhantomData};
 
 use current_aleph_aggregator::NetworkError as CurrentNetworkError;
 use legacy_aleph_aggregator::NetworkError as LegacyNetworkError;
+use parity_scale_codec::{Decode, Encode};
 
 use crate::{
     abft::SignatureSet,
-    aleph_primitives::BlockHash,
+    aleph_primitives::Hash,
     crypto::Signature,
     network::{
         data::{Network, SendError},
@@ -16,16 +17,37 @@ use crate::{
     Keychain,
 };
 
+/// Either a block hash or a performance report hash. They should never overlap. We assume that
+/// BlockHash and Hash are the same, it has always been this way, but if it ever changes this place
+/// will cause trouble.
+#[derive(PartialEq, Eq, StdHash, Copy, Clone, Debug, Encode, Decode)]
+pub enum EitherHash {
+    /// The hash corresponds to a block.
+    Block(Hash),
+    /// The hash corresponds to an ABFT performance report.
+    Performance(Hash),
+}
+
+impl AsRef<[u8]> for EitherHash {
+    fn as_ref(&self) -> &[u8] {
+        use EitherHash::*;
+        match self {
+            Block(hash) => hash.as_ref(),
+            Performance(hash) => hash.as_ref(),
+        }
+    }
+}
+
 pub type LegacyRmcNetworkData =
-    legacy_aleph_aggregator::RmcNetworkData<BlockHash, Signature, SignatureSet<Signature>>;
+    legacy_aleph_aggregator::RmcNetworkData<Hash, Signature, SignatureSet<Signature>>;
 pub type CurrentRmcNetworkData =
-    current_aleph_aggregator::RmcNetworkData<BlockHash, Signature, SignatureSet<Signature>>;
+    current_aleph_aggregator::RmcNetworkData<EitherHash, Signature, SignatureSet<Signature>>;
 
 pub type LegacyAggregator<N> =
-    legacy_aleph_aggregator::IO<BlockHash, NetworkWrapper<LegacyRmcNetworkData, N>, Keychain>;
+    legacy_aleph_aggregator::IO<Hash, NetworkWrapper<LegacyRmcNetworkData, N>, Keychain>;
 
 pub type CurrentAggregator<N> =
-    current_aleph_aggregator::IO<BlockHash, NetworkWrapper<CurrentRmcNetworkData, N>, Keychain>;
+    current_aleph_aggregator::IO<EitherHash, NetworkWrapper<CurrentRmcNetworkData, N>, Keychain>;
 
 enum EitherAggregator<CN, LN>
 where
@@ -72,7 +94,7 @@ where
         );
         let rmc_handler = current_aleph_bft_rmc::Handler::new(multikeychain.clone());
         let rmc_service = current_aleph_bft_rmc::Service::new(scheduler, rmc_handler);
-        let aggregator = current_aleph_aggregator::BlockSignatureAggregator::new();
+        let aggregator = current_aleph_aggregator::HashSignatureAggregator::new();
         let aggregator_io =
             CurrentAggregator::<CN>::new(NetworkWrapper::new(rmc_network), rmc_service, aggregator);
 
@@ -81,17 +103,24 @@ where
         }
     }
 
-    pub async fn start_aggregation(&mut self, h: BlockHash) {
+    pub async fn start_aggregation(&mut self, h: EitherHash) {
+        use EitherHash::*;
         match &mut self.agg {
             EitherAggregator::Current(agg) => agg.start_aggregation(h).await,
-            EitherAggregator::Legacy(agg) => agg.start_aggregation(h).await,
+            EitherAggregator::Legacy(agg) => match h {
+                Block(h) => agg.start_aggregation(h).await,
+                Performance(_) => { /* should never happen, but ignoring is fine */ }
+            },
         }
     }
 
-    pub async fn next_multisigned_hash(&mut self) -> Option<(BlockHash, SignatureSet<Signature>)> {
+    pub async fn next_multisigned_hash(&mut self) -> Option<(EitherHash, SignatureSet<Signature>)> {
         match &mut self.agg {
             EitherAggregator::Current(agg) => agg.next_multisigned_hash().await,
-            EitherAggregator::Legacy(agg) => agg.next_multisigned_hash().await,
+            EitherAggregator::Legacy(agg) => agg
+                .next_multisigned_hash()
+                .await
+                .map(|(h, sig)| (EitherHash::Block(h), sig)),
         }
     }
 

--- a/finality-aleph/src/party/manager/aggregator.rs
+++ b/finality-aleph/src/party/manager/aggregator.rs
@@ -11,7 +11,7 @@ use tokio::time;
 
 use crate::{
     abft::SignatureSet,
-    aggregation::Aggregator,
+    aggregation::{Aggregator, EitherHash},
     aleph_primitives::BlockHash,
     block::{
         substrate::{Justification, JustificationTranslator},
@@ -68,10 +68,10 @@ async fn process_new_block_data<CN, LN>(
     trace!(target: "aleph-party", "Received unit {:?} in aggregator.", block);
     let hash = block.hash();
     metrics.report_block(hash, Checkpoint::Ordered);
-    aggregator.start_aggregation(hash).await;
+    aggregator.start_aggregation(EitherHash::Block(hash)).await;
 }
 
-fn process_hash<H, C, JS>(
+fn process_block_hash<H, C, JS>(
     hash: BlockHash,
     multisignature: SignatureSet<Signature>,
     justifications_for_chain: &mut JS,
@@ -117,6 +117,7 @@ where
     LN: Network<LegacyRmcNetworkData>,
     CN: Network<CurrentRmcNetworkData>,
 {
+    use EitherHash::*;
     let IO {
         blocks_from_interpreter,
         mut justifications_for_chain,
@@ -157,9 +158,14 @@ where
             },
             multisigned_hash = aggregator.next_multisigned_hash() => {
                 let (hash, multisignature) = multisigned_hash.ok_or(Error::MultisignaturesStreamTerminated)?;
-                process_hash(hash, multisignature, &mut justifications_for_chain, &justification_translator, &client).map_err(|_| Error::UnableToProcessHash)?;
-                if Some(hash) == hash_of_last_block {
-                    hash_of_last_block = None;
+                match hash {
+                    Block(hash) => {
+                        process_block_hash(hash, multisignature, &mut justifications_for_chain, &justification_translator, &client).map_err(|_| Error::UnableToProcessHash)?;
+                        if Some(hash) == hash_of_last_block {
+                            hash_of_last_block = None;
+                        }
+                    },
+                    Performance(_) => unimplemented!("we don't gather multisignatures under performance reports yet"),
                 }
             },
             _ = status_ticker.tick() => {

--- a/finality-aleph/src/party/manager/aggregator.rs
+++ b/finality-aleph/src/party/manager/aggregator.rs
@@ -11,7 +11,7 @@ use tokio::time;
 
 use crate::{
     abft::SignatureSet,
-    aggregation::{Aggregator, EitherHash},
+    aggregation::{Aggregator, SignableTypedHash},
     aleph_primitives::BlockHash,
     block::{
         substrate::{Justification, JustificationTranslator},
@@ -68,7 +68,9 @@ async fn process_new_block_data<CN, LN>(
     trace!(target: "aleph-party", "Received unit {:?} in aggregator.", block);
     let hash = block.hash();
     metrics.report_block(hash, Checkpoint::Ordered);
-    aggregator.start_aggregation(EitherHash::Block(hash)).await;
+    aggregator
+        .start_aggregation(SignableTypedHash::Block(hash))
+        .await;
 }
 
 fn process_block_hash<H, C, JS>(
@@ -117,7 +119,7 @@ where
     LN: Network<LegacyRmcNetworkData>,
     CN: Network<CurrentRmcNetworkData>,
 {
-    use EitherHash::*;
+    use SignableTypedHash::*;
     let IO {
         blocks_from_interpreter,
         mut justifications_for_chain,


### PR DESCRIPTION
# Description

Makes the aggregator more generic and prepares for gathering multisignatures under hashes of ABFT performance reports. Not yet connected to anything, so technically doesn't change any behaviour.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have created new documentation
