### PR TITLE
A0-0000: Fix for gathering validator network data

### DIFF
--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -211,8 +211,8 @@ fn get_aleph_runtime_vars(client: &Arc<FullClient>) -> AlephRuntimeVars {
 }
 
 fn get_validator_address_cache(aleph_config: &AlephCli) -> Option<ValidatorAddressCache> {
-    aleph_config
-        .no_collection_of_extra_debugging_data()
+    (!aleph_config
+        .no_collection_of_extra_debugging_data())
         .then(ValidatorAddressCache::new)
 }
 

--- a/bin/node/src/service.rs
+++ b/bin/node/src/service.rs
@@ -211,9 +211,7 @@ fn get_aleph_runtime_vars(client: &Arc<FullClient>) -> AlephRuntimeVars {
 }
 
 fn get_validator_address_cache(aleph_config: &AlephCli) -> Option<ValidatorAddressCache> {
-    (!aleph_config
-        .no_collection_of_extra_debugging_data())
-        .then(ValidatorAddressCache::new)
+    (!aleph_config.no_collection_of_extra_debugging_data()).then(ValidatorAddressCache::new)
 }
 
 fn get_proposer_factory(


### PR DESCRIPTION
# Description

Fix for regression introduced in https://github.com/Cardinal-Cryptography/aleph-node/commit/1d65f62de7e090d07b0e6f2b2261c3edaa9583a1#diff-787215c6ec15e1ecc63e5d3628fc9cce8a083c8c658f7ce2312ff0c5b0265d5eR219.

There would be a companion PR in `main` as well.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Testing

Run locally command:
```
 curl  -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "alephNode_unstable_validatorNetworkInfo", "params": []}' http://localhost:9944/
{"jsonrpc":"2.0","result":{"5GBNeWRhZc2jXu7D55rBimKYDk8PGk8itRYFTPfC8RJLKG5o":{"session":0,"network_level_address":"127.0.0.1:30344","validator_network_peer_id":"5FyuCn5rKTJdYDPTbT1Xhr8VjqYWYskNrudefpk4VQSpkQse"},"5DiDShBWa1fQx6gLzpf3SFBhMinCoyvHM1BWjPNsmXS8hkrW":{"session":0,"network_level_address":"127.0.0.1:30347","validator_network_peer_id":"5Ebkjsh9i9PyFYXDVxxXwPjwRSq9XQR2mJkgZoU5k9dX4ACp"},"5F4H97f7nQovyrbiq4ZetaaviNwThSVcFobcA5aGab6167dK":{"session":0,"network_level_address":"127.0.0.1:30346","validator_network_peer_id":"5CC71TV5oztBx3585vqrSEqQpeX8xvavjjBDy8ufAf7WA9CS"},"5Dfis6XL8J2P6JHUnUtArnFWndn62SydeP8ee8sG2ky9nfm9":{"session":0,"network_level_address":"127.0.0.1:30345","validator_network_peer_id":"5CroYKMd4ZCLkyf4oYGUZuB5XPswUDL4n69ptPpAMbHRfe6F"}},"id":1}⏎                                                         
```
