### PR TITLE
A0-4346: Gather signatures and actually submit scores to chain

### DIFF
--- a/finality-aleph/src/abft/current/mod.rs
+++ b/finality-aleph/src/abft/current/mod.rs
@@ -9,7 +9,7 @@ mod performance;
 mod traits;
 
 pub use network::NetworkData;
-pub use performance::Service as PerformanceService;
+pub use performance::{Service as PerformanceService, ServiceIO as PerformanceServiceIO};
 
 pub use crate::aleph_primitives::CURRENT_FINALITY_VERSION as VERSION;
 use crate::{

--- a/finality-aleph/src/abft/current/performance/mod.rs
+++ b/finality-aleph/src/abft/current/performance/mod.rs
@@ -3,6 +3,6 @@ use crate::{data_io::AlephData, Hasher};
 mod scorer;
 mod service;
 
-pub use service::Service;
+pub use service::{Service, ServiceIO};
 
 type Batch<UH> = Vec<current_aleph_bft::OrderedUnit<AlephData<UH>, Hasher>>;

--- a/finality-aleph/src/abft/current/performance/service.rs
+++ b/finality-aleph/src/abft/current/performance/service.rs
@@ -128,7 +128,7 @@ where
                 signatures_from_aggregator,
                 runtime_api,
                 pending_scores: HashMap::new(),
-                nonce: 0,
+                nonce: 1,
                 scorer: Scorer::new(NodeCount(n_members)),
                 metrics,
             },

--- a/finality-aleph/src/abft/current/performance/service.rs
+++ b/finality-aleph/src/abft/current/performance/service.rs
@@ -1,20 +1,30 @@
+use std::collections::HashMap;
+
 use current_aleph_bft::NodeCount;
 use futures::{
     channel::{mpsc, oneshot},
     StreamExt,
 };
 use log::{debug, error, warn};
+use parity_scale_codec::Encode;
+use sp_runtime::traits::Hash as _;
 
 use crate::{
     abft::{
         current::performance::{scorer::Scorer, Batch},
         LOG_TARGET,
     },
+    aleph_primitives::{
+        crypto::SignatureSet, AuthoritySignature, Hash, Hashing, RawScore, Score, ScoreNonce,
+    },
     data_io::AlephData,
     metrics::ScoreMetrics,
     party::manager::Runnable,
-    Hasher, UnverifiedHeader,
+    runtime_api::RuntimeApi,
+    Hasher, SessionId, UnverifiedHeader,
 };
+
+const SCORE_SUBMISSION_PERIOD: usize = 300;
 
 struct FinalizationWrapper<UH, FH>
 where
@@ -59,26 +69,43 @@ where
 }
 
 /// A service computing the performance score of ABFT nodes based on batches of ordered units.
-pub struct Service<UH>
+pub struct Service<UH, RA>
 where
     UH: UnverifiedHeader,
+    RA: RuntimeApi,
 {
     my_index: usize,
+    session_id: SessionId,
     batches_from_abft: mpsc::UnboundedReceiver<Batch<UH>>,
+    hashes_for_aggregator: mpsc::UnboundedSender<Hash>,
+    signatures_from_aggregator: mpsc::UnboundedReceiver<(Hash, SignatureSet<AuthoritySignature>)>,
+    runtime_api: RA,
+    pending_scores: HashMap<Hash, Score>,
+    nonce: ScoreNonce,
     scorer: Scorer,
     metrics: ScoreMetrics,
 }
 
-impl<UH> Service<UH>
+pub struct ServiceIO {
+    pub hashes_for_aggregator: mpsc::UnboundedSender<Hash>,
+    pub signatures_from_aggregator:
+        mpsc::UnboundedReceiver<(Hash, SignatureSet<AuthoritySignature>)>,
+}
+
+impl<UH, RA> Service<UH, RA>
 where
     UH: UnverifiedHeader,
+    RA: RuntimeApi,
 {
     /// Create a new service, together with a unit finalization handler that should be passed to
     /// ABFT. It will wrap the provided finalization handler and call it in the background.
     pub fn new<FH>(
         my_index: usize,
         n_members: usize,
+        session_id: SessionId,
         finalization_handler: FH,
+        io: ServiceIO,
+        runtime_api: RA,
         metrics: ScoreMetrics,
     ) -> (
         Self,
@@ -87,38 +114,89 @@ where
     where
         FH: current_aleph_bft::FinalizationHandler<AlephData<UH>>,
     {
+        let ServiceIO {
+            hashes_for_aggregator,
+            signatures_from_aggregator,
+        } = io;
         let (batches_for_us, batches_from_abft) = mpsc::unbounded();
         (
             Service {
                 my_index,
+                session_id,
                 batches_from_abft,
+                hashes_for_aggregator,
+                signatures_from_aggregator,
+                runtime_api,
+                pending_scores: HashMap::new(),
+                nonce: 0,
                 scorer: Scorer::new(NodeCount(n_members)),
                 metrics,
             },
             FinalizationWrapper::new(finalization_handler, batches_for_us),
         )
     }
+
+    fn make_score(&mut self, points: RawScore) -> Score {
+        let result = Score {
+            session_id: self.session_id.0,
+            nonce: self.nonce,
+            points,
+        };
+        self.nonce += 1;
+        result
+    }
 }
 
 #[async_trait::async_trait]
-impl<UH> Runnable for Service<UH>
+impl<UH, RA> Runnable for Service<UH, RA>
 where
     UH: UnverifiedHeader,
+    RA: RuntimeApi,
 {
     async fn run(mut self, mut exit: oneshot::Receiver<()>) {
+        let mut batch_counter = 1;
         loop {
             tokio::select! {
                 maybe_batch = self.batches_from_abft.next() => {
-                    let score = match maybe_batch {
+                    let points = match maybe_batch {
                         Some(batch) => self.scorer.process_batch(batch),
                         None => {
                             error!(target: LOG_TARGET, "Batches' channel closed, ABFT performance scoring terminating.");
                             break;
                         },
                     };
-                    debug!(target: LOG_TARGET, "Received ABFT score: {:?}.", score);
-                    self.metrics.report_score(score[self.my_index]);
-                    // TODO(A0-4339): sometimes submit these scores to the chain.
+                    self.metrics.report_score(points[self.my_index]);
+                    if batch_counter % SCORE_SUBMISSION_PERIOD == 0 {
+                        let score = self.make_score(points);
+                        let score_hash = Hashing::hash_of(&score.encode());
+                        debug!(target: LOG_TARGET, "Gathering signature under ABFT score: {:?}.", score);
+                        self.pending_scores.insert(score_hash, score);
+                        if let Err(e) = self.hashes_for_aggregator.unbounded_send(score_hash) {
+                            error!(target: LOG_TARGET, "Failed to send score hash to signature aggregation: {}.", e);
+                            break;
+                        }
+                    }
+                    batch_counter += 1;
+                }
+                maybe_signed = self.signatures_from_aggregator.next() => {
+                    match maybe_signed {
+                        Some((hash, signature)) => {
+                            match self.pending_scores.remove(&hash) {
+                                Some(score) => {
+                                    if let Err(e) = self.runtime_api.submit_abft_score(score, signature) {
+                                        warn!(target: LOG_TARGET, "Failed to submit performance score to chain: {}.", e);
+                                    }
+                                },
+                                None => {
+                                    warn!(target: LOG_TARGET, "Received multisigned hash for unknown performance score, this shouldn't ever happen.");
+                                },
+                            }
+                        },
+                        None => {
+                            error!(target: LOG_TARGET, "Signatures' channel closed, ABFT performance scoring terminating.");
+                            break;
+                        },
+                    }
                 }
                 _ = &mut exit => {
                     debug!(target: LOG_TARGET, "ABFT performance scoring task received exit signal. Terminating.");

--- a/finality-aleph/src/abft/mod.rs
+++ b/finality-aleph/src/abft/mod.rs
@@ -21,7 +21,7 @@ pub use crypto::Keychain;
 pub use current::{
     create_aleph_config as current_create_aleph_config, run_member as run_current_member,
     NetworkData as CurrentNetworkData, PerformanceService as CurrentPerformanceService,
-    VERSION as CURRENT_VERSION,
+    PerformanceServiceIO as CurrentPerformanceServiceIO, VERSION as CURRENT_VERSION,
 };
 pub use legacy::{
     create_aleph_config as legacy_create_aleph_config, run_member as run_legacy_member,

--- a/finality-aleph/src/runtime_api.rs
+++ b/finality-aleph/src/runtime_api.rs
@@ -8,21 +8,31 @@ use frame_support::StorageHasher;
 use pallet_aleph_runtime_api::AlephSessionApi;
 use parity_scale_codec::{Decode, DecodeAll, Encode, Error as DecodeError};
 use sc_client_api::Backend;
+use sc_transaction_pool_api::{LocalTransactionPool, OffchainTransactionPoolFactory};
+use sp_api::ApiExt;
 use sp_application_crypto::key_types::AURA;
 use sp_core::twox_128;
 use sp_runtime::traits::{Block, OpaqueKeys};
 
 use crate::{
-    aleph_primitives::{AccountId, AuraId},
+    aleph_primitives::{crypto::SignatureSet, AccountId, AuraId, AuthoritySignature, Score},
     BlockHash, ClientForAleph,
 };
 
 /// Trait handling connection between host code and runtime storage
 pub trait RuntimeApi: Clone + Send + Sync + 'static {
     type Error: Display;
+
     /// Returns aura authorities for the next session using state from block `at`
     fn next_aura_authorities(&self, at: BlockHash)
         -> Result<Vec<(AccountId, AuraId)>, Self::Error>;
+
+    /// Submits a signed ABFT performance score.
+    fn submit_abft_score(
+        &self,
+        score: Score,
+        signature: SignatureSet<AuthoritySignature>,
+    ) -> Result<(), Self::Error>;
 }
 
 pub struct RuntimeApiImpl<C, B, BE>
@@ -33,7 +43,8 @@ where
     BE: Backend<B> + 'static,
 {
     client: Arc<C>,
-    _phantom: PhantomData<(B, BE)>,
+    transaction_pool_factory: OffchainTransactionPoolFactory<B>,
+    _phantom: PhantomData<BE>,
 }
 
 impl<C, B, BE> Clone for RuntimeApiImpl<C, B, BE>
@@ -44,7 +55,16 @@ where
     BE: Backend<B> + 'static,
 {
     fn clone(&self) -> Self {
-        RuntimeApiImpl::new(self.client.clone())
+        let RuntimeApiImpl {
+            client,
+            transaction_pool_factory,
+            _phantom,
+        } = self;
+        RuntimeApiImpl {
+            client: client.clone(),
+            transaction_pool_factory: transaction_pool_factory.clone(),
+            _phantom: *_phantom,
+        }
     }
 }
 
@@ -55,9 +75,14 @@ where
     B: Block<Hash = BlockHash>,
     BE: Backend<B> + 'static,
 {
-    pub fn new(client: Arc<C>) -> Self {
+    pub fn new<TP: LocalTransactionPool<Block = B> + 'static>(
+        client: Arc<C>,
+        transaction_pool: TP,
+    ) -> Self {
+        let transaction_pool_factory = OffchainTransactionPoolFactory::new(transaction_pool);
         Self {
             client,
+            transaction_pool_factory,
             _phantom: PhantomData,
         }
     }
@@ -115,22 +140,27 @@ pub enum ApiError {
     NoStorageMapEntry(String, String),
     NoStorageValue(String, String),
     DecodeError(DecodeError),
+    ScoreSubmissionFailure,
+    CallFailed,
 }
 
 impl Display for ApiError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        use ApiError::*;
         match self {
-            ApiError::StorageAccessFailure => {
+            StorageAccessFailure => {
                 write!(f, "blockchain error during a storage read attempt")
             }
-            ApiError::NoStorage => write!(f, "no storage found"),
-            ApiError::NoStorageMapEntry(pallet, item) => {
+            NoStorage => write!(f, "no storage found"),
+            NoStorageMapEntry(pallet, item) => {
                 write!(f, "storage map element not found under {}{}", pallet, item)
             }
-            ApiError::NoStorageValue(pallet, item) => {
+            NoStorageValue(pallet, item) => {
                 write!(f, "storage value not found under {}{}", pallet, item)
             }
-            ApiError::DecodeError(error) => write!(f, "decode error: {:?}", error),
+            DecodeError(error) => write!(f, "decode error: {:?}", error),
+            ScoreSubmissionFailure => write!(f, "failed to submit ABFT score"),
+            CallFailed => write!(f, "a call to the runtime failed"),
         }
     }
 }
@@ -160,6 +190,26 @@ where
             .filter_map(|(account_id, keys)| keys.get(AURA).map(|key| (account_id, key)))
             .collect())
     }
+
+    fn submit_abft_score(
+        &self,
+        score: Score,
+        signature: SignatureSet<AuthoritySignature>,
+    ) -> Result<(), Self::Error> {
+        // Use top finalized as base for this submission.
+        let block_hash = self.client.info().finalized_hash;
+        let mut runtime_api = self.client.runtime_api();
+        runtime_api.register_extension(
+            self.transaction_pool_factory
+                .offchain_transaction_pool(block_hash),
+        );
+
+        match runtime_api.submit_abft_score(block_hash, score, signature) {
+            Ok(Some(())) => Ok(()),
+            Ok(None) => Err(ApiError::ScoreSubmissionFailure),
+            Err(_) => Err(ApiError::CallFailed),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -172,6 +222,7 @@ mod test {
     use frame_support::Twox64Concat;
     use parity_scale_codec::Encode;
     use primitives::Hash;
+    use sc_transaction_pool_api::RejectAllTxPool;
     use sp_runtime::Storage;
     use substrate_test_client::ClientExt;
 
@@ -206,7 +257,7 @@ mod test {
         *client_builder.genesis_init_mut().extra_storage() = storage;
         let client = Arc::new(client_builder.build());
         let genesis_hash = client.genesis_hash();
-        let runtime_api = RuntimeApiImpl::new(client);
+        let runtime_api = RuntimeApiImpl::new(client, RejectAllTxPool::default());
 
         let map_value1 = runtime_api.read_storage_map::<Twox64Concat, u32, &str>(
             "Pallet",
@@ -245,7 +296,7 @@ mod test {
         *client_builder.genesis_init_mut().extra_storage() = storage;
         let client = Arc::new(client_builder.build());
         let genesis_hash = client.genesis_hash();
-        let runtime_api = RuntimeApiImpl::new(client);
+        let runtime_api = RuntimeApiImpl::new(client, RejectAllTxPool::default());
 
         let result1 = runtime_api.read_storage_map::<Twox64Concat, u32, &str>(
             "Pallet",
@@ -290,7 +341,7 @@ mod test {
         *client_builder.genesis_init_mut().extra_storage() = storage;
         let client = Arc::new(client_builder.build());
         let genesis_hash = client.genesis_hash();
-        let runtime_api = RuntimeApiImpl::new(client);
+        let runtime_api = RuntimeApiImpl::new(client, RejectAllTxPool::default());
 
         // parameterize function with String instead of u32
         let result1 = runtime_api.read_storage_map::<Twox64Concat, String, &str>(
@@ -327,7 +378,7 @@ mod test {
         let mut client_builder = TestClientBuilder::new();
         *client_builder.genesis_init_mut().extra_storage() = storage;
         let client = Arc::new(client_builder.build());
-        let runtime_api = RuntimeApiImpl::new(client);
+        let runtime_api = RuntimeApiImpl::new(client, RejectAllTxPool::default());
 
         let result1 = runtime_api.read_storage_map::<Twox64Concat, u32, &str>(
             "Pallet",

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -65,6 +65,9 @@ pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
 /// never know...
 pub type AccountIndex = u32;
 
+/// The hashing algorithm we use for everything.
+pub type Hashing = BlakeTwo256;
+
 /// A hash of some data used by the chain.
 pub type Hash = sp_core::H256;
 
@@ -75,7 +78,7 @@ pub type Nonce = u32;
 pub type Balance = u128;
 
 /// Header type.
-pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Header = generic::Header<BlockNumber, Hashing>;
 
 /// Block type.
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;

--- a/scripts/run_nodes.sh
+++ b/scripts/run_nodes.sh
@@ -44,6 +44,7 @@ CHAINSPEC_GENERATOR="target/release/chain-bootstrapper"
 NODE_P2P_PORT_RANGE_START=30333
 NODE_VALIDATOR_PORT_RANGE_START=30343
 NODE_RPC_PORT_RANGE_START=9944
+PROMETHEUS_PORT_RANGE_START=9615
 
 # ------------------------ argument parsing and usage -----------------------
 
@@ -174,6 +175,7 @@ function run_node() {
     --name "${node_name}"
     --rpc-port $((NODE_RPC_PORT_RANGE_START + index))
     --port $((NODE_P2P_PORT_RANGE_START + index))
+    --prometheus-port $((PROMETHEUS_PORT_RANGE_START + index))
     --validator-port "${validator_port}"
     --node-key-file "${BASE_PATH}/${account_id}/p2p_secret"
     --backup-path "${BASE_PATH}/${account_id}/backup-stash"
@@ -193,6 +195,7 @@ function run_node() {
     -laleph-data-store=debug
     -laleph-updater=debug
     -laleph-metrics=debug
+    -laleph-abft=debug
   )
 
   info "Running node ${index}..."


### PR DESCRIPTION
# Description

Send performance scores to the aggregator for gathering multisignatures under them and then submits them on chain. This should finish the ABFT performance project on the node side, modulo testing.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- I have created new documentation
