### PR TITLE
Fix typo in README.md

### DIFF
--- a/bin/cliain/README.md
+++ b/bin/cliain/README.md
@@ -11,7 +11,7 @@ extrinsic or RPC calls. Run `./cliain --help` to see which of them are supported
 
 ## Signing account
 
-Tool reqires `--seed` parameter to sign given transaction with an account derived from the given seed.
+Tool requires `--seed` parameter to sign given transaction with an account derived from the given seed.
 If `--seed` is not given a prompt is displayed to enter the seed.
 
 ## WS endpoint


### PR DESCRIPTION
# Fix Typo in `README.md`

## Description

This pull request fixes a typo in the `README.md` file for the `aleph-node` repository. The word **"reqires"** has been corrected to **"requires"**.

### Changes Made:
1. **Fixed Typo**:
   - **"reqires"** → **"requires"**


