### PR TITLE
A0-4583: Make NonTransfer filter out identity pallet

### DIFF
--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -80,7 +80,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("aleph-node"),
     impl_name: create_runtime_str!("aleph-node"),
     authoring_version: 1,
-    spec_version: 16_000_000,
+    spec_version: 15_000_000,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 19,
@@ -860,7 +860,6 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                     | RuntimeCall::Utility(..)
                     | RuntimeCall::Multisig(..)
                     | RuntimeCall::NominationPools(..)
-                    | RuntimeCall::Identity(..)
             ),
             ProxyType::Staking => {
                 matches!(


### PR DESCRIPTION
Also, this PR sets proper `spec-version` - should be 15.0.0 as last cut off release branch is `release-14`.