### PR TITLE
A0-4596: Avoid sending task requests when in major sync

### DIFF
--- a/finality-aleph/src/sync/service.rs
+++ b/finality-aleph/src/sync/service.rs
@@ -576,7 +576,10 @@ where
         if let TaskAction::Request(pre_request, (task, delay)) =
             task.process(self.handler.interest_provider())
         {
-            self.send_request(pre_request);
+            if !self.major_sync_last_status {
+                // don't actually send requests if we are in major sync anyway, but keep them
+                self.send_request(pre_request);
+            }
             self.tasks.schedule_in(task, delay);
         }
         self.metrics.report_event(Event::HandleTask);


### PR DESCRIPTION
# Description

We don't need to send additional requests when in major sync, and when we do then the helpful nodes receiving them overwhelm us with data. It's a bug that's a bit hard to trigger, but quite annoying when it happens. This PR stops that behaviour without impacting major sync times. I tested that major sync speed when far from the chain head is unaffected (some earlier attempts _did_ affect it, even if only a little), but was unable to check that this actually solves the issue it's designed to solve, nor that it doesn't cause some problems when the node is in session – that is _very_ unlikely imo, but crucial, so has to be tested before full release.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:
