### PR TITLE
A0-4610: Added support for overriding snapshot say

### DIFF
--- a/.github/actions/sync-from-snapshot/action.yml
+++ b/.github/actions/sync-from-snapshot/action.yml
@@ -10,7 +10,7 @@ inputs:
     type: string
     required: true
   snapshot-day:
-    description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+    description: "Day in date format %Y-%m-%d. If not given, current date - 1 day is assumed."
     type: string
     required: false
   aws-access-key-id:
@@ -47,7 +47,7 @@ runs:
       shell: bash
       run: |
         if [[ '${{ inputs.snapshot-day }}' == "" ]]; then
-          snapshot_day=$(date "+%Y-%m-%d")
+          snapshot_day=$(date "+%Y-%m-%d" -d "1 day ago")
         else
           snapshot_day='${{ inputs.snapshot-day }}'
         fi

--- a/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
@@ -12,6 +12,12 @@ on:
   schedule:
     - cron: '0 20 * * 6'
   workflow_dispatch:
+    inputs:
+      snapshot-day:
+        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -48,6 +54,7 @@ jobs:
           args: --mainnet --parity-db --pruned
           aws-access-key-id: ${{ secrets.AWS_MAINNET_S3_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_MAINNET_S3_SECRET_ACCESS_KEY }}
+          snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:
     name: Slack notification

--- a/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
@@ -7,14 +7,14 @@
 
 name: Sync from snapshot, Mainnet, ParityDB pruned
 on:
-  # At 20:00 on Saturday
+  # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time
   schedule:
-    - cron: '0 20 * * 6'
+    - cron: '0 15 * * 0'
   workflow_dispatch:
     inputs:
       snapshot-day:
-        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        description: "Day in date format %Y-%m-%d. If not given, current date - 1 day is assumed."
         type: string
         required: false
         default: ''

--- a/.github/workflows/sync-from-snapshot-mainnet-paritydb.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-paritydb.yml
@@ -7,14 +7,14 @@
 
 name: Sync from snapshot test, Mainnet, ParityDB non-pruned
 on:
-  # At 21:00 on Saturday
+  # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time
   schedule:
-    - cron: '0 21 * * 6'
+    - cron: '0 15 * * 0'
   workflow_dispatch:
     inputs:
       snapshot-day:
-        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        description: "Day in date format %Y-%m-%d. If not given, current date - 1 day is assumed."
         type: string
         required: false
         default: ''

--- a/.github/workflows/sync-from-snapshot-mainnet-paritydb.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-paritydb.yml
@@ -12,6 +12,12 @@ on:
   schedule:
     - cron: '0 21 * * 6'
   workflow_dispatch:
+    inputs:
+      snapshot-day:
+        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -48,6 +54,7 @@ jobs:
           args: --mainnet --parity-db
           aws-access-key-id: ${{ secrets.AWS_MAINNET_S3_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_MAINNET_S3_SECRET_ACCESS_KEY }}
+          snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:
     name: Slack notification

--- a/.github/workflows/sync-from-snapshot-mainnet.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet.yml
@@ -7,14 +7,14 @@
 
 name: Sync from snapshot test, Mainnet, RocksDB
 on:
-  # At 22:00 on Saturday
+  # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time
   schedule:
-    - cron: '0 22 * * 6'
+    - cron: '0 15 * * 0'
   workflow_dispatch:
     inputs:
       snapshot-day:
-        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        description: "Day in date format %Y-%m-%d. If not given, current date - 1 day is assumed."
         type: string
         required: false
         default: ''

--- a/.github/workflows/sync-from-snapshot-mainnet.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet.yml
@@ -12,6 +12,12 @@ on:
   schedule:
     - cron: '0 22 * * 6'
   workflow_dispatch:
+    inputs:
+      snapshot-day:
+        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -48,6 +54,7 @@ jobs:
           args: --mainnet
           aws-access-key-id: ${{ secrets.AWS_MAINNET_S3_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_MAINNET_S3_SECRET_ACCESS_KEY }}
+          snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:
     name: Slack notification

--- a/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
@@ -9,6 +9,12 @@ on:
   schedule:
     - cron: '0 20 * * 6'
   workflow_dispatch:
+    inputs:
+      snapshot-day:
+        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -45,6 +51,7 @@ jobs:
           args: --testnet --parity-db --pruned
           aws-access-key-id: ${{ secrets.AWS_TESTNET_S3_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TESTNET_S3_SECRET_ACCESS_KEY }}
+          snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:
     name: Slack notification

--- a/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
@@ -4,14 +4,14 @@
 
 name: Sync from snapshot, Testnet, ParityDB pruned
 on:
-  # At 20:00 on Saturday
+  # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time
   schedule:
-    - cron: '0 20 * * 6'
+    - cron: '0 15 * * 0'
   workflow_dispatch:
     inputs:
       snapshot-day:
-        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        description: "Day in date format %Y-%m-%d. If not given, current date - 1 day is assumed."
         type: string
         required: false
         default: ''

--- a/.github/workflows/sync-from-snapshot-testnet-paritydb.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb.yml
@@ -4,14 +4,14 @@
 
 name: Sync from snapshot test, Testnet, ParityDB non-pruned
 on:
-  # At 21:00 on Saturday
+  # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time
   schedule:
-    - cron: '0 21 * * 6'
+    - cron: '0 15 * * 0'
   workflow_dispatch:
     inputs:
       snapshot-day:
-        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        description: "Day in date format %Y-%m-%d. If not given, current date - 1 day is assumed."
         type: string
         required: false
         default: ''

--- a/.github/workflows/sync-from-snapshot-testnet-paritydb.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb.yml
@@ -9,6 +9,12 @@ on:
   schedule:
     - cron: '0 21 * * 6'
   workflow_dispatch:
+    inputs:
+      snapshot-day:
+        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -45,6 +51,7 @@ jobs:
           args: --testnet --parity-db
           aws-access-key-id: ${{ secrets.AWS_TESTNET_S3_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TESTNET_S3_SECRET_ACCESS_KEY }}
+          snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:
     name: Slack notification

--- a/.github/workflows/sync-from-snapshot-testnet.yml
+++ b/.github/workflows/sync-from-snapshot-testnet.yml
@@ -9,6 +9,12 @@ on:
   schedule:
     - cron: '0 22 * * 6'
   workflow_dispatch:
+    inputs:
+      snapshot-day:
+        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -45,6 +51,7 @@ jobs:
           args: --testnet
           aws-access-key-id: ${{ secrets.AWS_TESTNET_S3_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TESTNET_S3_SECRET_ACCESS_KEY }}
+          snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:
     name: Slack notification

--- a/.github/workflows/sync-from-snapshot-testnet.yml
+++ b/.github/workflows/sync-from-snapshot-testnet.yml
@@ -4,14 +4,14 @@
 
 name: Sync from snapshot test, Testnet, RocksDB
 on:
-  # At 22:00 on Saturday
+  # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time
   schedule:
-    - cron: '0 22 * * 6'
+    - cron: '0 15 * * 0'
   workflow_dispatch:
     inputs:
       snapshot-day:
-        description: "Day in date format %Y-%m-%d. If not given, current date is assumed."
+        description: "Day in date format %Y-%m-%d. If not given, current date - 1 day is assumed."
         type: string
         required: false
         default: ''


### PR DESCRIPTION
# Description

1. Adds support for overriding snapshot date. If this date is not given, current day is assumed (current behaviour).

![image](https://github.com/user-attachments/assets/94a979e4-1b0b-4625-8368-158a1532d539)

2. Move workflow run time to +1 day.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

