### PR TITLE
A0-4615: Release 15 preparations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-node"
-version = "15.0.0+dev"
+version = "15.0.0"
 dependencies = [
  "aleph-runtime",
  "fake-runtime-api",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-runtime"
-version = "15.0.0+dev"
+version = "15.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-node"
-version = "15.0.0+dev"
+version = "15.0.0"
 description = "Aleph node binary"
 build = "build.rs"
 license = "GPL-3.0-or-later"

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-runtime"
-version = "15.0.0+dev"
+version = "15.0.0"
 license = "GPL-3.0-or-later"
 authors.workspace = true
 edition.workspace = true

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -1048,7 +1048,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    Migration
+    Migration,
 >;
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/bin/runtime/src/lib.rs
+++ b/bin/runtime/src/lib.rs
@@ -1048,6 +1048,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    Migration
 >;
 
 #[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
* Setting node and runtime crate version
* `spec_version` is already set to correct number
* `transaction_version` does not need to be bumped
* Enabling migration