### PR TITLE
A0-0000: Make Deploy to Testnet and Mainnet workflows run from inputs tag

### DIFF
--- a/.github/actions/get-docker-image-names/action.yml
+++ b/.github/actions/get-docker-image-names/action.yml
@@ -13,6 +13,9 @@ inputs:
   dockerhub-repo:
     required: true
     description: URL to public aleph-node repo in DockerHub
+  tag:
+    required: true
+    description: aleph-node git tag to run this action on
 outputs:
   ecr-rc-image:
     description: ECR release candidate image name
@@ -37,28 +40,20 @@ runs:
   using: composite
   steps:
     - name: Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag }}
 
     - name: Call action get-ref-properties
       id: get-ref-properties
-      # yamllint disable-line rule:line-length
-      uses: Cardinal-Cryptography/github-actions/get-ref-properties@v1
-
-    - name: Check if tag push was a trigger
-      shell: bash
-      run: |
-        if [[ -z '${{ steps.get-ref-properties.outputs.tag }}' ]]; then
-          echo 'Error: did you forgot to run this workflow from tag?'
-          echo 'Instead, it was run from branch ${{ steps.get-ref-properties.outputs.branch }}'
-          exit 1
-        fi
+      uses: Cardinal-Cryptography/github-actions/get-ref-properties@v7
 
     - name: Get node image names
       id: get-docker-image-names
       shell: bash
       env:
         COMMIT_SHA: ${{ steps.get-ref-properties.outputs.sha }}
-        COMMIT_TAG: ${{ steps.get-ref-properties.outputs.tag }}
+        COMMIT_TAG: ${{ inputs.tag }}
         ECR: ${{ inputs.ecr-repo }}
         DOCKERHUB: ${{ inputs.dockerhub-repo }}
       # yamllint disable rule:line-length

--- a/.github/workflows/_update-node-image-infra.yml
+++ b/.github/workflows/_update-node-image-infra.yml
@@ -7,6 +7,10 @@ on:
         required: true
         type: string
         description: mainnet or testnet
+      tag:
+        description: aleph-node git tag to deploy
+        type: string
+        required: true
 
 jobs:
   main:
@@ -22,20 +26,18 @@ jobs:
             echo 'Error: inputs.env should be either mainnet or testnet!'
             exit 1
           fi
-
-      - name: Checkout source code
-        uses: actions/checkout@v4
-
-      - name: Call action get-ref-properties
-        id: get-ref-properties
-        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v7
+          if [[ '${{ inputs.tag }}' == '' ]]; then
+            echo 'Error: inputs.tag should be set!'
+            exit 2
+          fi
 
       - name: Call action Get ECR image names
         id: get-docker-image-names
-        uses: ./.github/actions/get-docker-image-names
+        uses: Cardinal-Cryptography/aleph-node/.github/actions/get-docker-image-names@main
         with:
           ecr-repo: ${{ vars.ECR_ALEPH_NODE_REPO }}
           dockerhub-repo: ${{ vars.DOCKERHUB_ALEPH_NODE_REPO }}
+          tag: ${{ inputs.tag }}
 
       # this step checks indirectly as well that git HEAD has an r-* tag
       # otherwise ECR image would not exist
@@ -67,7 +69,7 @@ jobs:
       - name: Update aleph-node docker image and trigger ArgoCD deploy for ${{ inputs.env }}
         env:
           DEPLOY_IMAGE: ${{ steps.get-docker-image-names.outputs.ecr-deploy-image }}
-          REGIONS_AWS: 'eu-central-1,eu-west-1,eu-west-2,us-east-1,us-east-2'
+          REGIONS_AWS: 'eu-central-1,us-east-1'
         shell: bash
         run: |
           IFS="," read -a region_array <<< ${{ env.REGIONS_AWS }}
@@ -96,7 +98,7 @@ jobs:
       - name: GIT | Commit changes to argocd apps repository.
         uses: EndBug/add-and-commit@v9.1.4
         env:
-          TAG: ${{ steps.get-ref-properties.outputs.tag }}
+          TAG: ${{ inputs.tag }}
         with:
           author_name: ${{ secrets.AUTOCOMMIT_AUTHOR }}
           author_email: ${{ secrets.AUTOCOMMIT_EMAIL }}

--- a/.github/workflows/deploy-to-mainnet.yml
+++ b/.github/workflows/deploy-to-mainnet.yml
@@ -9,6 +9,10 @@ on:
         required: false
         type: boolean
         default: false
+      tag:
+        description: 'aleph-node git tag to deploy to Mainnet'
+        type: string
+        required: true
 
 # there might be only one deployment to the Mainnet at a time
 concurrency:
@@ -27,6 +31,8 @@ jobs:
     steps:
       - name: Checkout aleph-node sources
         uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
 
       - name: Get Testnet node commit SHA
         id: get-testnet-node-commit-sha
@@ -36,7 +42,6 @@ jobs:
 
       - name: Call action get-ref-properties
         id: get-ref-properties
-        # yamllint disable-line rule:line-length
         uses: Cardinal-Cryptography/github-actions/get-ref-properties@v7
 
       - name: Compare Testnet node SHA version with currently deployed SHA
@@ -58,21 +63,20 @@ jobs:
     uses: ./.github/workflows/_update-node-image-infra.yml
     with:
       env: mainnet
+      tag: ${{ inputs.tag }}
     secrets: inherit
 
   push-dockerhub-image-mainnet:
     needs: [deploy-to-mainnet]
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout aleph-node sources
-        uses: actions/checkout@v4
-
       - name: Get docker image names
         id: get-docker-image-names
-        uses: ./.github/actions/get-docker-image-names
+        uses: Cardinal-Cryptography/aleph-node/.github/actions/get-docker-image-names@main
         with:
           ecr-repo: ${{ vars.ECR_ALEPH_NODE_REPO }}
           dockerhub-repo: ${{ vars.DOCKERHUB_ALEPH_NODE_REPO }}
+          tag: ${{ inputs.tag }}
 
       - name: Build and push Docker Hub image for Mainnet
         uses: ./.github/actions/build-and-push-dockerhub-image

--- a/.github/workflows/deploy-to-testnet.yml
+++ b/.github/workflows/deploy-to-testnet.yml
@@ -3,6 +3,11 @@ name: Deploy to Testnet
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'aleph-node git tag to deploy to Testnet'
+        type: string
+        required: true
 
 # there might be only one deployment to the Testnet at a time
 concurrency:
@@ -21,21 +26,20 @@ jobs:
     uses: ./.github/workflows/_update-node-image-infra.yml
     with:
       env: testnet
+      tag: ${{ inputs.tag }}
     secrets: inherit
 
   push-dockerhub-image-testnet:
     needs: [deploy-to-testnet]
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout aleph-node sources
-        uses: actions/checkout@v4
-
       - name: Get docker image names
         id: get-docker-image-names
-        uses: ./.github/actions/get-docker-image-names
+        uses: Cardinal-Cryptography/aleph-node/.github/actions/get-docker-image-names@main
         with:
           ecr-repo: ${{ vars.ECR_ALEPH_NODE_REPO }}
           dockerhub-repo: ${{ vars.DOCKERHUB_ALEPH_NODE_REPO }}
+          tag: ${{ inputs.tag }}
 
       - name: Build and push Docker Hub image for Testnet
         uses: ./.github/actions/build-and-push-dockerhub-image

--- a/.github/workflows/on-push-release-tag.yml
+++ b/.github/workflows/on-push-release-tag.yml
@@ -50,15 +50,13 @@ jobs:
     needs: [check-node-version]
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout source code
-        uses: actions/checkout@v4
-
       - name: Get docker image names
         id: get-docker-image-names
-        uses: ./.github/actions/get-docker-image-names
+        uses: Cardinal-Cryptography/aleph-node/.github/actions/get-docker-image-names@main
         with:
           ecr-repo: ${{ vars.ECR_ALEPH_NODE_REPO }}
           dockerhub-repo: ${{ vars.DOCKERHUB_ALEPH_NODE_REPO }}
+          tag: ${{ github.ref }}
 
       - name: Login to Public Amazon ECR
         id: login-public-ecr


### PR DESCRIPTION
It turns out it is more convient to run Deploy to Testnet and Mainnet workflows from input tag, as those workflows can fail while tagged already, like this one https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/13284043237/job/37088626598, and there's no way to re-tag and fix the issue in the workflow. Instead, those should be always called from `main` - if there's an issue in them, we can fix them and run them again against the same tag.

This PR requires some GitHub Actions shenanigans knowledge:
* There's a mess in GHA with regards to checkout out dirs of the same repo, see https://github.com/actions/runner/issues/2816. Theefore, we need to call so called composite acionts via full path, ie `Cardinal-Cryptography/aleph-node/.github/actions/get-docker-image-names@main`
* our action `get-ref-properties` it's a little bit mess too, as first of all it assumes there's some aleph-node cloned beforehand, and secondly parts of its logic requires this cloned repo, and part based on what ref was checked out by GitHub. Therefore, I removed it's usage in one place. This action should be reworked eventually, but it's out of scope of this PR.
* there's one `fetch-depth: '0'` usage, and it's required because by default checkout actions downloads only current ref

Testing: run Deploy to Testnet and Mainnet run with modified version which does not any write/push. 
* https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/13325962070/job/37219219310
* https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/13325942309

Unfortunately, I cannot test on push tag workflow that this PR modifies. Please read carefully dear reviewer, and we'll battle-test this single workflow in the future.