### PR TITLE
A0-4546: Extend github-based tests for pruning with pruned rocksdb snapshot

### DIFF
--- a/.github/scripts/test_db_sync.sh
+++ b/.github/scripts/test_db_sync.sh
@@ -38,8 +38,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ "${PRUNING}" == "true" && "${PARITY_DB}" == "false" ]]; then
-    echo "Error! Passed '--pruned' without '--parity-db'"
+if [[ "${PRUNING}" == "true" && "${PARITY_DB}" == "true" ]]; then
+    echo "Error! Passed '--pruned' with'--parity-db'"
     echo "That is an unsupported argument combination."
     exit 1
 fi
@@ -74,10 +74,10 @@ if [[ "${PARITY_DB}" == "true" ]]; then
 fi
 if [[ "${PRUNING}" == "true" ]]; then
     DB_ARG+=("--enable-pruning")
-    S3_SNAPSHOT_PREFIX="db_backup_parity_pruned"
-    LATEST_SNAPSHOT_NAME="latest-parity-pruned.html"
+    S3_SNAPSHOT_PREFIX="db_backup_rocksdb_pruned"
+    LATEST_SNAPSHOT_NAME="latest-rocksdb-pruned.html"
 fi
-if [[ "${PARITY_DB}" != "true" && "${PRUNING}" != "true" ]]; then
+if [[ "${PRUNING}" != "true" ]]; then
     S3_SNAPSHOT_PREFIX="db_backup"
     LATEST_SNAPSHOT_NAME="latest.html"
 fi

--- a/.github/workflows/sync-from-snapshot-mainnet-rocksdb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-rocksdb-pruned.yml
@@ -1,8 +1,11 @@
 ---
-# This workflow performs sync to Testnet from a pruned ParityDB snapshot using the latest
+# This workflow performs sync to Mainnet from a pruned RocksDB snapshot using the latest
 # main version.
+#
+# For now, this test not quite correctly tests sync Mainnet from latest aleph-node binary,
+# for which we don't guarantee it will always happen to work.
 
-name: Sync from snapshot, Testnet, ParityDB pruned
+name: Sync from snapshot, Mainnet, RocksDB pruned
 on:
   # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time
@@ -48,9 +51,9 @@ jobs:
         with:
           # yamllint disable-line rule:line-length
           aleph-node-artifact-name: ${{ needs.build-production-aleph-node.outputs.artifact-name-binary }}
-          args: --testnet --parity-db --pruned
-          aws-access-key-id: ${{ secrets.AWS_TESTNET_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_TESTNET_S3_SECRET_ACCESS_KEY }}
+          args: --mainnet --pruned
+          aws-access-key-id: ${{ secrets.AWS_MAINNET_S3_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_MAINNET_S3_SECRET_ACCESS_KEY }}
           snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:

--- a/.github/workflows/sync-from-snapshot-testnet-rocksdb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-rocksdb-pruned.yml
@@ -1,11 +1,8 @@
 ---
-# This workflow performs sync to Mainnet from a pruned ParityDB snapshot using the latest
+# This workflow performs sync to Testnet from a pruned RocksDB snapshot using the latest
 # main version.
-#
-# For now, this test not quite correctly tests sync Mainnet from latest aleph-node binary,
-# for which we don't guarantee it will always happen to work.
 
-name: Sync from snapshot, Mainnet, ParityDB pruned
+name: Sync from snapshot, Testnet, RocksDB pruned
 on:
   # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time
@@ -51,9 +48,9 @@ jobs:
         with:
           # yamllint disable-line rule:line-length
           aleph-node-artifact-name: ${{ needs.build-production-aleph-node.outputs.artifact-name-binary }}
-          args: --mainnet --parity-db --pruned
-          aws-access-key-id: ${{ secrets.AWS_MAINNET_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_MAINNET_S3_SECRET_ACCESS_KEY }}
+          args: --testnet --pruned
+          aws-access-key-id: ${{ secrets.AWS_TESTNET_S3_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TESTNET_S3_SECRET_ACCESS_KEY }}
           snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:


### PR DESCRIPTION
# Description

* Remove ParityDB snapshotter test
* Add RocksDB Pruned snapshotter test

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

