### PR TITLE
A0-0000: Fix once again snapshot workflows

### DIFF
--- a/.github/scripts/test_db_sync.sh
+++ b/.github/scripts/test_db_sync.sh
@@ -38,8 +38,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ "${PRUNING}" == "true" && "${PARITY_DB}" == "true" ]]; then
-    echo "Error! Passed '--pruned' with'--parity-db'"
+if [[ "${PRUNING}" == "false" && "${PARITY_DB}" == "true" ]]; then
+    echo "Error! Passed '--parity-db' without '--pruned'."
     echo "That is an unsupported argument combination."
     exit 1
 fi
@@ -67,17 +67,18 @@ fi
 declare -a DB_ARG
 S3_SNAPSHOT_PREFIX=""
 LATEST_SNAPSHOT_NAME=""
-if [[ "${PARITY_DB}" == "true" ]]; then
+if [[ "${PARITY_DB}" == "true" && "${PRUNING}" == "true" ]]; then
     DB_ARG+=("--database paritydb")
-    S3_SNAPSHOT_PREFIX="db_backup_parity"
-    LATEST_SNAPSHOT_NAME="latest-parity.html"
+    DB_ARG+=("--enable-pruning")
+    S3_SNAPSHOT_PREFIX="db_backup_parity_pruned"
+    LATEST_SNAPSHOT_NAME="latest-parity-pruned.html"
 fi
-if [[ "${PRUNING}" == "true" ]]; then
+if [[ "${PARITY_DB}" == "false" && "${PRUNING}" == "true"  ]]; then
     DB_ARG+=("--enable-pruning")
     S3_SNAPSHOT_PREFIX="db_backup_rocksdb_pruned"
     LATEST_SNAPSHOT_NAME="latest-rocksdb-pruned.html"
 fi
-if [[ "${PRUNING}" != "true" ]]; then
+if [[ "${PARITY_DB}" == "false" && "${PRUNING}" == "false" ]]; then
     S3_SNAPSHOT_PREFIX="db_backup"
     LATEST_SNAPSHOT_NAME="latest.html"
 fi

--- a/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
@@ -18,9 +18,6 @@ on:
         type: string
         required: false
         default: ''
-  push:
-    branches:
-      - fix-snapshot-tests
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -57,7 +54,7 @@ jobs:
           args: --mainnet --parity-db --pruned
           aws-access-key-id: ${{ secrets.AWS_MAINNET_S3_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_MAINNET_S3_SECRET_ACCESS_KEY }}
-          snapshot-day: '2025-02-22'
+          snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:
     name: Slack notification

--- a/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
@@ -1,8 +1,11 @@
 ---
-# This workflow performs sync to Testnet from a ParityDB non-pruned snapshot using the latest
+# This workflow performs sync to Mainnet from a pruned ParityDB snapshot using the latest
 # main version.
+#
+# For now, this test not quite correctly tests sync Mainnet from latest aleph-node binary,
+# for which we don't guarantee it will always happen to work.
 
-name: Sync from snapshot test, Testnet, ParityDB non-pruned
+name: Sync from snapshot, Mainnet, ParityDB pruned
 on:
   # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time
@@ -38,7 +41,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, euc1-med-xldisk]
-    timeout-minutes: 360
+    timeout-minutes: 120
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -48,9 +51,9 @@ jobs:
         with:
           # yamllint disable-line rule:line-length
           aleph-node-artifact-name: ${{ needs.build-production-aleph-node.outputs.artifact-name-binary }}
-          args: --testnet --parity-db
-          aws-access-key-id: ${{ secrets.AWS_TESTNET_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_TESTNET_S3_SECRET_ACCESS_KEY }}
+          args: --mainnet --parity-db --pruned
+          aws-access-key-id: ${{ secrets.AWS_MAINNET_S3_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_MAINNET_S3_SECRET_ACCESS_KEY }}
           snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:

--- a/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-paritydb-pruned.yml
@@ -18,6 +18,9 @@ on:
         type: string
         required: false
         default: ''
+  push:
+    branches:
+      - fix-snapshot-tests
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -54,7 +57,7 @@ jobs:
           args: --mainnet --parity-db --pruned
           aws-access-key-id: ${{ secrets.AWS_MAINNET_S3_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_MAINNET_S3_SECRET_ACCESS_KEY }}
-          snapshot-day: ${{ inputs.snapshot-day }}
+          snapshot-day: '2025-02-22'
 
   slack-notification:
     name: Slack notification

--- a/.github/workflows/sync-from-snapshot-mainnet-rocksdb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-mainnet-rocksdb-pruned.yml
@@ -1,11 +1,11 @@
 ---
-# This workflow performs sync to Mainnet from a pruned RocksDB snapshot using the latest
+# This workflow performs sync to Mainnet from a RocksDB pruned snapshot using the latest
 # main version.
 #
 # For now, this test not quite correctly tests sync Mainnet from latest aleph-node binary,
 # for which we don't guarantee it will always happen to work.
 
-name: Sync from snapshot, Mainnet, RocksDB pruned
+name: Sync from snapshot test, Mainnet, RocksDB pruned
 on:
   # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time

--- a/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
@@ -15,6 +15,9 @@ on:
         type: string
         required: false
         default: ''
+  push:
+    branches:
+      - fix-snapshot-tests
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -51,7 +54,7 @@ jobs:
           args: --testnet --parity-db --pruned
           aws-access-key-id: ${{ secrets.AWS_TESTNET_S3_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TESTNET_S3_SECRET_ACCESS_KEY }}
-          snapshot-day: ${{ inputs.snapshot-day }}
+          snapshot-day: '2025-02-22'
 
   slack-notification:
     name: Slack notification

--- a/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
@@ -15,9 +15,6 @@ on:
         type: string
         required: false
         default: ''
-  push:
-    branches:
-      - fix-snapshot-tests
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -54,7 +51,7 @@ jobs:
           args: --testnet --parity-db --pruned
           aws-access-key-id: ${{ secrets.AWS_TESTNET_S3_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TESTNET_S3_SECRET_ACCESS_KEY }}
-          snapshot-day: '2025-02-22'
+          snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:
     name: Slack notification

--- a/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-paritydb-pruned.yml
@@ -1,11 +1,8 @@
 ---
-# This workflow performs sync to Mainnet from a ParityDB non-pruned snapshot using the latest
+# This workflow performs sync to Testnet from a pruned ParityDB snapshot using the latest
 # main version.
-#
-# For now, this test not quite correctly tests sync Mainnet from latest aleph-node binary,
-# for which we don't guarantee it will always happen to work.
 
-name: Sync from snapshot test, Mainnet, ParityDB non-pruned
+name: Sync from snapshot, Testnet, ParityDB pruned
 on:
   # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time
@@ -41,7 +38,7 @@ jobs:
     needs: [build-production-aleph-node]
     name: Download snapshot and run
     runs-on: [self-hosted, Linux, X64, euc1-med-xldisk]
-    timeout-minutes: 360
+    timeout-minutes: 120
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -51,9 +48,9 @@ jobs:
         with:
           # yamllint disable-line rule:line-length
           aleph-node-artifact-name: ${{ needs.build-production-aleph-node.outputs.artifact-name-binary }}
-          args: --mainnet --parity-db
-          aws-access-key-id: ${{ secrets.AWS_MAINNET_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_MAINNET_S3_SECRET_ACCESS_KEY }}
+          args: --testnet --parity-db --pruned
+          aws-access-key-id: ${{ secrets.AWS_TESTNET_S3_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TESTNET_S3_SECRET_ACCESS_KEY }}
           snapshot-day: ${{ inputs.snapshot-day }}
 
   slack-notification:

--- a/.github/workflows/sync-from-snapshot-testnet-rocksdb-pruned.yml
+++ b/.github/workflows/sync-from-snapshot-testnet-rocksdb-pruned.yml
@@ -1,8 +1,8 @@
 ---
-# This workflow performs sync to Testnet from a pruned RocksDB snapshot using the latest
+# This workflow performs sync to Testnet from a RocksDB pruned snapshot using the latest
 # main version.
 
-name: Sync from snapshot, Testnet, RocksDB pruned
+name: Sync from snapshot test, Testnet, RocksDB pruned
 on:
   # At 15:00 on Sunday
   # Time corresponds with a snapshot creation time


### PR DESCRIPTION
Revert "A0-4546: Extend github-based tests for pruning with pruned rocksdb snapshot (#1948)"

This reverts commit 81c377d0e0fc866ccf7c71e10a2b18170f03e571.

Removed Parity non-pruned workflows for Testnet and Mainnet. Added RocksDB Pruned workflows for Mainnet and Testnet.

## Testing

Run manually ParityDB Pruned for Mainnet and Testnet, which were not triggered for 2025-02-22 day.
* https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/13493135548
* https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/13493135540
