### PR TITLE
A0-4616: Don't request blocks you started iimporting (#1950)

### DIFF
--- a/finality-aleph/src/sync/handler/mod.rs
+++ b/finality-aleph/src/sync/handler/mod.rs
@@ -571,6 +571,7 @@ where
                         );
                     }
                     last_imported = Some(b.header().id());
+                    self.forest.start_import(&b.header().id());
                     self.block_importer.import_block(b, false);
                 }
             }

--- a/finality-aleph/src/sync/tasks.rs
+++ b/finality-aleph/src/sync/tasks.rs
@@ -38,9 +38,10 @@ impl Display for RequestTask {
 
 type DelayedTask = (RequestTask, Duration);
 
-/// What do to with the task, either ignore or perform a request and add a delayed task.
+/// What do to with the task, either ignore or add a delayed task, usually also performing a request.
 pub enum Action<UH: UnverifiedHeader, I: PeerId> {
     Ignore,
+    Delay(DelayedTask),
     Request(PreRequest<UH, I>, DelayedTask),
 }
 
@@ -85,6 +86,9 @@ impl RequestTask {
                         delay_for_attempt(tries),
                     ),
                 )
+            }
+            Interest::MaybeLater => {
+                Action::Delay((RequestTask { id, tries }, delay_for_attempt(tries)))
             }
             Interest::Uninterested => Action::Ignore,
         }


### PR DESCRIPTION
# Description

By optimistically assuming that a block that we started importing will get imported, we treat it as already imported for purposes of sending requests. This should limit both the amount of received blocks, as well as the amount of blocks in the import queue, both of which were slowing sync down.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

<!-- delete when not applicable to your PR -->

- I have added tests
- I have made corresponding changes to the existing documentation
- I have created new documentation