### PR TITLE
Introduce relative directories when installing Rust in e2e-tests and cliain build

### DIFF
--- a/.github/workflows/_build-aleph-e2e-client.yml
+++ b/.github/workflows/_build-aleph-e2e-client.yml
@@ -38,9 +38,9 @@ jobs:
         uses: Cardinal-Cryptography/github-actions/get-ref-properties@v7
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v7
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@add-workdir-to-install-action
         with:
-          targets: wasm32-unknown-unknown
+          directory: './e2e-tests/'
 
       - name: Build aleph-e2e-client
         shell: bash

--- a/.github/workflows/_build-aleph-e2e-client.yml
+++ b/.github/workflows/_build-aleph-e2e-client.yml
@@ -38,7 +38,7 @@ jobs:
         uses: Cardinal-Cryptography/github-actions/get-ref-properties@v7
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@add-workdir-to-install-action
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v7.3.0
         with:
           directory: './e2e-tests/'
 

--- a/.github/workflows/_build-and-push-cliain.yml
+++ b/.github/workflows/_build-and-push-cliain.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@add-workdir-to-install-action
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v7.3.0
         with:
           directory: './bin/cliain/'
 

--- a/.github/workflows/_build-and-push-cliain.yml
+++ b/.github/workflows/_build-and-push-cliain.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: ${{ env.CARGO_COMMAND }} cliain binary
         run: |
-          cargo ${{ env.CARGO_COMMAND }} --release ${{ env.FEATURES }}
+          cd ./bin/cliain && cargo ${{ env.CARGO_COMMAND }} --release ${{ env.FEATURES }}
 
       - name: Upload cliain binary to GH artifacts
         if: ${{ inputs.check-only != true }}

--- a/.github/workflows/_build-and-push-cliain.yml
+++ b/.github/workflows/_build-and-push-cliain.yml
@@ -21,15 +21,14 @@ jobs:
     runs-on: [self-hosted, Linux, X64, large]
     env:
       CARGO_COMMAND: ${{ inputs.check-only && 'check' || 'build' }}
-    defaults:
-      run:
-        working-directory: './bin/cliain'
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v7
+        uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@add-workdir-to-install-action
+        with:
+          directory: '.bin/cliain/'
 
       - name: ${{ env.CARGO_COMMAND }} cliain binary
         run: |

--- a/.github/workflows/_build-and-push-cliain.yml
+++ b/.github/workflows/_build-and-push-cliain.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: [self-hosted, Linux, X64, large]
     env:
       CARGO_COMMAND: ${{ inputs.check-only && 'check' || 'build' }}
+    defaults:
+      run:
+        working-directory: './bin/cliain'
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -30,7 +33,7 @@ jobs:
 
       - name: ${{ env.CARGO_COMMAND }} cliain binary
         run: |
-          cd ./bin/cliain && cargo ${{ env.CARGO_COMMAND }} --release ${{ env.FEATURES }}
+          cargo ${{ env.CARGO_COMMAND }} --release ${{ env.FEATURES }}
 
       - name: Upload cliain binary to GH artifacts
         if: ${{ inputs.check-only != true }}

--- a/.github/workflows/_build-and-push-cliain.yml
+++ b/.github/workflows/_build-and-push-cliain.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Rust toolchain
         uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@add-workdir-to-install-action
         with:
-          directory: '.bin/cliain/'
+          directory: './bin/cliain/'
 
       - name: ${{ env.CARGO_COMMAND }} cliain binary
         run: |


### PR DESCRIPTION
# Description

As per PR title - for some reason automatic toolchain download stopped working. 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


