### PR TITLE
A0-0000: Forgot to pass ref

### DIFF
--- a/.github/workflows/deploy-to-mainnet.yml
+++ b/.github/workflows/deploy-to-mainnet.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: '0'
+          ref: ${{ inputs.tag }}
 
       - name: Get Testnet node commit SHA
         id: get-testnet-node-commit-sha


### PR DESCRIPTION
# Description

This is a bugfix for a regression introduced in https://github.com/Cardinal-Cryptography/aleph-node/commit/74c888e981cabe265d5352a771ccbeeccc1b9cbb

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

