### PR TITLE
A0-4612: Fix update net test deploy from Testnet to Mainnet

### DIFF
--- a/.github/workflows/nightly-update-test-mainnet-testnet.yml
+++ b/.github/workflows/nightly-update-test-mainnet-testnet.yml
@@ -33,7 +33,7 @@ jobs:
       validators: '7'
       internal: true
       short-session: false
-      finality-version: '3'
+      finality-version: 'legacy'
 
   update-featurenet-to-testnet:
     needs: [create-featurenet-from-mainnet]


### PR DESCRIPTION
# Description

With Mainnet v15 release, `chain-bootstrapper` supports only `legacy` or `current`. 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Testing

Run https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/14078538853
