### PR TITLE
A0-0000 Fixed performance e2e flakiness

### DIFF
--- a/.github/workflows/_run-e2e-tests.yml
+++ b/.github/workflows/_run-e2e-tests.yml
@@ -707,6 +707,7 @@ jobs:
         uses: ./.github/actions/run-e2e-test
         with:
           test-case: all_validators_have_ideal_performance
+          node-count: '4'
           artifact-aleph-e2e-client-image: ${{ inputs.artifact-aleph-e2e-client-image }}
           artifact-aleph-node-image: ${{ inputs.artifact-aleph-node-image }}
           artifact-chain-bootstrapper-image: ${{ inputs.artifact-chain-bootstrapper-image }}
@@ -723,6 +724,7 @@ jobs:
         uses: ./.github/actions/run-e2e-test
         with:
           test-case: one_validator_is_dead
+          node-count: '4'
           artifact-aleph-e2e-client-image: ${{ inputs.artifact-aleph-e2e-client-image }}
           artifact-aleph-node-image: ${{ inputs.artifact-aleph-node-image }}
           artifact-chain-bootstrapper-image: ${{ inputs.artifact-chain-bootstrapper-image }}


### PR DESCRIPTION
# Description

The way `one_validator_is_dead` is written now, it's disabling both AURA and Aleph keys. Since default production ban config threshold is 3, sometimes we kicked disabled node from the committee which then resulted in perfect score, hence test failed. This PR fixes that by extending production ban config threshold so that kick does not happen.

There's tiny bug in the test which does not influence test run - it printed out wrong account id to std out. Also, I decreased waiting time here and there so both performance tests should run faster now (around 3 minutes).

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing

* https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/14104180901
