### PR TITLE
A0-4614: attach chain bootstrapper to release

### DIFF
--- a/.github/actions/store-artifacts-in-s3/action.yml
+++ b/.github/actions/store-artifacts-in-s3/action.yml
@@ -1,7 +1,6 @@
 ---
-name: Store node and runtime
-description: This workflow stores test or release version of aleph-node and aleph-runtime in S3, in
-             a given bucket
+name: Store build artifacts in S3
+description: This workflow stores production version of CI build artifacts in S3
 inputs:
   aleph-node-artifact-name:
     required: true
@@ -9,9 +8,9 @@ inputs:
   aleph-runtime-artifact-name:
     required: true
     description: 'Name of artifact aleph-runtime'
-  profile:
+  chain-bootstrapper-artifact-name:
     required: true
-    description: 'test or production'
+    description: 'Name of artifact chain-bootstrapper'
   aws-access-key-id:
     required: true
     description: 'AWS Access Key ID to be used when storing artifacts'
@@ -25,14 +24,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Validate workflow inputs
-      shell: bash
-      run: |
-        if [[ '${{ inputs.profile }}' != 'test' && '${{ inputs.profile }}' != 'production' ]]; then
-          echo 'Error: inputs.profile should be either test or production!'
-          exit 1
-        fi
-
     - name: Checkout aleph-node source code
       uses: actions/checkout@v4
 
@@ -50,6 +41,12 @@ runs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.aleph-runtime-artifact-name }}
+        path: target
+
+    - name: Download chain-bootstrapper from GH artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.chain-bootstrapper-artifact-name }}
         path: target
 
     - name: Configure AWS credentials for S3 AWS
@@ -72,19 +69,30 @@ runs:
         source-filename: aleph-node
         s3-bucket-path:
           # yamllint disable-line rule:line-length
-          builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/aleph-${{ inputs.profile }}-node
+          builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/aleph-production-node
         s3-bucket-filename:
-          aleph-${{ inputs.profile }}-node-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
+          aleph-production-node-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
         s3-bucket-name: ${{ inputs.aws-bucket }}
 
     - name: Copy runtime to S3 AWS bucket
-      uses: Cardinal-Cryptography/github-actions/copy-file-to-s3@v1
+      uses: Cardinal-Cryptography/github-actions/copy-file-to-s3@v7
       with:
         source-path: target
         source-filename: aleph_runtime.compact.compressed.wasm
         s3-bucket-path:
           # yamllint disable-line rule:line-length
-          builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/aleph-${{ inputs.profile }}-runtime
+          builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/aleph-production-runtime
         s3-bucket-filename:
-          aleph-${{ inputs.profile }}-runtime-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
+          aleph-production-runtime-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
+        s3-bucket-name: ${{ inputs.aws-bucket }}
+
+    - name: Copy chain-bootstrapper to S3 AWS bucket
+      uses: Cardinal-Cryptography/github-actions/copy-file-to-s3@v7
+      with:
+        source-path: target
+        source-filename: chain-bootstrapper
+        s3-bucket-path:
+          builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/chain-bootstrapper-production
+        s3-bucket-filename:
+          chain-bootstrapper-production-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
         s3-bucket-name: ${{ inputs.aws-bucket }}

--- a/.github/actions/store-artifacts-in-s3/action.yml
+++ b/.github/actions/store-artifacts-in-s3/action.yml
@@ -92,6 +92,7 @@ runs:
         source-path: target
         source-filename: chain-bootstrapper
         s3-bucket-path:
+          # yamllint disable-line rule:line-length
           builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/chain-bootstrapper-production
         s3-bucket-filename:
           chain-bootstrapper-production-${{ steps.get-ref-properties.outputs.sha }}.tar.gz

--- a/.github/workflows/on-main-or-release-branch-commit.yml
+++ b/.github/workflows/on-main-or-release-branch-commit.yml
@@ -56,11 +56,11 @@ jobs:
     uses: ./.github/workflows/_push-image-to-ecr.yml
     secrets: inherit
     with:
-      binary-artifact-name: ${{ needs.build-chain-bootstrapper.outputs.artifact-name-binary }}
-      # yamllint disable-line rule:line-length
+      # yamllint disable rule:line-length
+      binary-artifact-name: ${{ needs.build-production-chain-bootstrapper.outputs.artifact-name-binary }}
       docker-image-name: ${{ needs.get-full-docker-image-path.outputs.chain-bootstrapper-fqdn-image }}
-      # yamllint disable-line rule:line-length
       docker-image-name-latest: ${{ needs.get-full-docker-image-path.outputs.chain-bootstrapper-fqdn-image-latest }}
+      # yamllint enable rule:line-length
       binary-name: chain-bootstrapper
       docker-file-path: ./bin/chain-bootstrapper/Dockerfile
 

--- a/.github/workflows/on-main-or-release-branch-commit.yml
+++ b/.github/workflows/on-main-or-release-branch-commit.yml
@@ -39,7 +39,7 @@ jobs:
           ecr-chain-bootstrapper-repo: ${{ vars.ECR_CHAIN_BOOTSTRAPPER_REPO }}
           test-binary: 'false'
 
-  build-chain-bootstrapper:
+  build-production-chain-bootstrapper:
     needs: [check-vars-and-secrets]
     name: Build chain-bootstrapper
     uses: ./.github/workflows/_build-chain-bootstrapper.yml
@@ -49,7 +49,7 @@ jobs:
 
   push-chain-bootstrapper-image-to-ecr:
     needs:
-      - build-chain-bootstrapper
+      - build-production-chain-bootstrapper
       - get-full-docker-image-path
     name: Push chain-bootstrapper docker image to ECR
     uses: ./.github/workflows/_push-image-to-ecr.yml
@@ -101,13 +101,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Store production node and runtime
-        uses: ./.github/actions/store-node-and-runtime
+        uses: ./.github/actions/store-artifacts-in-s3
         with:
-          profile: production
-          # yamllint disable-line rule:line-length
+          # yamllint disable rule:line-length
           aleph-node-artifact-name: ${{ needs.build-production-aleph-node.outputs.artifact-name-binary }}
-          # yamllint disable-line rule:line-length
           aleph-runtime-artifact-name: ${{ needs.build-production-runtime.outputs.aleph-runtime-artifact-name }}
+          chain-bootstrapper-artifact-name: ${{ needs.build-production-chain-bootstrapper.outputs.artifact-name-binary }}
+          # yamllint enable rule:line-length
           aws-access-key-id: ${{ secrets.AWS_MAINNET_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_MAINNET_SECRET_ACCESS_KEY }}
           aws-bucket: ${{ secrets.CI_MAINNET_S3BUCKET_NAME }}

--- a/.github/workflows/on-main-or-release-branch-commit.yml
+++ b/.github/workflows/on-main-or-release-branch-commit.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - 'release-*'
+      - 'A0-4614-attach-chain-bootstrapper'
 
 jobs:
   check-vars-and-secrets:

--- a/.github/workflows/on-main-or-release-branch-commit.yml
+++ b/.github/workflows/on-main-or-release-branch-commit.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - 'release-*'
-      - 'A0-4614-attach-chain-bootstrapper'
 
 jobs:
   check-vars-and-secrets:

--- a/.github/workflows/on-main-or-release-branch-commit.yml
+++ b/.github/workflows/on-main-or-release-branch-commit.yml
@@ -90,12 +90,13 @@ jobs:
     needs: [build-production-runtime]
     uses: ./.github/workflows/_check-runtime-determimism.yml
 
-  store-production-node-and-runtime-in-mainnet-s3:
-    name: Store production node and runtime in Mainnet bucket
+  store-ci-artifacts-in-mainnet-s3:
+    name: Store CI artifacts in Mainnet bucket
     runs-on: ubuntu-20.04
     needs:
       - build-production-aleph-node
       - build-production-runtime
+      - build-production-chain-bootstrapper
     steps:
       - name: Checkout aleph-node source code
         uses: actions/checkout@v4

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,5 +1,5 @@
 ---
-name: Upload runtime and binary to GitHub Release
+name: Upload CI artifacts to GitHub Release
 
 on:
   release:
@@ -17,9 +17,9 @@ jobs:
     uses: ./.github/workflows/_check-vars-and-secrets.yml
     secrets: inherit
 
-  add-runtime-and-binary-to-release:
+  add-ci-artifacts-to-release:
     needs: [check-vars-and-secrets]
-    name: Add runtime and binary to release
+    name: Add CI artifacts to the release
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
@@ -58,6 +58,16 @@ jobs:
           aws s3 cp '${{ env.S3BUCKET_URL }}/${{ env.S3BUCKET_FILE }}' \
              'aleph-node-${{ steps.get-ref-properties.outputs.sha }}-linux-amd64.tar.gz'
 
+      - name: Download chain-bootstrapper binary from S3 bucket
+        shell: bash
+        env:
+          # yamllint disable-line rule:line-length
+          S3BUCKET_URL: s3://${{ secrets.CI_MAINNET_S3BUCKET_NAME }}/builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/chain-bootstrapper-production
+          S3BUCKET_FILE: chain-bootstrapper-production-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
+        run: |
+          aws s3 cp '${{ env.S3BUCKET_URL }}/${{ env.S3BUCKET_FILE }}' \
+             'chain-bootstrapper-${{ steps.get-ref-properties.outputs.sha }}-linux-amd64.tar.gz'
+
       - name: Generate release artifacts checksum (SHA256)
         uses: jmgilman/actions-generate-checksum@v1
         with:
@@ -66,18 +76,19 @@ jobs:
           patterns: |
             *.tar.gz
 
-      - name: Add runtime and binary to the release
+      - name: Add CI artifacts to the release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             checksums-${{ steps.get-ref-properties.outputs.sha }}-linux-amd64.tar.gz.SHA256.txt
             aleph-runtime-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
             aleph-node-${{ steps.get-ref-properties.outputs.sha }}-linux-amd64.tar.gz
+            chain-bootstrapper-${{ steps.get-ref-properties.outputs.sha }}-linux-amd64.tar.gz
 
   slack:
     name: Slack notification
     runs-on: ubuntu-20.04
-    needs: [add-runtime-and-binary-to-release]
+    needs: [add-ci-artifacts-to-release]
     if: always()
     steps:
       - name: Send Slack message

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -63,6 +63,7 @@ jobs:
         env:
           # yamllint disable-line rule:line-length
           S3BUCKET_URL: s3://${{ secrets.CI_MAINNET_S3BUCKET_NAME }}/builds/aleph-node/commits/${{ steps.get-ref-properties.outputs.sha }}/chain-bootstrapper-production
+          # yamllint disable-line rule:line-length
           S3BUCKET_FILE: chain-bootstrapper-production-${{ steps.get-ref-properties.outputs.sha }}.tar.gz
         run: |
           aws s3 cp '${{ env.S3BUCKET_URL }}/${{ env.S3BUCKET_FILE }}' \


### PR DESCRIPTION
# Description

What needs to be done?

* In push to main workflow, we should store as well chain-bootstrapper binary
* In release changed workflow, we should attach production chain bootstrapper

Why?

* For us devs doing release preparation tests - now for 14 release I need to build it manually which is error-prone
* Community transparency   - generating runtime is now decoupled from aleph-node

Also, `profile` input was removed from store artifacts action, since it was not used with `test` anywhere. 

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing

* https://github.com/Cardinal-Cryptography/aleph-node/actions/runs/14106515515 PASS